### PR TITLE
fix: skip build/push image if it already exists

### DIFF
--- a/.semaphore/generate-helm-chart.yml
+++ b/.semaphore/generate-helm-chart.yml
@@ -62,7 +62,12 @@ blocks:
             - if git rev-parse --is-shallow-repository | grep -q true; then git fetch --unshallow --tags; else git fetch --tags; fi
             - export APP_NAME=$(jq -r --arg application "$APPLICATION" '.services[$application][]["app"]' .semaphore/services.json)
             - cd $(jq -r --arg application "$APPLICATION" '.services[$application][]["path"]' .semaphore/services.json)
-            - if docker manifest inspect $(make registry.image); then export SEMAPHORE_JOB_RESULT=passed && return 130; fi
+            - |
+              if docker manifest inspect $(make registry.image); then
+                echo "Image $(make registry.image) already exists - skipping"
+                export SEMAPHORE_JOB_RESULT=passed
+                return 130
+              fi
             - make build NO_BUILD_CACHE=true
             - 'if [[ -n $SEMAPHORE_GIT_TAG_NAME ]]; then make configure.sign; fi'
             - make registry.configure

--- a/.semaphore/generate-helm-chart.yml
+++ b/.semaphore/generate-helm-chart.yml
@@ -14,6 +14,8 @@ blocks:
           value: "prod"
         - name: DOCKER_BUILDKIT
           value: "1"
+        - name: REGISTRY_HOST
+          value: "ghcr.io/semaphoreio"
       jobs:
         - name: Build and push images
           matrix:
@@ -60,9 +62,9 @@ blocks:
             - if git rev-parse --is-shallow-repository | grep -q true; then git fetch --unshallow --tags; else git fetch --tags; fi
             - export APP_NAME=$(jq -r --arg application "$APPLICATION" '.services[$application][]["app"]' .semaphore/services.json)
             - cd $(jq -r --arg application "$APPLICATION" '.services[$application][]["path"]' .semaphore/services.json)
+            - if docker manifest inspect $(make registry.image); then export SEMAPHORE_JOB_RESULT=passed && return 130; fi
             - make build NO_BUILD_CACHE=true
             - 'if [[ -n $SEMAPHORE_GIT_TAG_NAME ]]; then make configure.sign; fi'
-            - export REGISTRY_HOST=ghcr.io/semaphoreio
             - make registry.configure
             - make registry.push
             - 'if [[ -n $SEMAPHORE_GIT_TAG_NAME ]]; then make registry.sign; fi'

--- a/.semaphore/generate-helm-chart.yml
+++ b/.semaphore/generate-helm-chart.yml
@@ -36,7 +36,6 @@ blocks:
                 - "PublicApiGateway"
                 - "HooksProcessor"
                 - "HooksReceiver"
-                - "Self Hosted Hub"
                 - "Keycloak image"
                 - "Keycloak setup"
                 - "Bootstrapper"

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,9 @@ registry.sign: cosign.install
 		--identity-token $$(cat /tmp/sigstore-token) \
 		$(shell docker inspect --format='{{index .RepoDigests 0}}' $(REGISTRY_HOST)/$(APP_NAME):$(RELEASE_TAG))
 
+registry.image:
+	@echo $(REGISTRY_HOST)/$(APP_NAME):$(RELEASE_TAG)
+
 registry.configure:
 	@printf "%s" "$(GITHUB_TOKEN)" | docker login ghcr.io -u "$(GITHUB_USERNAME)" --password-stdin
 

--- a/self_hosted_hub/pkg/publicapi/server.go
+++ b/self_hosted_hub/pkg/publicapi/server.go
@@ -111,8 +111,6 @@ type RefreshTokenResponse struct {
 func (s *Server) RefreshToken(w http.ResponseWriter, r *http.Request) {
 	defer watchman.Benchmark(time.Now(), "token.refresh")
 
-	// TODO: remove this, I just want to check if the build actually is built now
-
 	agent, err := findAgent(r)
 	if err != nil {
 		respondWith404(w)

--- a/self_hosted_hub/pkg/publicapi/server.go
+++ b/self_hosted_hub/pkg/publicapi/server.go
@@ -111,6 +111,8 @@ type RefreshTokenResponse struct {
 func (s *Server) RefreshToken(w http.ResponseWriter, r *http.Request) {
 	defer watchman.Benchmark(time.Now(), "token.refresh")
 
+	// TODO: remove this, I just want to check if the build actually is built now
+
 	agent, err := findAgent(r)
 	if err != nil {
 		respondWith404(w)


### PR DESCRIPTION
## 📝 Description

When building the Helm chart, we do not need to build/push images that already exist. By skipping that, we can save up to ~1h of build time (if we sum up all the durations in all the build/push jobs) and ~10min of waiting (the maximum duration  is ~10min, for the github_hooks application) on the "Generate Helm chart" promotion.

Ref: https://github.com/renderedtext/project-tasks/issues/2269

## ✅ Checklist

- [x] I have tested this change
- [ ] This change requires documentation update
