### PR TITLE
fix(rbaac): SAML assigned roles can be managed manually

### DIFF
--- a/ee/rbac/lib/rbac/grpc_servers/rbac_server.ex
+++ b/ee/rbac/lib/rbac/grpc_servers/rbac_server.ex
@@ -408,7 +408,6 @@ defmodule Rbac.GrpcServers.RbacServer do
           "github" -> :ROLE_BINDING_SOURCE_GITHUB
           "bitbucket" -> :ROLE_BINDING_SOURCE_BITBUCKET
           "okta" -> :ROLE_BINDING_SOURCE_SCIM
-          "saml_jit" -> :ROLE_BINDING_SOURCE_SAML_JIT
           "inherited_from_org_role" -> :ROLE_BINDING_SOURCE_INHERITED_FROM_ORG_ROLE
           _ -> :ROLE_BINDING_SOURCE_UNSPECIFIED
         end

--- a/ee/rbac/lib/rbac/okta/saml/jit_provisioner/add_user.ex
+++ b/ee/rbac/lib/rbac/okta/saml/jit_provisioner/add_user.ex
@@ -116,7 +116,9 @@ defmodule Rbac.Okta.Saml.JitProvisioner.AddUser do
       :ok
     else
       {:ok, rbi} = RoleBindingIdentification.new(user_id: user_id, org_id: org_id)
-      {:ok, nil} = RoleManagement.assign_role(rbi, role_id, :saml_jit)
+      # Although this role is assigned through :saml_jit, it can be updated and
+      # removed manually, hence it is marked as "manually_assigned"
+      {:ok, nil} = RoleManagement.assign_role(rbi, role_id, :manually_assigned)
 
       Rbac.Events.UserJoinedOrganization.publish(user_id, org_id)
       :ok

--- a/ee/rbac/lib/rbac/okta/saml/jit_provisioner/add_user.ex
+++ b/ee/rbac/lib/rbac/okta/saml/jit_provisioner/add_user.ex
@@ -116,7 +116,7 @@ defmodule Rbac.Okta.Saml.JitProvisioner.AddUser do
       :ok
     else
       {:ok, rbi} = RoleBindingIdentification.new(user_id: user_id, org_id: org_id)
-      # Although this role is assigned through :saml_jit, it can be updated and
+      # Although this role is assigned through saml_jit, it can be updated and
       # removed manually, hence it is marked as "manually_assigned"
       {:ok, nil} = RoleManagement.assign_role(rbi, role_id, :manually_assigned)
 

--- a/ee/rbac/lib/rbac/repo/subject_role_binding.ex
+++ b/ee/rbac/lib/rbac/repo/subject_role_binding.ex
@@ -3,7 +3,7 @@ defmodule Rbac.Repo.SubjectRoleBinding do
   alias Rbac.Repo.{RbacRole, Subject}
   import Ecto.Query, only: [where: 3]
 
-  @binding_sources ~w(github bitbucket gitlab manually_assigned okta inherited_from_org_role saml_jit)a
+  @binding_sources ~w(github bitbucket gitlab manually_assigned okta inherited_from_org_role)a
 
   schema "subject_role_bindings" do
     belongs_to(:role, RbacRole)


### PR DESCRIPTION
## 📝 Description

Roles that have been assigned through saml jit provisioning should be managed later on manually. Hence we have to mark them as :manually_assigned

https://github.com/renderedtext/tasks/issues/7653

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
