### PR TITLE
fix(front): add simple.yml to ce_new

### DIFF
--- a/front/workflow_templates/ce_new/templates/simple.yml
+++ b/front/workflow_templates/ce_new/templates/simple.yml
@@ -1,0 +1,13 @@
+version: v1.0
+name: Initial Pipeline
+agent:
+  machine:
+    type: {{ machine_type }}
+    os_image: {{ os_image }}
+blocks:
+  - name: 'Block #1'
+    task:
+      jobs:
+        - name: 'Job #1'
+          commands:
+            - checkout


### PR DESCRIPTION
## 📝 Description
Related Issue: https://github.com/semaphoreio/semaphore/issues/133

- Added missing simple.yml template file for CE
- This template has changeable os_image and machine type
- It was missing when Clicking on Design from Scratch for the workflow builder.
- It fixes an error 500 in CE
![image](https://github.com/user-attachments/assets/62f551e8-ea70-4158-8057-434d7b7aa7bd)

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
