### PR TITLE
fix(front): fix setting default agent type, image in wf editor

### DIFF
--- a/front/config/runtime.exs
+++ b/front/config/runtime.exs
@@ -189,3 +189,7 @@ config :front,
 config :front,
        :single_tenant,
        System.get_env("SINGLE_TENANT") == "true"
+
+config :front,
+       :edition,
+       System.get_env("EDITION", "") |> String.trim() |> String.downcase()

--- a/front/helm/templates/job-page.yaml
+++ b/front/helm/templates/job-page.yaml
@@ -88,6 +88,8 @@ spec:
           - secretRef:
               name: {{ include "secrets.authentication.name" . }}
           env:
+            - name: EDITION
+              value: {{ .Values.global.edition | quote }}
             - name: PORT
               value: "4000"
             - name: USE_RBAC_API

--- a/front/helm/templates/project-page.yaml
+++ b/front/helm/templates/project-page.yaml
@@ -114,6 +114,8 @@ spec:
           - configMapRef:
              name: {{ .Values.global.internalApi.configMapName }}
           env:
+            - name: EDITION
+              value: {{ .Values.global.edition | quote }}
             - name: AMQP_URL
               valueFrom:
                 secretKeyRef:

--- a/front/helm/templates/ui-cache-reactor.yaml
+++ b/front/helm/templates/ui-cache-reactor.yaml
@@ -68,6 +68,8 @@ spec:
           env:
             - name: START_REACTOR
               value: "true"
+            - name: EDITION
+              value: {{ .Values.global.edition | quote }}
             - name: PREHEAT_PROJECT_PAGE
               value: "true"
             - name: USE_RBAC_API

--- a/front/lib/front.ex
+++ b/front/lib/front.ex
@@ -11,4 +11,28 @@ defmodule Front do
   def ce_roles? do
     Application.get_env(:front, :ce_roles)
   end
+
+  @doc """
+  Check if it's CE edition
+  """
+  @spec ce?() :: boolean()
+  def ce? do
+    Application.get_env(:front, :edition) == "ce"
+  end
+
+  @doc """
+  Check if it's EE edition
+  """
+  @spec ee?() :: boolean()
+  def ee? do
+    Application.get_env(:front, :edition) == "ee"
+  end
+
+  @doc """
+  Check if it's OS edition
+  """
+  @spec os?() :: boolean()
+  def os? do
+    ee?() || ce?()
+  end
 end

--- a/front/lib/front_web/templates/project/edit_workflow.html.eex
+++ b/front/lib/front_web/templates/project/edit_workflow.html.eex
@@ -23,6 +23,7 @@
   window.InjectedDataByBackend.Features = <%= raw Poison.encode!(%{
     "parameterizedPromotions" => FeatureProvider.feature_enabled?(:parameterized_promotions, param: @conn.assigns.organization_id),
     "hidePromotions" => @hide_promotions,
+    "isOS" => Front.os?(),
     "deploymentTargets" => FeatureProvider.feature_enabled?(:deployment_targets, param: @conn.assigns.organization_id),
     "uiMonacoWorkflowCodeEditor" => FeatureProvider.feature_enabled?(:ui_monaco_workflow_code_editor, param: @conn.assigns.organization_id),
     "useCommitJob" => FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: @conn.assigns.organization_id)

--- a/front/lib/front_web/templates/project_onboarding/setup.html.eex
+++ b/front/lib/front_web/templates/project_onboarding/setup.html.eex
@@ -21,6 +21,7 @@
   window.InjectedDataByBackend.Features = <%= raw Poison.encode!(%{
     "parameterizedPromotions" => FeatureProvider.feature_enabled?(:parameterized_promotions, param: @conn.assigns.organization_id),
     "hidePromotions" => @hide_promotions,
+    "isOS" => Front.os?(),
     "deploymentTargets" => FeatureProvider.feature_enabled?(:deployment_targets, param: @conn.assigns.organization_id),
     "uiMonacoWorkflowCodeEditor" => FeatureProvider.feature_enabled?(:ui_monaco_workflow_code_editor, param: @conn.assigns.organization_id),
     "useCommitJob" => FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: @conn.assigns.organization_id)

--- a/front/lib/front_web/templates/workflow/edit.html.eex
+++ b/front/lib/front_web/templates/workflow/edit.html.eex
@@ -9,6 +9,7 @@
   window.InjectedDataByBackend.Features = <%= raw Poison.encode!(%{
     "parameterizedPromotions" => FeatureProvider.feature_enabled?(:parameterized_promotions, param: @conn.assigns.organization_id),
     "hidePromotions" => @hide_promotions,
+    "isOS" => Front.os?(),
     "deploymentTargets" => FeatureProvider.feature_enabled?(:deployment_targets, param: @conn.assigns.organization_id),
     "uiMonacoWorkflowCodeEditor" => FeatureProvider.feature_enabled?(:ui_monaco_workflow_code_editor, param: @conn.assigns.organization_id),
     "useCommitJob" => FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: @conn.assigns.organization_id)


### PR DESCRIPTION
## 📝 Description

**Fixes** https://github.com/semaphoreio/semaphore/issues/187

This PR introduces the following improvements:
- Sets the default machine type to the first available self-hosted agent type.
- Sets the default container image for promotions that use Docker environments.

### Behavior

- **Self-hosted agent default:**  
  When adding a promotion with a block (without overriding global agent definition), the first available self-hosted agent is selected by default.  
  ![Self-hosted default](https://github.com/user-attachments/assets/e53199c0-c9a5-4d41-8256-16db1e3b1a04)

- **Docker environment default:**  
  When adding a promotion with a block that uses a Docker environment, the default container image is automatically set.  
  ![Docker image default](https://github.com/user-attachments/assets/e9cd7420-7a3b-4e86-8e35-0bb6c96617e9)


## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ - N/A
