### PR TITLE
fix(front): decode URL encoded grpc error messages

### DIFF
--- a/front/lib/front_web/controllers/notifications_controller.ex
+++ b/front/lib/front_web/controllers/notifications_controller.ex
@@ -91,12 +91,12 @@ defmodule FrontWeb.NotificationsController do
 
           {:error, %{status: :invalid_argument, message: message}} ->
             conn
-            |> put_flash(:alert, message)
+            |> put_flash(:alert, URI.decode(message))
             |> redirect(to: notifications_path(conn, :new))
 
           {:error, %{status: 3, message: message}} ->
             conn
-            |> put_flash(:alert, message)
+            |> put_flash(:alert, URI.decode(message))
             |> redirect(to: notifications_path(conn, :new))
 
           {:error, %{message: message, status: 9}} ->
@@ -168,12 +168,12 @@ defmodule FrontWeb.NotificationsController do
 
           {:error, %{status: :invalid_argument, message: message}} ->
             conn
-            |> put_flash(:alert, message)
+            |> put_flash(:alert, URI.decode(message))
             |> redirect(to: notifications_path(conn, :edit, id))
 
           {:error, %{status: 3, message: message}} ->
             conn
-            |> put_flash(:alert, message)
+            |> put_flash(:alert, URI.decode(message))
             |> redirect(to: notifications_path(conn, :edit, id))
 
           {:error, %{message: message, status: 9}} ->

--- a/front/lib/front_web/controllers/people_controller.ex
+++ b/front/lib/front_web/controllers/people_controller.ex
@@ -590,7 +590,7 @@ defmodule FrontWeb.PeopleController do
 
       {:error, message} ->
         conn
-        |> put_flash(:alert, message)
+        |> put_flash(:alert, URI.decode(message))
         |> redirect(to: people_path(conn, :sync))
     end
   end

--- a/front/lib/front_web/controllers/project_settings_controller.ex
+++ b/front/lib/front_web/controllers/project_settings_controller.ex
@@ -470,7 +470,7 @@ defmodule FrontWeb.ProjectSettingsController do
       else
         {:error, message} when is_binary(message) ->
           conn
-          |> put_flash(:alert, message)
+          |> put_flash(:alert, URI.decode(message))
           |> redirect(to: project_settings_path(conn, :general, project.name))
 
         {:error, owner_changeset} ->
@@ -494,7 +494,7 @@ defmodule FrontWeb.ProjectSettingsController do
 
         {:error, message} ->
           conn
-          |> put_flash(:alert, message)
+          |> put_flash(:alert, URI.decode(message))
           |> redirect(to: project_settings_path(conn, :repository, project.name))
       end
     end)
@@ -512,7 +512,7 @@ defmodule FrontWeb.ProjectSettingsController do
 
         {:error, message} ->
           conn
-          |> put_flash(:alert, message)
+          |> put_flash(:alert, URI.decode(message))
           |> redirect(to: project_settings_path(conn, :repository, project.name))
       end
     end)
@@ -538,7 +538,7 @@ defmodule FrontWeb.ProjectSettingsController do
 
         {:error, :message, message} ->
           conn
-          |> put_flash(:alert, message)
+          |> put_flash(:alert, URI.decode(message))
           |> redirect(to: project_settings_path(conn, source, project.name))
 
         {:error, :grpc_req_failed} ->

--- a/front/lib/front_web/controllers/self_hosted_agent_controller.ex
+++ b/front/lib/front_web/controllers/self_hosted_agent_controller.ex
@@ -174,7 +174,7 @@ defmodule FrontWeb.SelfHostedAgentController do
 
       {:error, %GRPC.RPCError{status: 3, message: message}} ->
         conn
-        |> put_flash(:alert, "Error creating agent type: #{message}")
+        |> put_flash(:alert, "Error creating agent type: #{URI.decode(message)}")
         |> redirect(to: self_hosted_agent_path(conn, :new))
 
       {:error, e} ->
@@ -227,7 +227,7 @@ defmodule FrontWeb.SelfHostedAgentController do
         conn
         |> put_status(422)
         |> json(%{
-          message: "Error updating agent type: #{message}"
+          message: "Error updating agent type: #{URI.decode(message)}"
         })
 
       {:error, e} ->
@@ -249,7 +249,7 @@ defmodule FrontWeb.SelfHostedAgentController do
 
       {:error, %GRPC.RPCError{status: 3, message: message}} ->
         conn
-        |> put_flash(:alert, "Error updating agent type: #{message}")
+        |> put_flash(:alert, "Error updating agent type: #{URI.decode(message)}")
         |> redirect(to: self_hosted_agent_edit_path(conn, :edit, agent_type_name))
 
       {:error, e} ->


### PR DESCRIPTION
## 📝 Description

Related Task: https://github.com/semaphoreio/semaphore/issues/35

- Some Grpc error messages are being URL encoded to [an update in its grpc library ](https://github.com/elixir-grpc/grpc/pull/271)
- Added Uri encode in grpc responses to ensure it will be decoded. If not, it will keep the same.


![image](https://github.com/user-attachments/assets/d2fca20d-2667-4e4c-9de8-fa4e3575b4d8)

![image](https://github.com/user-attachments/assets/7dd3d6bb-159b-4ce9-b0a4-c855d706024f)



## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
