### PR TITLE
fix(guard,rbac): Update same_site cookie policy to Lax

### DIFF
--- a/ee/rbac/lib/rbac/utils/http.ex
+++ b/ee/rbac/lib/rbac/utils/http.ex
@@ -5,7 +5,9 @@ defmodule Rbac.Utils.Http do
   @state_cookie_options [
     encrypt: true,
     max_age: 30 * 60,
-    same_site: "Strict",
+    # If `same_site` is set to `Strict` then the cookie will not be sent on
+    # IdP callback redirects, which will break the auth flow.
+    same_site: "Lax",
     path: "/",
     secure: true,
     http_only: true

--- a/guard/lib/guard/utils.ex
+++ b/guard/lib/guard/utils.ex
@@ -137,7 +137,9 @@ defmodule Guard.Utils.Http do
   @state_cookie_options [
     encrypt: true,
     max_age: 30 * 60,
-    same_site: "Strict",
+    # If `same_site` is set to `Strict` then the cookie will not be sent on
+    # IdP callback redirects, which will break the auth flow.
+    same_site: "Lax",
     path: "/",
     secure: true,
     http_only: true

--- a/guard/test/guard/id/api_test.exs
+++ b/guard/test/guard/id/api_test.exs
@@ -476,7 +476,7 @@ defmodule Guard.Id.Api.Test do
       {_, cookie} = Enum.find(response.headers, fn h -> elem(h, 0) == "set-cookie" end)
 
       assert cookie =~ "semaphore_auth_state="
-      assert cookie =~ "secure; HttpOnly; SameSite=Strict"
+      assert cookie =~ "secure; HttpOnly; SameSite=Lax"
 
       assert response.body =~ "/protocol/openid-connect/auth"
       assert response.body =~ "localhost"


### PR DESCRIPTION
## 📝 Description
- Update same_site cookie policy to Lax to prevent error 500 during login
- same_site=Lax makes the Idp always send the state cookie and it makes the auth flow to not break.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
