### PR TITLE
fix(front): github app url nil if cached value does not contain field

### DIFF
--- a/front/lib/front/github_app.ex
+++ b/front/lib/front/github_app.ex
@@ -10,13 +10,11 @@ defmodule Front.GithubApp do
   end
 
   def get(field) do
-    Cachex.get(:front_cache, @cache_key)
-    |> case do
-      {:ok, gh_app} when not is_nil(gh_app) ->
-        gh_app.fields[field]
-
-      _ ->
-        get_from_api(field)
+    with {:ok, gh_app} when not is_nil(gh_app) <- Cachex.get(:front_cache, @cache_key),
+      field when not is_nil(field) <- gh_app.fields[field] do
+        field
+      else
+        _ -> get_from_api(field)
     end
   end
 


### PR DESCRIPTION
## Description
When fetching `app_url` if the cached value did not contain the `html_url` it returned nil causing issues elsewhere.
## Type of Change
<!-- Mark relevant items with an [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Enterprise Edition feature
- [ ] Test updates

## Impact
<!-- Delete the non-applicable section -->
### Community Edition Impact
<!-- Describe the impact on CE users -->

### Enterprise Edition Impact
<!-- Describe the impact on EE users -->

## Testing
<!-- How has this been tested? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Not applicable

## Documentation
<!-- Mark relevant items with an [x] -->
- [ ] Documentation update required
- [ ] Documentation updated
- [ ] No documentation changes needed

## Related Issues
<!-- Link related issues below. Insert the issue link or issue number -->
- Closes <!-- insert issue link here -->
- Related to <!-- insert issue link here -->

## Checklist
<!-- Mark relevant items with an [x] -->
- [ ] Code follows project style guidelines
- [ ] Self review performed
- [ ] Comments added to hard-to-understand areas
- [ ] Tests prove change is effective
- [ ] Relevant documentation updated
- [ ] Changelog updated if needed
- [ ] CI/CD changes required

## Additional Notes
<!-- Add any additional notes for reviewers -->