### PR TITLE
feat(gofer, secrethub): enable gofer and oidc in ee

### DIFF
--- a/bootstrapper/cmd/gen_secrets.go
+++ b/bootstrapper/cmd/gen_secrets.go
@@ -1,7 +1,15 @@
 package cmd
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
 	"log"
+	"os"
+	"strconv"
+	"time"
 
 	"github.com/semaphoreio/semaphore/bootstrapper/pkg/kubernetes"
 	"github.com/semaphoreio/semaphore/bootstrapper/pkg/random"
@@ -19,6 +27,7 @@ var genSecretsCmd = &cobra.Command{
 		generateJWTSecret(client)
 		generateAuthenticationSecret(client)
 		generateEncryptionKey(client)
+		generateEESecrets(client)
 	},
 }
 
@@ -58,6 +67,87 @@ func generateEncryptionKey(client *kubernetes.KubernetesClient) {
 
 	if err != nil {
 		log.Fatalf("Failed to generate encryption key: %v", err)
+	}
+}
+
+func generateRSAKeyPair() ([]byte, []byte, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate RSA key: %v", err)
+	}
+
+	// Generate private key PEM
+	privateKeyPEM := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}
+
+	// Generate public key PEM
+	publicKeyPEM := &pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: x509.MarshalPKCS1PublicKey(&privateKey.PublicKey),
+	}
+
+	return pem.EncodeToMemory(privateKeyPEM), pem.EncodeToMemory(publicKeyPEM), nil
+}
+
+func generateOpenIDSecret(client *kubernetes.KubernetesClient) error {
+	secretName := utils.AssertEnv("OPENID_SECRET_NAME")
+
+	privateKey, _, err := generateRSAKeyPair()
+	if err != nil {
+		return fmt.Errorf("failed to generate OpenID RSA key pair: %v", err)
+	}
+
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	privateKeyName := fmt.Sprintf("%s.pem", timestamp)
+
+	err = client.UpsertSecret(secretName, map[string]string{
+		privateKeyName: string(privateKey),
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to generate OpenID secret: %v", err)
+	}
+	return nil
+}
+
+func generateVaultSecret(client *kubernetes.KubernetesClient) error {
+	secretName := utils.AssertEnv("VAULT_SECRET_NAME")
+
+	privateKey, publicKey, err := generateRSAKeyPair()
+	if err != nil {
+		return fmt.Errorf("failed to generate Vault RSA key pair: %v", err)
+	}
+
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	privateKeyName := fmt.Sprintf("%s.prv.pem", timestamp)
+	publicKeyName := fmt.Sprintf("%s.pub.pem", timestamp)
+
+	err = client.UpsertSecret(secretName, map[string]string{
+		privateKeyName: string(privateKey),
+		publicKeyName:  string(publicKey),
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to generate Vault secret: %v", err)
+	}
+	return nil
+}
+
+// runSecretGeneration handles the actual secret generation logic, allowing for dependency injection in tests
+func generateEESecrets(client *kubernetes.KubernetesClient) {
+	// Only generate OpenID and Vault secrets for EE edition
+	edition := os.Getenv("SEMAPHORE_EDITION")
+	if edition != "ee" {
+		return
+	}
+
+	if err := generateOpenIDSecret(client); err != nil {
+		log.Fatalf("Failed to generate OpenID secret: %v", err)
+	}
+	if err := generateVaultSecret(client); err != nil {
+		log.Fatalf("Failed to generate Vault secret: %v", err)
 	}
 }
 

--- a/bootstrapper/cmd/gen_secrets_test.go
+++ b/bootstrapper/cmd/gen_secrets_test.go
@@ -1,0 +1,278 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/semaphoreio/semaphore/bootstrapper/pkg/kubernetes"
+	"github.com/semaphoreio/semaphore/bootstrapper/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// setTestEnv sets up the environment variables needed for tests
+func setTestEnv(edition string) func() {
+	envVars := map[string]string{
+		"JWT_SECRET_NAME":            "jwt-secret",
+		"AUTHENTICATION_SECRET_NAME": "auth-secret",
+		"ENCRYPTION_SECRET_NAME":     "encryption-secret",
+		"KUBERNETES_NAMESPACE":       "test",
+		"OPENID_SECRET_NAME":         "openid-secret",
+		"VAULT_SECRET_NAME":          "vault-secret",
+	}
+
+	if edition != "" {
+		envVars["SEMAPHORE_EDITION"] = edition
+	}
+
+	// Set all environment variables
+	for key, value := range envVars {
+		os.Setenv(key, value)
+	}
+
+	// Return cleanup function
+	return func() {
+		for key := range envVars {
+			os.Unsetenv(key)
+		}
+	}
+}
+
+// MockKubernetesClient implements the minimal interface needed for testing
+type MockKubernetesClient struct {
+	*kubernetes.KubernetesClient
+	Clientset *fake.Clientset
+}
+
+func NewMockKubernetesClient() *MockKubernetesClient {
+	fakeClientset := fake.NewSimpleClientset()
+	return &MockKubernetesClient{
+		KubernetesClient: kubernetes.NewClientWithClientset(fakeClientset, "test"),
+		Clientset:        fakeClientset,
+	}
+}
+
+func TestGenerateRSAKey(t *testing.T) {
+	// Test generateRSAKeyPair
+	privateKey, publicKey, err := generateRSAKeyPair()
+	assert.NoError(t, err)
+	assert.NotNil(t, privateKey)
+	assert.NotNil(t, publicKey)
+
+	// Verify private key format
+	assert.True(t, strings.Contains(string(privateKey), "-----BEGIN RSA PRIVATE KEY-----"))
+	assert.True(t, strings.Contains(string(privateKey), "-----END RSA PRIVATE KEY-----"))
+
+	// Verify public key format
+	assert.True(t, strings.Contains(string(publicKey), "-----BEGIN RSA PUBLIC KEY-----"))
+	assert.True(t, strings.Contains(string(publicKey), "-----END RSA PUBLIC KEY-----"))
+
+	// Test generateRSAKey (which should only return private key)
+	privateKeyOnly, _, err := generateRSAKeyPair()
+	assert.NoError(t, err)
+	assert.NotNil(t, privateKeyOnly)
+	assert.True(t, strings.Contains(string(privateKeyOnly), "-----BEGIN RSA PRIVATE KEY-----"))
+	assert.True(t, strings.Contains(string(privateKeyOnly), "-----END RSA PRIVATE KEY-----"))
+}
+
+func TestGenerateOpenIDSecret(t *testing.T) {
+	// Set required env vars
+	cleanup := setTestEnv("ee")
+	defer cleanup()
+
+	mockClient := NewMockKubernetesClient()
+
+	err := generateOpenIDSecret(mockClient.KubernetesClient)
+	assert.NoError(t, err)
+
+	// Verify the secret was created with correct format
+	secret, err := mockClient.Clientset.CoreV1().Secrets("test").Get(context.Background(), "openid-secret", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, secret)
+	// Verify secret type
+	assert.Equal(t, corev1.SecretTypeOpaque, secret.Type)
+
+	// Verify there's exactly one key pair with correct format
+	foundPrivate := false
+
+	// Helper function to check keys in either StringData or Data
+	checkKeys := func(data map[string]string) {
+		for k, v := range data {
+			if strings.HasSuffix(k, ".pem") && strings.Contains(v, "-----BEGIN RSA PRIVATE KEY-----") {
+				foundPrivate = true
+			}
+		}
+	}
+
+	// Check StringData first
+	checkKeys(secret.StringData)
+
+	// If not found in StringData, check Data
+	if !foundPrivate {
+		data := make(map[string]string)
+		for k, v := range secret.Data {
+			data[k] = string(v)
+		}
+		checkKeys(data)
+	}
+
+	assert.True(t, foundPrivate, "No valid RSA private key found in secret")
+}
+
+func TestGenerateVaultSecret(t *testing.T) {
+	// Set required env vars
+	cleanup := setTestEnv("ee")
+	defer cleanup()
+
+	mockClient := NewMockKubernetesClient()
+
+	err := generateVaultSecret(mockClient.KubernetesClient)
+	assert.NoError(t, err)
+
+	// Verify the secret was created with correct format
+	secret, err := mockClient.Clientset.CoreV1().Secrets("test").Get(context.Background(), utils.AssertEnv("VAULT_SECRET_NAME"), metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, secret)
+	// Verify secret type
+	assert.Equal(t, corev1.SecretTypeOpaque, secret.Type)
+
+	// Verify there's exactly one key pair with correct format
+	foundPrivate := false
+	foundPublic := false
+	timestamp := ""
+
+	// Helper function to check keys in either StringData or Data
+	checkKeys := func(data map[string]string) {
+		for k, v := range data {
+			if strings.HasSuffix(k, ".prv.pem") && strings.Contains(v, "-----BEGIN RSA PRIVATE KEY-----") {
+				foundPrivate = true
+				// Extract timestamp from the key name
+				timestamp = strings.TrimSuffix(k, ".prv.pem")
+			}
+			if strings.HasSuffix(k, ".pub.pem") && strings.Contains(v, "-----BEGIN RSA PUBLIC KEY-----") {
+				foundPublic = true
+			}
+		}
+	}
+
+	// Check StringData first
+	checkKeys(secret.StringData)
+
+	// If not found in StringData, check Data
+	if !foundPrivate || !foundPublic {
+		data := make(map[string]string)
+		for k, v := range secret.Data {
+			data[k] = string(v)
+		}
+		checkKeys(data)
+	}
+
+	assert.True(t, foundPrivate, "No valid RSA private key found in secret")
+	assert.True(t, foundPublic, "No valid RSA public key found in secret")
+
+	// Verify that both keys have the same timestamp
+	if foundPrivate && foundPublic {
+		assert.Contains(t, secret.StringData, fmt.Sprintf("%s.pub.pem", timestamp), "Public key name does not match private key timestamp")
+	}
+}
+
+func TestSecretGenerationForEditions(t *testing.T) {
+	tests := []struct {
+		name           string
+		edition        string
+		expectSecrets  bool
+		secretsToCheck []string
+	}{
+		{
+			name:           "EE Edition",
+			edition:        "ee",
+			expectSecrets:  true,
+			secretsToCheck: []string{"openid-secret", "vault-secret"},
+		},
+		{
+			name:           "CE Edition",
+			edition:        "ce",
+			expectSecrets:  false,
+			secretsToCheck: []string{"openid-secret", "vault-secret"},
+		},
+		{
+			name:           "No Edition Set",
+			edition:        "",
+			expectSecrets:  false,
+			secretsToCheck: []string{"openid-secret", "vault-secret"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := NewMockKubernetesClient()
+
+			// No need to set up explicit mocks as we're using the real implementation with a fake clientset
+
+			// Set required env vars
+			cleanup := setTestEnv(tt.edition)
+			defer cleanup()
+
+			// Run the secret generation
+			generateEESecrets(mockClient.KubernetesClient)
+
+			// Verify secrets based on edition
+			for _, secretName := range tt.secretsToCheck {
+				secret, err := mockClient.Clientset.CoreV1().Secrets("test").Get(context.Background(), secretName, metav1.GetOptions{})
+
+				if tt.expectSecrets {
+					// For EE edition, verify secrets exist with correct format
+					assert.NoError(t, err)
+					assert.NotNil(t, secret)
+					// Verify secret type
+					assert.Equal(t, corev1.SecretTypeOpaque, secret.Type)
+
+					// Verify there's exactly one key pair with correct format
+					foundPrivate := false
+					foundPublic := false
+					timestamp := ""
+
+					// Helper function to check keys in either StringData or Data
+					checkKeys := func(data map[string]string) {
+						for k, v := range data {
+							if (strings.HasSuffix(k, ".prv.pem") || strings.HasSuffix(k, ".pem")) && strings.Contains(v, "-----BEGIN RSA PRIVATE KEY-----") {
+								foundPrivate = true
+								// Extract timestamp from the key name
+								timestamp = strings.TrimSuffix(k, ".prv.pem")
+							}
+							if strings.HasSuffix(k, ".pub.pem") && strings.Contains(v, "-----BEGIN RSA PUBLIC KEY-----") {
+								foundPublic = true
+							}
+						}
+					}
+
+					// Check StringData first
+					checkKeys(secret.StringData)
+
+					// If not found in StringData, check Data
+					if !foundPrivate || !foundPublic {
+						data := make(map[string]string)
+						for k, v := range secret.Data {
+							data[k] = string(v)
+						}
+						checkKeys(data)
+					}
+
+					assert.True(t, foundPrivate, "No valid RSA private key found in secret %s", secretName)
+					if secretName == "vault-secret" {
+						assert.True(t, foundPublic, "No valid RSA public key found in secret %s", secretName)
+						assert.Contains(t, secret.StringData, fmt.Sprintf("%s.pub.pem", timestamp), "Public key name does not match private key timestamp for secret %s", secretName)
+					}
+				} else {
+					// For non-EE editions, verify secrets don't exist
+					assert.Error(t, err, "Secret %s should not exist", secretName)
+				}
+			}
+		})
+	}
+}

--- a/bootstrapper/helm/templates/gen-secrets-job.yml
+++ b/bootstrapper/helm/templates/gen-secrets-job.yml
@@ -45,6 +45,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: SEMAPHORE_EDITION
+              value: "{{ .Values.global.edition }}"
+{{- if eq .Values.global.edition "ee" }}
+            - name: OPENID_SECRET_NAME
+              value: {{ include "secrets.openid.name" . }}
+            - name: VAULT_SECRET_NAME
+              value: {{ include "secrets.vault.name" . }}
+{{- end }}
 {{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 13 }}

--- a/bootstrapper/pkg/kubernetes/kubernetes.go
+++ b/bootstrapper/pkg/kubernetes/kubernetes.go
@@ -55,6 +55,7 @@ func (c *KubernetesClient) UpsertSecretWithLabels(secretName string, data map[st
 	if err != nil {
 		log.Infof("Secret %s does not exist in namespace %s - creating a new one", secretName, c.Namespace)
 		secret := &corev1.Secret{
+			Type:       corev1.SecretTypeOpaque,
 			StringData: data,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
@@ -89,6 +90,9 @@ func (c *KubernetesClient) UpsertSecretWithLabels(secretName string, data map[st
 	for key, value := range labels {
 		secret.Labels[key] = value
 	}
+
+	// Ensure secret type is set
+	secret.Type = corev1.SecretTypeOpaque
 
 	_, err = c.Clientset.CoreV1().
 		Secrets(c.Namespace).

--- a/ee/gofer/helm/templates/dpl.yaml
+++ b/ee/gofer/helm/templates/dpl.yaml
@@ -104,8 +104,13 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.global.internalApi.configMapName }}
                   key: INTERNAL_API_URL_SECRETHUB
+{{- if eq .Values.global.edition "ee" }}
+            - name: ROLES_CACHE_ENABLED
+              value: "true"
+{{- else }}
             - name: ROLES_CACHE_ENABLED
               value: "false"
+{{- end }}
             - name: ROLES_CACHE_EXPIRATION_TTL
               value: "120"
             - name: ROLES_CACHE_EXPIRATION_INTERVAL

--- a/helm-chart/templates/configmaps/features.yaml
+++ b/helm-chart/templates/configmaps/features.yaml
@@ -105,7 +105,7 @@ data:
     activity_monitor:
       enabled: true
     advanced_deployment_targets:
-      enabled: false
+      enabled: true
     artifacts:
       enabled: true
     audit_logs:
@@ -123,7 +123,7 @@ data:
     github_oauth_token:
       enabled: false
     deployment_targets:
-      enabled: false
+      enabled: true
     expose_cloud_agent_types:
       enabled: false
     feedback:
@@ -145,9 +145,9 @@ data:
     okta:
       enabled: false
     open_id_connect:
-      enabled: false
+      enabled: true
     open_id_connect_aws_tags:
-      enabled: false
+      enabled: true
     organization_health:
       enabled: true
     parameterized_promotions:

--- a/helm-chart/templates/emissary-ingress/mappings.yaml
+++ b/helm-chart/templates/emissary-ingress/mappings.yaml
@@ -204,7 +204,7 @@ spec:
   host_regex: true
   bypass_auth: true
   prefix: /
-  rewrite: "" 
+  rewrite: ""
   service: guard-id-http-api.{{ .Release.Namespace }}:80
 ---
 apiVersion: getambassador.io/v3alpha1
@@ -518,6 +518,20 @@ spec:
   rewrite: ""
   service: secrethub-http.{{ .Release.Namespace }}:4000
   precedence: 100
+{{- if eq .Values.global.edition "ee" }}
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: secrethub-openid-mapping
+  namespace: {{ .Release.Namespace }}
+spec:
+  hostname: "*"
+  prefix: /.well-known/
+  rewrite: ""
+  service: secrethub-openid-connect-http.{{ .Release.Namespace }}:5000
+  precedence: 100
+{{- end }}
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: Mapping

--- a/helm-chart/templates/secrets.tpl
+++ b/helm-chart/templates/secrets.tpl
@@ -21,3 +21,19 @@
 {{- .Values.global.encryption.secretName }}
 {{- end }}
 {{- end }}
+
+{{- define "secrets.openid.name" }}
+{{- if eq .Values.global.openid.secretName "" }}
+{{- printf "%s-openid" .Release.Name }}
+{{- else }}
+{{- .Values.global.openid.secretName }}
+{{- end }}
+{{- end }}
+
+{{- define "secrets.vault.name" }}
+{{- if eq .Values.global.vault.secretName "" }}
+{{- printf "%s-vault" .Release.Name }}
+{{- else }}
+{{- .Values.global.vault.secretName }}
+{{- end }}
+{{- end }}

--- a/helm-chart/values.yaml.in
+++ b/helm-chart/values.yaml.in
@@ -144,6 +144,12 @@ global:
   gitlabApp:
     secretName: ""
 
+  openid:
+    secretName: ""
+
+  vault:
+    secretName: ""
+
 toolbox:
   version: "v1.22.5"
 

--- a/plumber/ppl/helm/templates/plumber-dpl.yml
+++ b/plumber/ppl/helm/templates/plumber-dpl.yml
@@ -51,9 +51,9 @@ spec:
 {{- if eq .Values.global.edition "ce" }}
             - name: SKIP_PFC
               value: "true"
-{{- end }}
             - name: SKIP_PROMOTIONS
               value: "true"
+{{- end }}
             - name: REPO_PROXY_NEW_GRPC_URL
               valueFrom:
                 configMapKeyRef:

--- a/secrethub/helm/templates/dpl.yaml
+++ b/secrethub/helm/templates/dpl.yaml
@@ -1,3 +1,18 @@
+{{- if eq .Values.global.edition "ee"}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Chart.Name }}-openid-connect-http"
+spec:
+  type: ClusterIP
+  selector:
+    app: "{{ .Chart.Name }}"
+  ports:
+    - name: http
+      port: 5000
+      targetPort: 5000
+---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -75,6 +90,14 @@ spec:
             items:
             - key: features.yml
               path: features.yml
+{{- if eq .Values.global.edition "ee" }}
+        - name: openid-secrets
+          secret:
+            secretName: {{ include "secrets.openid.name" . }}
+        - name: vault-secrets
+          secret:
+            secretName: {{ include "secrets.vault.name" . }}
+{{- end }}
       initContainers:
 {{ include "initContainers.all" . | indent 8 }}
       containers:
@@ -87,6 +110,14 @@ spec:
               mountPath: "/app/features.yml"
               readOnly: true
               subPath: features.yml
+{{- if eq .Values.global.edition "ee" }}
+            - name: openid-secrets
+              mountPath: "/var/openid_secrets"
+              readOnly: true
+            - name: vault-secrets
+              mountPath: "/var/vault_secrets"
+              readOnly: true
+{{- end }}
           ports:
             - name: http-port
               containerPort: 4000
@@ -112,10 +143,23 @@ spec:
               value: "true"
             - name: START_HTTP_API
               value: "true"
+{{- if eq .Values.global.edition "ee" }}
+            - name: START_OPENID_CONNECT_HTTP_API
+              value: "true"
+            - name: START_OPENID_KEY_MANAGER
+              value: "true"
+            - name: OPENID_KEYS_PATH
+              value: "/var/openid_secrets"
+            - name: KEY_VAULT_PATH
+              value: "/var/vault_secrets"
+{{- else }}
             - name: START_OPENID_CONNECT_HTTP_API
               value: "false"
             - name: START_OPENID_KEY_MANAGER
               value: "false"
+            - name: OPENID_KEYS_PATH
+              value: "/var/open_id_secrets"
+{{- end }}
             - name: START_ENCRYPTOR_WORKER
               value: "false"
             - name: BASE_DOMAIN
@@ -136,8 +180,6 @@ spec:
                   key: amqp-url
             - name: ENCRYPTOR_URL
               value: "localhost:50052"
-            - name: OPENID_KEYS_PATH
-              value: "/var/open_id_secrets"
 {{- if .Values.global.statsd.enabled }}
             - name: METRICS_NAMESPACE
               value: {{ .Values.global.statsd.metricsNamespace }}


### PR DESCRIPTION
## 📝 Description

- Enabled `gofer` in EE, including promotions and deployment targets.
- Updated `secrethub` to use vault and OIDC keys, and enabled the OIDC server in EE.
- Modified `bootstrapper` to generate vault and OIDC keys for EE.

For more details, see: [project task](https://github.com/renderedtext/project-tasks/issues/2272)

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
