### PR TITLE
fix: use proper digest index for GCR push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ gcloud.push:
 gcloud.sign: cosign.install
 	cosign sign -y \
 		--identity-token $$(cat /tmp/sigstore-token) \
-		$(shell docker inspect --format='{{index .RepoDigests 1}}' us.gcr.io/$(GOOGLE_PROJECT_NAME)/$(APP_NAME):$(GCR_RELEASE_TAG))
+		$(shell docker inspect --format='{{index .RepoDigests 0}}' us.gcr.io/$(GOOGLE_PROJECT_NAME)/$(APP_NAME):$(GCR_RELEASE_TAG))
 
 ghcr.configure:
 	@printf "%s" "$(GITHUB_TOKEN)" | docker login ghcr.io -u "$(GITHUB_USERNAME)" --password-stdin


### PR DESCRIPTION
## Description

Image signing for GCR is failing due to [this issue](https://semaphore.semaphoreci.com/jobs/ce075e89-8a72-4923-992c-6604547b8ad9). This fixes it.

## Type of Change
<!-- Mark relevant items with an [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Enterprise Edition feature
- [ ] Test updates

## Testing
<!-- How has this been tested? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] Not applicable

## Documentation
<!-- Mark relevant items with an [x] -->
- [ ] Documentation update required
- [ ] Documentation updated
- [x] No documentation changes needed

## Checklist
<!-- Mark relevant items with an [x] -->
- [ ] Code follows project style guidelines
- [ ] Self review performed
- [ ] Comments added to hard-to-understand areas
- [ ] Tests prove change is effective
- [ ] Relevant documentation updated
- [ ] Changelog updated if needed
- [x] CI/CD changes required