### PR TITLE
fix: handle jobs with no name

### DIFF
--- a/zebra/lib/zebra/apis/public_job_api.ex
+++ b/zebra/lib/zebra/apis/public_job_api.ex
@@ -111,6 +111,9 @@ defmodule Zebra.Apis.PublicJobApi do
 
         {:error, :internal, message} ->
           raise GRPC.RPCError, status: :internal, message: message
+
+        {:error, message} ->
+          raise GRPC.RPCError, status: :invalid_argument, message: message
       end
     end)
   end

--- a/zebra/lib/zebra/apis/public_job_api/serializer.ex
+++ b/zebra/lib/zebra/apis/public_job_api/serializer.ex
@@ -9,7 +9,13 @@ defmodule Zebra.Apis.PublicJobApi.Serializer do
     Job.Metadata.new(
       [
         id: job.id,
-        name: job.name
+
+        #
+        # We didn't require names to be non-empty before (we do now),
+        # so we need to default to empty string here to avoid throwing
+        # a Protobuf.InvalidError error here.
+        #
+        name: job.name || ""
       ] ++
         encode_timestamps(
           create_time: job.created_at,

--- a/zebra/lib/zebra/models/job.ex
+++ b/zebra/lib/zebra/models/job.ex
@@ -97,14 +97,14 @@ defmodule Zebra.Models.Job do
     params = set_machine_type_if_empty(params)
 
     changeset(%__MODULE__{}, params)
-      |> LegacyRepo.insert()
-      |> case do
-        {:ok, job} ->
-          {:ok, job}
+    |> LegacyRepo.insert()
+    |> case do
+      {:ok, job} ->
+        {:ok, job}
 
-        {:error, changeset} ->
-          {:error, readable_changeset_errors(changeset)}
-      end
+      {:error, changeset} ->
+        {:error, readable_changeset_errors(changeset)}
+    end
   end
 
   def update(job, params \\ %{}) do

--- a/zebra/test/support/factories/job.ex
+++ b/zebra/test/support/factories/job.ex
@@ -45,7 +45,8 @@ defmodule Support.Factories.Job do
             name: "RSpec 1/3",
             spec: Job.encode_spec(spec()),
             aasm_state: Atom.to_string(state),
-            created_at: @timestamp
+            created_at: @timestamp,
+            updated_at: @timestamp
           },
           params
         )
@@ -72,6 +73,7 @@ defmodule Support.Factories.Job do
             spec: Job.encode_spec(spec()),
             aasm_state: Atom.to_string(state),
             created_at: @timestamp,
+            updated_at: @timestamp,
             enqueued_at: now
           },
           params
@@ -98,6 +100,7 @@ defmodule Support.Factories.Job do
             spec: Job.encode_spec(spec()),
             aasm_state: Atom.to_string(state),
             created_at: @timestamp,
+            updated_at: @timestamp,
             enqueued_at: @timestamp,
             scheduled_at: @timestamp
           },
@@ -125,6 +128,7 @@ defmodule Support.Factories.Job do
             spec: Job.encode_spec(spec()),
             aasm_state: Atom.to_string(state),
             created_at: @timestamp,
+            updated_at: @timestamp,
             enqueued_at: @timestamp,
             scheduled_at: @timestamp
           },
@@ -156,6 +160,7 @@ defmodule Support.Factories.Job do
             agent_auth_token: "lol",
             aasm_state: Atom.to_string(state),
             created_at: @timestamp,
+            updated_at: @timestamp,
             enqueued_at: @timestamp,
             scheduled_at: @timestamp,
             started_at: @timestamp
@@ -189,6 +194,7 @@ defmodule Support.Factories.Job do
             spec: Job.encode_spec(spec()),
             aasm_state: Atom.to_string(state),
             created_at: @timestamp,
+            updated_at: @timestamp,
             enqueued_at: @timestamp,
             scheduled_at: @timestamp,
             dispatched_at: @timestamp,

--- a/zebra/test/zebra/apis/public_job_api/serializer_test.exs
+++ b/zebra/test/zebra/apis/public_job_api/serializer_test.exs
@@ -14,7 +14,7 @@ defmodule Zebra.Apis.PublicJobApi.SerializerTest do
     assert serialized_job.metadata.name == job.name
     assert serialized_job.metadata.id == job.id
     assert serialized_job.metadata.create_time == DateTime.to_unix(job.created_at)
-    assert serialized_job.metadata.update_time == 0
+    assert serialized_job.metadata.update_time == DateTime.to_unix(job.updated_at)
     assert serialized_job.metadata.start_time == DateTime.to_unix(job.started_at)
     assert serialized_job.metadata.finish_time == DateTime.to_unix(job.finished_at)
 

--- a/zebra/test/zebra/apis/public_job_api_test.exs
+++ b/zebra/test/zebra/apis/public_job_api_test.exs
@@ -545,17 +545,18 @@ defmodule Zebra.Api.PublicJobApiTest do
       job =
         Semaphore.Jobs.V1alpha.Job.new(
           metadata: Semaphore.Jobs.V1alpha.Job.Metadata.new(name: ""),
-          spec: Semaphore.Jobs.V1alpha.Job.Spec.new(
-            agent:
-              Semaphore.Jobs.V1alpha.Job.Spec.Agent.new(
-                machine:
-                  Semaphore.Jobs.V1alpha.Job.Spec.Agent.Machine.new(
-                    type: "e1-standard-2",
-                    os_image: "ubuntu1804"
-                  )
-              ),
-            project_id: hd(@authorized_projects)
-          )
+          spec:
+            Semaphore.Jobs.V1alpha.Job.Spec.new(
+              agent:
+                Semaphore.Jobs.V1alpha.Job.Spec.Agent.new(
+                  machine:
+                    Semaphore.Jobs.V1alpha.Job.Spec.Agent.Machine.new(
+                      type: "e1-standard-2",
+                      os_image: "ubuntu1804"
+                    )
+                ),
+              project_id: hd(@authorized_projects)
+            )
         )
 
       {:ok, channel} = GRPC.Stub.connect("localhost:50051")

--- a/zebra/test/zebra/models/job_test.exs
+++ b/zebra/test/zebra/models/job_test.exs
@@ -11,41 +11,41 @@ defmodule Zebra.Models.JobTest do
   describe ".create" do
     test "empty name => error" do
       assert {:error, "name: can't be blank"} =
-        Zebra.Models.Job.create(
-          organization_id: @org_id,
-          project_id: @project_id,
-          index: 0,
-          priority: 75,
-          spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
-          machine_type: "e1-standard-2",
-          machine_os_image: "ubuntu1804"
-        )
+               Zebra.Models.Job.create(
+                 organization_id: @org_id,
+                 project_id: @project_id,
+                 index: 0,
+                 priority: 75,
+                 spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
+                 machine_type: "e1-standard-2",
+                 machine_os_image: "ubuntu1804"
+               )
     end
 
     test "empty organization_id => error" do
       assert {:error, "organization_id: can't be blank"} =
-        Zebra.Models.Job.create(
-          project_id: @project_id,
-          index: 0,
-          priority: 75,
-          name: "Test",
-          spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
-          machine_type: "e1-standard-2",
-          machine_os_image: "ubuntu1804"
-        )
+               Zebra.Models.Job.create(
+                 project_id: @project_id,
+                 index: 0,
+                 priority: 75,
+                 name: "Test",
+                 spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
+                 machine_type: "e1-standard-2",
+                 machine_os_image: "ubuntu1804"
+               )
     end
 
     test "empty project_id => error" do
       assert {:error, "project_id: can't be blank"} =
-        Zebra.Models.Job.create(
-          organization_id: @org_id,
-          index: 0,
-          priority: 75,
-          name: "Test",
-          spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
-          machine_type: "e1-standard-2",
-          machine_os_image: "ubuntu1804"
-        )
+               Zebra.Models.Job.create(
+                 organization_id: @org_id,
+                 index: 0,
+                 priority: 75,
+                 name: "Test",
+                 spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
+                 machine_type: "e1-standard-2",
+                 machine_os_image: "ubuntu1804"
+               )
     end
 
     test "creates a new job" do

--- a/zebra/test/zebra/models/job_test.exs
+++ b/zebra/test/zebra/models/job_test.exs
@@ -9,6 +9,45 @@ defmodule Zebra.Models.JobTest do
   @agent_id Ecto.UUID.generate()
 
   describe ".create" do
+    test "empty name => error" do
+      assert {:error, "name: can't be blank"} =
+        Zebra.Models.Job.create(
+          organization_id: @org_id,
+          project_id: @project_id,
+          index: 0,
+          priority: 75,
+          spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
+          machine_type: "e1-standard-2",
+          machine_os_image: "ubuntu1804"
+        )
+    end
+
+    test "empty organization_id => error" do
+      assert {:error, "organization_id: can't be blank"} =
+        Zebra.Models.Job.create(
+          project_id: @project_id,
+          index: 0,
+          priority: 75,
+          name: "Test",
+          spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
+          machine_type: "e1-standard-2",
+          machine_os_image: "ubuntu1804"
+        )
+    end
+
+    test "empty project_id => error" do
+      assert {:error, "project_id: can't be blank"} =
+        Zebra.Models.Job.create(
+          organization_id: @org_id,
+          index: 0,
+          priority: 75,
+          name: "Test",
+          spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
+          machine_type: "e1-standard-2",
+          machine_os_image: "ubuntu1804"
+        )
+    end
+
     test "creates a new job" do
       spec = %Semaphore.Jobs.V1alpha.Job.Spec{
         agent: %Semaphore.Jobs.V1alpha.Job.Spec.Agent{
@@ -46,6 +85,8 @@ defmodule Zebra.Models.JobTest do
       {:ok, job1} =
         Zebra.Models.Job.create(
           organization_id: @org_id,
+          project_id: @project_id,
+          name: "test",
           spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
           machine_type: "e1-standard-2"
         )
@@ -53,6 +94,8 @@ defmodule Zebra.Models.JobTest do
       {:ok, job2} =
         Zebra.Models.Job.create(
           organization_id: @org_id,
+          project_id: @project_id,
+          name: "test",
           spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
           machine_type: "a1-standard-4"
         )
@@ -65,6 +108,8 @@ defmodule Zebra.Models.JobTest do
       {:ok, job} =
         Zebra.Models.Job.create(
           organization_id: @org_id,
+          project_id: @project_id,
+          name: "test",
           spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
           machine_type: "x1-standard-4"
         )
@@ -75,6 +120,9 @@ defmodule Zebra.Models.JobTest do
     test "when the machine_os_image is set => it leaves it intact" do
       {:ok, job} =
         Zebra.Models.Job.create(
+          organization_id: @org_id,
+          project_id: @project_id,
+          name: "test",
           spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
           machine_type: "x1-standard-4",
           machine_os_image: "xubuntu"
@@ -87,6 +135,8 @@ defmodule Zebra.Models.JobTest do
       {:ok, job} =
         Zebra.Models.Job.create(
           organization_id: @org_id,
+          project_id: @project_id,
+          name: "test",
           spec: %Semaphore.Jobs.V1alpha.Job.Spec{},
           machine_type: "e1-standard-2"
         )
@@ -454,15 +504,6 @@ defmodule Zebra.Models.JobTest do
       assert Job.finished?(job)
       assert Job.stopped?(job)
       assert Zebra.Models.Task.finished?(task)
-    end
-
-    test "stops jobs with invalid machine_type" do
-      {:ok, job} = Support.Factories.Job.create(:pending, %{machine_type: nil})
-
-      assert {:ok, job} = Job.stop(job)
-
-      assert Job.stopped?(job)
-      assert Job.finished?(job)
     end
   end
 


### PR DESCRIPTION
## 📝 Description

Currently, we are not validating that required fields for jobs are always present. That can lead to a scenario where a job is created without a name – `sem create` – which will break listing jobs.

This pull request fixes that by:
- Validating that required fields are present when creating/updating job records
- Defaulting to empty string when serializing jobs without a name, to ensure we are handling the old empty-name jobs still in the database and being returned when listing jobs using the API.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
