### PR TITLE
fix: unshallow only if necessary

### DIFF
--- a/.semaphore/daily-builds.yml
+++ b/.semaphore/daily-builds.yml
@@ -3262,6 +3262,7 @@ blocks:
             - make check.ruby.code
         - name: "\U0001F6E1️ Check dependencies"
           commands:
+            - sem-version ruby 3.3
             - make check.ruby.deps
         - name: "\U0001F6E1️ Check docker"
           commands:

--- a/.semaphore/daily-builds.yml
+++ b/.semaphore/daily-builds.yml
@@ -23,7 +23,7 @@ global_job_config:
       - echo $DOCKER_PASSWORD | docker login --username "$DOCKER_USERNAME" --password-stdin || echo "Docker login failed, but continuing the build process." && true
       - echo $SEMAPHORE_REGISTRY_PASSWORD | docker login --username "$SEMAPHORE_REGISTRY_USERNAME" --password-stdin $SEMAPHORE_REGISTRY_HOST || echo "Semaphore Registry login failed, but continuing the build process." && true
       - export REGISTRY_HOST=$SEMAPHORE_REGISTRY_HOST
-      - sem-version ruby 3.0
+      - sem-version ruby 3.3
   epilogue:
     always:
       commands:
@@ -3262,7 +3262,6 @@ blocks:
             - make check.ruby.code
         - name: "\U0001F6E1️ Check dependencies"
           commands:
-            - sem-version ruby 3.3
             - make check.ruby.deps
         - name: "\U0001F6E1️ Check docker"
           commands:

--- a/.semaphore/generate-helm-chart.yml
+++ b/.semaphore/generate-helm-chart.yml
@@ -60,7 +60,7 @@ blocks:
                 - "Zebra"
           commands:
             - checkout
-            - git fetch --unshallow --tags
+            - git fetch --unshallow --tags || true
             - echo $SEMAPHORE_REGISTRY_PASSWORD | docker login --username "$SEMAPHORE_REGISTRY_USERNAME" --password-stdin $SEMAPHORE_REGISTRY_HOST || echo "Semaphore Registry login failed, but continuing the build process." && true
             - export REGISTRY_HOST=$SEMAPHORE_REGISTRY_HOST
             - sudo chmod 600 ~/.ssh/feature_provider_rsa
@@ -79,7 +79,7 @@ blocks:
         - name: Create helm chart artifact
           commands:
             - checkout
-            - git fetch --unshallow --tags
+            - git fetch --unshallow --tags || true
             - cd helm-chart
             - make helm.create
             - export CHART_PATH=$(find . -name *.tgz)

--- a/.semaphore/generate-helm-chart.yml
+++ b/.semaphore/generate-helm-chart.yml
@@ -60,7 +60,7 @@ blocks:
                 - "Zebra"
           commands:
             - checkout
-            - git fetch --unshallow --tags || true
+            - if git rev-parse --is-shallow-repository | grep -q true; then git fetch --unshallow --tags; else git fetch --tags; fi
             - echo $SEMAPHORE_REGISTRY_PASSWORD | docker login --username "$SEMAPHORE_REGISTRY_USERNAME" --password-stdin $SEMAPHORE_REGISTRY_HOST || echo "Semaphore Registry login failed, but continuing the build process." && true
             - export REGISTRY_HOST=$SEMAPHORE_REGISTRY_HOST
             - sudo chmod 600 ~/.ssh/feature_provider_rsa
@@ -79,7 +79,7 @@ blocks:
         - name: Create helm chart artifact
           commands:
             - checkout
-            - git fetch --unshallow --tags || true
+            - if git rev-parse --is-shallow-repository | grep -q true; then git fetch --unshallow --tags; else git fetch --tags; fi
             - cd helm-chart
             - make helm.create
             - export CHART_PATH=$(find . -name *.tgz)

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ global_job_config:
       - echo $DOCKER_PASSWORD | docker login --username "$DOCKER_USERNAME" --password-stdin || echo "Docker login failed, but continuing the build process." && true
       - echo $SEMAPHORE_REGISTRY_PASSWORD | docker login --username "$SEMAPHORE_REGISTRY_USERNAME" --password-stdin $SEMAPHORE_REGISTRY_HOST || echo "Semaphore Registry login failed, but continuing the build process." && true
       - export REGISTRY_HOST=$SEMAPHORE_REGISTRY_HOST
-      - sem-version ruby 3.0
+      - sem-version ruby 3.3
   epilogue:
     always:
       commands:
@@ -3552,7 +3552,6 @@ blocks:
             - make check.ruby.code
         - name: "\U0001F6E1️ Check dependencies"
           commands:
-            - sem-version ruby 3.3
             - make check.ruby.deps
         - name: "\U0001F6E1️ Check docker"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ global_job_config:
       - echo $DOCKER_PASSWORD | docker login --username "$DOCKER_USERNAME" --password-stdin || echo "Docker login failed, but continuing the build process." && true
       - echo $SEMAPHORE_REGISTRY_PASSWORD | docker login --username "$SEMAPHORE_REGISTRY_USERNAME" --password-stdin $SEMAPHORE_REGISTRY_HOST || echo "Semaphore Registry login failed, but continuing the build process." && true
       - export REGISTRY_HOST=$SEMAPHORE_REGISTRY_HOST
-      - sem-version ruby 3.3
+      - sem-version ruby 3.0
   epilogue:
     always:
       commands:
@@ -3552,6 +3552,7 @@ blocks:
             - make check.ruby.code
         - name: "\U0001F6E1️ Check dependencies"
           commands:
+            - sem-version ruby 3.3
             - make check.ruby.deps
         - name: "\U0001F6E1️ Check docker"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ global_job_config:
       - echo $DOCKER_PASSWORD | docker login --username "$DOCKER_USERNAME" --password-stdin || echo "Docker login failed, but continuing the build process." && true
       - echo $SEMAPHORE_REGISTRY_PASSWORD | docker login --username "$SEMAPHORE_REGISTRY_USERNAME" --password-stdin $SEMAPHORE_REGISTRY_HOST || echo "Semaphore Registry login failed, but continuing the build process." && true
       - export REGISTRY_HOST=$SEMAPHORE_REGISTRY_HOST
-      - sem-version ruby 3.0
+      - sem-version ruby 3.3
   epilogue:
     always:
       commands:

--- a/github_hooks/Dockerfile
+++ b/github_hooks/Dockerfile
@@ -86,7 +86,6 @@ COPY --chown=nobody:root config config
 COPY --chown=nobody:root db db
 COPY --chown=nobody:root lib lib
 COPY --chown=nobody:root protobuffer protobuffer
-COPY --chown=nobody:root tmp tmp
 COPY --chown=nobody:root config.ru config.ru
 COPY --chown=nobody:root Rakefile Rakefile
 COPY --chown=nobody:root sidekiq.ru sidekiq.ru

--- a/github_hooks/Dockerfile
+++ b/github_hooks/Dockerfile
@@ -93,6 +93,12 @@ COPY --chown=nobody:root Gemfile Gemfile
 COPY --chown=nobody:root Gemfile.lock Gemfile.lock
 COPY --from=production-builder --chown=nobody:root $BUNDLE_PATH $BUNDLE_PATH
 
+# Check if tmp exists before copying it
+RUN test -d tmp && cp -r tmp /app/tmp || true
+
+# Ensure tmp exists (if it wasn't copied)
+RUN mkdir -p /app/tmp && chown nobody:root /app/tmp
+
 USER nobody
 
 EXPOSE 3000

--- a/github_hooks/Dockerfile
+++ b/github_hooks/Dockerfile
@@ -93,10 +93,6 @@ COPY --chown=nobody:root Gemfile Gemfile
 COPY --chown=nobody:root Gemfile.lock Gemfile.lock
 COPY --from=production-builder --chown=nobody:root $BUNDLE_PATH $BUNDLE_PATH
 
-# Check if tmp exists before copying it
-RUN test -d tmp && cp -r tmp /app/tmp || true
-
-# Ensure tmp exists (if it wasn't copied)
 RUN mkdir -p /app/tmp && chown nobody:root /app/tmp
 
 USER nobody

--- a/github_hooks/Gemfile
+++ b/github_hooks/Gemfile
@@ -34,7 +34,7 @@ gem "sentry-sidekiq"
 gem "sprockets", "< 4"
 gem "nokogiri", "~> 1.16.5"
 
-gem "rt-watchman", :require => "watchman", :github => "renderedtext/watchman", :ref => "d3fa4f44b4565dac5fa98df03d1124c68aee304c"
+gem "rt-watchman", :require => "watchman", :github => "renderedtext/watchman"
 gem "rt-logman", :require => "logman"
 gem "rt-tackle", :require => "tackle"
 

--- a/github_hooks/Gemfile
+++ b/github_hooks/Gemfile
@@ -34,7 +34,7 @@ gem "sentry-sidekiq"
 gem "sprockets", "< 4"
 gem "nokogiri", "~> 1.18.3"
 
-gem "rt-watchman", :require => "watchman", :github => "renderedtext/watchman"
+gem "rt-watchman", :require => "watchman", :github => "renderedtext/watchman", :ref => "74530687a232aea678b6738114c82dfc163657cd"
 gem "rt-logman", :require => "logman"
 gem "rt-tackle", :require => "tackle"
 

--- a/github_hooks/Gemfile
+++ b/github_hooks/Gemfile
@@ -32,7 +32,7 @@ gem "sentry-rails"
 gem "sentry-sidekiq"
 
 gem "sprockets", "< 4"
-gem "nokogiri", "~> 1.16.5"
+gem "nokogiri", "~> 1.18.3"
 
 gem "rt-watchman", :require => "watchman", :github => "renderedtext/watchman"
 gem "rt-logman", :require => "logman"

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/renderedtext/watchman.git
   revision: 74530687a232aea678b6738114c82dfc163657cd
+  ref: 74530687a232aea678b6738114c82dfc163657cd
   specs:
     rt-watchman (0.10.0)
       dogstatsd-ruby (~> 5.5.0)

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.16.8)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.20.0)

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/renderedtext/watchman.git
-  revision: d3fa4f44b4565dac5fa98df03d1124c68aee304c
-  ref: d3fa4f44b4565dac5fa98df03d1124c68aee304c
+  revision: 74530687a232aea678b6738114c82dfc163657cd
   specs:
     rt-watchman (0.10.0)
       dogstatsd-ruby (~> 5.5.0)
@@ -221,7 +220,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.3)
+    nokogiri (1.16.8)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.20.0)

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.16.8)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.20.0)
@@ -465,7 +465,7 @@ DEPENDENCIES
   kaminari (~> 1.2.2)
   lograge
   net-http
-  nokogiri (~> 1.16.5)
+  nokogiri (~> 1.18.3)
   octokit
   pg (~> 1.1)
   pry-byebug (~> 3.10, >= 3.10.1)

--- a/github_hooks/Makefile
+++ b/github_hooks/Makefile
@@ -88,7 +88,7 @@ check.ruby.code: check.prepare
 	$(MAKE) check.code LANGUAGE=ruby
 
 check.ruby.deps: check.prepare
-	$(MAKE) check.deps LANGUAGE=ruby
+	$(MAKE) check.deps LANGUAGE=ruby CHECK_DEPS_OPTS="-w rt-watchman,app"
 
 pb.gen:
 	bash ./protobuffer/regenerate.sh

--- a/github_hooks/Makefile
+++ b/github_hooks/Makefile
@@ -88,7 +88,7 @@ check.ruby.code: check.prepare
 	$(MAKE) check.code LANGUAGE=ruby
 
 check.ruby.deps: check.prepare
-	$(MAKE) check.deps LANGUAGE=ruby CHECK_DEPS_OPTS="-w app"
+	$(MAKE) check.deps LANGUAGE=ruby CHECK_DEPS_OPTS="-w app,rt-watchman"
 
 pb.gen:
 	bash ./protobuffer/regenerate.sh

--- a/github_hooks/Makefile
+++ b/github_hooks/Makefile
@@ -88,7 +88,7 @@ check.ruby.code: check.prepare
 	$(MAKE) check.code LANGUAGE=ruby
 
 check.ruby.deps: check.prepare
-	$(MAKE) check.deps LANGUAGE=ruby CHECK_DEPS_OPTS="-w rt-watchman,app"
+	$(MAKE) check.deps LANGUAGE=ruby CHECK_DEPS_OPTS="-w app"
 
 pb.gen:
 	bash ./protobuffer/regenerate.sh


### PR DESCRIPTION
## Description
- Helm Chart Generation was not working
- set ruby version to 3.3 before security box analysis so the license check may work
- Ignore license check for rt-watchman (references a commit without a license) and app (it has a modified version of OS license) dependecies
- Fix Dockerfile that was trying to copy the tmp folder that didn't exist on helm chart generation

## Type of Change
<!-- Mark relevant items with an [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Enterprise Edition feature
- [ ] Test updates

### Community Edition Impact
It would not be possible to generate helm charts

## Testing
<!-- How has this been tested? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Not applicable

## Documentation
<!-- Mark relevant items with an [x] -->
- [ ] Documentation update required
- [ ] Documentation updated
- [x] No documentation changes needed

## Checklist
<!-- Mark relevant items with an [x] -->
- [x] Code follows project style guidelines
- [x] Self review performed
- [x] Comments added to hard-to-understand areas
- [x] Tests prove change is effective
- [ ] Relevant documentation updated
- [ ] Changelog updated if needed
- [x] CI/CD changes required

## Additional Notes
<!-- Add any additional notes for reviewers -->