### PR TITLE
refactor: replace gradient to fixed color in logout and CE login page

### DIFF
--- a/guard/templates/logout.html.eex
+++ b/guard/templates/logout.html.eex
@@ -54,7 +54,7 @@
                           </figure>
                           <div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-medium"></div>
                           <div class="wp-block-group is-layout-constrained wp-container-core-group-is-layout-3 wp-block-group-is-layout-constrained">
-                              <div class="wp-block-group has-background is-layout-flow wp-block-group-is-layout-flow" style="border-radius:20px;background:linear-gradient(43deg,rgb(199,218,255) 0%,rgb(194,240,215) 100%);padding-top:2%;padding-right:2%;padding-bottom:2%;padding-left:2%">
+                              <div class="wp-block-group has-background is-layout-flow wp-block-group-is-layout-flow" style="border-radius:20px;background:#d7e3fc;padding-top:2%;padding-right:2%;padding-bottom:2%;padding-left:2%">
                                   <div class="wp-block-group has-border-color has-v-8-stroke-border-color has-v-8-white-background-color has-background is-layout-flow wp-block-group-is-layout-flow" style="border-width:1px;border-radius:20px;padding-top:6%;padding-right:6%;padding-bottom:6%;padding-left:6%">
                                       <p style="text-align: center; font-size: 1.25rem; color: #202B30; margin-bottom: 0px">
                                           Confirm Logout

--- a/keycloak/image/themes/semaphore/login/login.ftl
+++ b/keycloak/image/themes/semaphore/login/login.ftl
@@ -4,7 +4,7 @@
     <div class="tc mt6 mb4">
         <img decoding="async" width="164" height="23" src="https://semaphoreci.com/wp-content/uploads/2024/04/semaphore-logo.svg" alt="" class="wp-image-23606">
     </div>
-    <div class="mw6 center br4 pa4" style="background:linear-gradient(43deg,rgb(199,218,255) 0%,rgb(194,240,215) 100%);">
+    <div class="mw6 center br4 pa4" style="background:#d7e3fc">
         <div class="bg-white ba pa3 br4" style="border-color: #ccc;">
             <div class="gray tc f4 mt2">
                 Log in to Semaphore


### PR DESCRIPTION
## 📝 Description
- When we changed to the signup and login Page, I missed the CE Login page and the Logout
- This PR remove the gradients

![image](https://github.com/user-attachments/assets/ea9e3832-397a-4fea-8143-06d10f466683)
![image](https://github.com/user-attachments/assets/40f766d4-8ba7-4c3c-922f-c68d8fedfb51)


## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
