### PR TITLE
feat(boostrapper): add installed telemetry request in boostrapper

### DIFF
--- a/bootstrapper/cmd/init_org.go
+++ b/bootstrapper/cmd/init_org.go
@@ -12,6 +12,7 @@ import (
 	"github.com/semaphoreio/semaphore/bootstrapper/pkg/installation"
 	"github.com/semaphoreio/semaphore/bootstrapper/pkg/kubernetes"
 	"github.com/semaphoreio/semaphore/bootstrapper/pkg/organization"
+	"github.com/semaphoreio/semaphore/bootstrapper/pkg/telemetry"
 	"github.com/semaphoreio/semaphore/bootstrapper/pkg/user"
 	"github.com/semaphoreio/semaphore/bootstrapper/pkg/utils"
 	log "github.com/sirupsen/logrus"
@@ -52,9 +53,15 @@ var initOrgCmd = &cobra.Command{
 		}
 
 		if os.Getenv("CONFIGURE_INSTALLATION_DEFAULTS") == "true" {
-			if err := installation.ConfigureInstallationDefaults(instanceConfigClient, orgId); err != nil {
+			telemetryClient := telemetry.NewTelemetryClient(os.Getenv("CHART_VERSION"))
+
+			installation_defaults, err := installation.ConfigureInstallationDefaults(instanceConfigClient, orgId)
+			if err != nil {
 				log.Errorf("Failed to configure installation defaults: %v", err)
+
+				telemetryClient.SendTelemetryInstallationData(installation_defaults)
 			}
+
 		}
 
 		if os.Getenv("CONFIGURE_GITHUB_APP") == "true" {

--- a/bootstrapper/cmd/init_org.go
+++ b/bootstrapper/cmd/init_org.go
@@ -56,12 +56,11 @@ var initOrgCmd = &cobra.Command{
 			telemetryClient := telemetry.NewTelemetryClient(os.Getenv("CHART_VERSION"))
 
 			installationDefaults, err := installation.ConfigureInstallationDefaults(instanceConfigClient, orgId)
-			if err != nil {
-				log.Errorf("Failed to configure installation defaults: %v", err)
-
+			if err == nil {
 				telemetryClient.SendTelemetryInstallationData(installationDefaults)
+			} else {
+				log.Errorf("Failed to configure installation defaults: %v", err)
 			}
-
 		}
 
 		if os.Getenv("CONFIGURE_GITHUB_APP") == "true" {

--- a/bootstrapper/cmd/init_org.go
+++ b/bootstrapper/cmd/init_org.go
@@ -55,11 +55,11 @@ var initOrgCmd = &cobra.Command{
 		if os.Getenv("CONFIGURE_INSTALLATION_DEFAULTS") == "true" {
 			telemetryClient := telemetry.NewTelemetryClient(os.Getenv("CHART_VERSION"))
 
-			installation_defaults, err := installation.ConfigureInstallationDefaults(instanceConfigClient, orgId)
+			installationDefaults, err := installation.ConfigureInstallationDefaults(instanceConfigClient, orgId)
 			if err != nil {
 				log.Errorf("Failed to configure installation defaults: %v", err)
 
-				telemetryClient.SendTelemetryInstallationData(installation_defaults)
+				telemetryClient.SendTelemetryInstallationData(installationDefaults)
 			}
 
 		}

--- a/bootstrapper/helm/templates/init-org-job.yml
+++ b/bootstrapper/helm/templates/init-org-job.yml
@@ -80,6 +80,8 @@ spec:
               value: "true"
             - name: TELEMETRY_ENDPOINT
               value: {{ .Values.global.telemetry.endpoint }}
+            - name: CHART_VERSION
+              value: {{ .Chart.Version }}
             - name: KUBE_VERSION
               value: {{ .Capabilities.KubeVersion.Version }}
             - name: ROOT_USER_SECRET_NAME

--- a/bootstrapper/pkg/installation/installation.go
+++ b/bootstrapper/pkg/installation/installation.go
@@ -10,9 +10,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func ConfigureInstallationDefaults(instanceConfigClient *clients.InstanceConfigClient, orgId string) error {
-	return retry.WithConstantWait("Installation Defaults configuration", 5, 10*time.Second, func() error {
-		err := instanceConfigClient.ConfigureInstallationDefaults(installationDefaultsParams(orgId))
+func ConfigureInstallationDefaults(instanceConfigClient *clients.InstanceConfigClient, orgId string) (map[string]string, error) {
+	installationDefaults := installationDefaultsParams(orgId)
+	err := retry.WithConstantWait("Installation Defaults configuration", 5, 10*time.Second, func() error {
+		err := instanceConfigClient.ConfigureInstallationDefaults(installationDefaults)
 		if err == nil {
 			log.Info("Successfully configured Installation Defaults")
 			return nil
@@ -20,6 +21,8 @@ func ConfigureInstallationDefaults(instanceConfigClient *clients.InstanceConfigC
 
 		return err
 	})
+
+	return installationDefaults, err
 }
 
 func installationDefaultsParams(orgId string) map[string]string {

--- a/bootstrapper/pkg/telemetry/telemetry.go
+++ b/bootstrapper/pkg/telemetry/telemetry.go
@@ -1,0 +1,64 @@
+package telemetry
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type RequestPayload struct {
+	OrganizationId  string `json:"organization_id"`
+	InstallationId  string `json:"installation_id"`
+	KubeVersion     string `json:"kube_version"`
+	Version         string `json:"version"`
+	ProjectsCount   int    `json:"projects_count"`
+	OrgMembersCount int    `json:"org_members_count"`
+	State           string `json:"state"`
+}
+
+type TelemetryClient struct {
+	chartVersion string
+}
+
+func NewTelemetryClient(chartVersion string) *TelemetryClient {
+	return &TelemetryClient{
+		chartVersion: chartVersion,
+	}
+}
+
+func (c *TelemetryClient) SendTelemetryInstallationData(installationDefaults map[string]string) {
+	endpoint := installationDefaults["telemetry_endpoint"]
+
+	request := RequestPayload{
+		OrganizationId:  installationDefaults["organization_id"],
+		InstallationId:  installationDefaults["installation_id"],
+		KubeVersion:     installationDefaults["kube_version"],
+		Version:         c.chartVersion,
+		ProjectsCount:   0,
+		OrgMembersCount: 1,
+		State:           "installed",
+	}
+
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		log.Errorf("Failed to marshal request payload: %v", err)
+		return
+	}
+
+	// Make HTTP request
+	resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		log.Errorf("Failed to send request: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		log.Errorf("Failed to send request: %v", resp.Status)
+		return
+	}
+
+	log.Info("Successfully sent telemetry installation data")
+}

--- a/bootstrapper/pkg/telemetry/telemetry.go
+++ b/bootstrapper/pkg/telemetry/telemetry.go
@@ -10,7 +10,6 @@ import (
 )
 
 type RequestPayload struct {
-	OrganizationId  string `json:"organization_id"`
 	InstallationId  string `json:"installation_id"`
 	KubeVersion     string `json:"kube_version"`
 	Version         string `json:"version"`
@@ -33,7 +32,6 @@ func (c *TelemetryClient) SendTelemetryInstallationData(installationDefaults map
 	endpoint := installationDefaults["telemetry_endpoint"]
 
 	request := RequestPayload{
-		OrganizationId:  installationDefaults["organization_id"],
 		InstallationId:  installationDefaults["installation_id"],
 		KubeVersion:     installationDefaults["kube_version"],
 		Version:         c.chartVersion,

--- a/bootstrapper/pkg/telemetry/telemetry_test.go
+++ b/bootstrapper/pkg/telemetry/telemetry_test.go
@@ -1,0 +1,58 @@
+package telemetry_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/semaphoreio/semaphore/bootstrapper/pkg/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendTelemetryInstallationData(t *testing.T) {
+	orgId := uuid.New().String()
+	instId := uuid.New().String()
+
+	// Create a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		require.Equal(t, "POST", r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		defer r.Body.Close()
+
+		var requestPayload telemetry.RequestPayload
+		err = json.Unmarshal(body, &requestPayload)
+		require.NoError(t, err)
+
+		assert.Equal(t, orgId, requestPayload.OrganizationId)
+		assert.Equal(t, instId, requestPayload.InstallationId)
+		assert.Equal(t, "v1.23.0+k3s1", requestPayload.KubeVersion)
+		assert.Equal(t, "1.0.0", requestPayload.Version)
+		assert.Equal(t, 0, requestPayload.ProjectsCount)
+		assert.Equal(t, 1, requestPayload.OrgMembersCount)
+		assert.Equal(t, "installed", requestPayload.State)
+
+		// Respond with HTTP 200 OK
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create telemetry client and test data
+	client := telemetry.NewTelemetryClient("1.0.0")
+	installationDefaults := map[string]string{
+		"telemetry_endpoint": server.URL,
+		"organization_id":    orgId,
+		"installation_id":    instId,
+		"kube_version":       "v1.23.0+k3s1",
+	}
+
+	// Call function to be tested
+	client.SendTelemetryInstallationData(installationDefaults)
+}

--- a/bootstrapper/pkg/telemetry/telemetry_test.go
+++ b/bootstrapper/pkg/telemetry/telemetry_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestSendTelemetryInstallationData(t *testing.T) {
-	orgId := uuid.New().String()
 	instId := uuid.New().String()
 
 	// Create a mock HTTP server
@@ -31,7 +30,6 @@ func TestSendTelemetryInstallationData(t *testing.T) {
 		err = json.Unmarshal(body, &requestPayload)
 		require.NoError(t, err)
 
-		assert.Equal(t, orgId, requestPayload.OrganizationId)
 		assert.Equal(t, instId, requestPayload.InstallationId)
 		assert.Equal(t, "v1.23.0+k3s1", requestPayload.KubeVersion)
 		assert.Equal(t, "1.0.0", requestPayload.Version)
@@ -48,7 +46,6 @@ func TestSendTelemetryInstallationData(t *testing.T) {
 	client := telemetry.NewTelemetryClient("1.0.0")
 	installationDefaults := map[string]string{
 		"telemetry_endpoint": server.URL,
-		"organization_id":    orgId,
 		"installation_id":    instId,
 		"kube_version":       "v1.23.0+k3s1",
 	}


### PR DESCRIPTION
## 📝 Description
Related issue: https://github.com/semaphoreio/semaphore/issues/182

- Add 'Installed' state for a telemetry request
- It should only happen in bootstrapper


## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
