### PR TITLE
fix(guard): fix gitlab caching null

### DIFF
--- a/guard/lib/guard/git_provider_credentials.ex
+++ b/guard/lib/guard/git_provider_credentials.ex
@@ -47,7 +47,8 @@ defmodule Guard.GitProviderCredentials do
     cache_key = "#{provider}_credentials"
 
     case Cachex.get(:config_cache, cache_key) do
-      {:ok, credentials} when not is_nil(credentials) ->
+      {:ok, %{client_id: client_id, client_secret: client_secret} = credentials}
+      when not is_nil(client_id) and not is_nil(client_secret) ->
         {:ok, credentials}
 
       _ ->


### PR DESCRIPTION
## Description
- Fix inconsistent cache: Since credentials is a map, the is_nil would always return false. Setting empty Crendentials
Tested with these steps:
- Cleared instance_config cache
- Recreated gilab integration
- Created a project

![Captura de Tela 2025-02-26 às 14 15 47](https://github.com/user-attachments/assets/4c7a3389-4b32-4616-8d58-2c4a25be9623)

![Captura de Tela 2025-02-26 às 14 16 17](https://github.com/user-attachments/assets/84f12ebb-c3de-49a2-9753-d3e3aeeeb196)

## Type of Change
<!-- Mark relevant items with an [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Enterprise Edition feature
- [ ] Test updates

## Testing
<!-- How has this been tested? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Not applicable

## Documentation
<!-- Mark relevant items with an [x] -->
- [ ] Documentation update required
- [ ] Documentation updated
- [x] No documentation changes needed

## Checklist
<!-- Mark relevant items with an [x] -->
- [x] Code follows project style guidelines
- [x] Self review performed
- [ ] Comments added to hard-to-understand areas
- [ ] Tests prove change is effective
- [ ] Relevant documentation updated
- [ ] Changelog updated if needed
- [ ] CI/CD changes required

## Additional Notes
<!-- Add any additional notes for reviewers -->