### PR TITLE
toil(front): Add Pedro as codeowner on front

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /encryptor/ @VeljkoMaksimovic @lucaspin @forestileao
 /ephemeral_environment/ @VeljkoMaksimovic @lucaspin @hamir-suspect
 /feature_provider/ @skipi @hamir-suspect @dexyk
-/front/ @hamir-suspect @skipi @VeljkoMaksimovic
+/front/ @hamir-suspect @skipi @VeljkoMaksimovic @forestileao
 /github_hooks/ @VeljkoMaksimovic @skipi @darkofabijan
 /github_notifier/ @VeljkoMaksimovic @hamir-suspect @skipi
 /guard/ @VeljkoMaksimovic @forestileao @lucaspin


### PR DESCRIPTION
## 📝 Description

Add pedro as codeowner on front repo

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
