### PR TITLE
fix: ignore license check for internal libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 
 DOCKER_BUILD_PATH=.
 EX_CATCH_WARRNINGS_FLAG=--warnings-as-errors
-CHECK_DEPS_EXTRA_OPTS?=-w feature_provider,grpc_health_check,tentacat,util,watchman,fun_registry,sentry_grpc,traceman,cacheman,log_tee,open_api_spex,when,uuid,esaml,openid_connect
+CHECK_DEPS_EXTRA_OPTS?=-w feature_provider,grpc_health_check,tentacat,util,watchman,fun_registry,sentry_grpc,traceman,cacheman,log_tee,spec,proto,sys2app,looper,job_matrix,definition_validator,gofer_client,open_api_spex,when,uuid,esaml,openid_connect
 ROOT_MAKEFILE_PATH := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 #


### PR DESCRIPTION
## 📝 Description
- Ignore internal libraries for license check to avoid breaking the services and keep the green build.
- Ignoring only libraries that we know that have valid license or the ones that are internal to the monorepo.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
