### PR TITLE
Remove references to Quota which does no longer exist

### DIFF
--- a/guard/lib/guard/front_repo.ex
+++ b/guard/lib/guard/front_repo.ex
@@ -3,18 +3,6 @@ defmodule Guard.FrontRepo do
     otp_app: :guard,
     adapter: Ecto.Adapters.Postgres
 
-  defmodule Quota do
-    use Ecto.Schema
-
-    @primary_key {:id, :binary_id, autogenerate: true}
-
-    schema "quotas" do
-      field(:type, :string)
-      field(:value, :integer)
-      field(:organization_id, :binary_id)
-    end
-  end
-
   defmodule OauthConnection do
     use Ecto.Schema
 

--- a/guard/lib/guard/store/user.ex
+++ b/guard/lib/guard/store/user.ex
@@ -268,8 +268,6 @@ defmodule Guard.Store.User do
             repo.delete_all(
               from(c in Repo.OrganizationContact, where: c.organization_id == ^org.id)
             )
-
-            repo.delete_all(from(q in Repo.Quota, where: q.organization_id == ^org.id))
           end)
 
           {:ok, :deleted_related_data}


### PR DESCRIPTION
## 📝 Description

A month back we removed deprecated tables for Quotas and UserRefs. In Guard, there was still a reference to this entity, and this PR removed it.


## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
