### PR TITLE
fix(front): move select-none to app.css

### DIFF
--- a/front/assets/css/app-semaphore.css
+++ b/front/assets/css/app-semaphore.css
@@ -6896,12 +6896,7 @@ code, .code, pre {
   -webkit-font-feature-settings: 'tnum';
           font-feature-settings: 'tnum';
 }
-.select-none {
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
-}
+
 /* Variables */
 /* Importing here will allow you to override any variables in the modules */
 /*

--- a/front/assets/css/app.css
+++ b/front/assets/css/app.css
@@ -458,3 +458,10 @@ sem-popover {
     flex-shrink: 0.2;
     flex-grow: 1;
 }
+
+.select-none {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}


### PR DESCRIPTION
## 📝 Description

app-semaphore.css is not loaded. What was loaded is app.css and app-semaphore-min.css (generated).
So, I just changed the select-none class that was added to app.css.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
