### PR TITLE
fix(github_hooks): return null if commit author is nil

### DIFF
--- a/github_hooks/lib/repo_host/bitbucket/payload.rb
+++ b/github_hooks/lib/repo_host/bitbucket/payload.rb
@@ -97,7 +97,7 @@ module RepoHost::Bitbucket
 
     # ✔️
     def commit_author
-      @commits.last&.dig("author", "user", "nickname")
+      @commits.last&.dig("author", "user", "nickname") || ""
     end
 
     # ✔️
@@ -120,7 +120,7 @@ module RepoHost::Bitbucket
     end
 
     # ✔️
-    def author_name
+  def author_name
       @data.dig("actor", "nickname") || @data.dig("actor", "username") || ""
     end
 

--- a/github_hooks/lib/repo_host/bitbucket/payload.rb
+++ b/github_hooks/lib/repo_host/bitbucket/payload.rb
@@ -97,9 +97,7 @@ module RepoHost::Bitbucket
 
     # ✔️
     def commit_author
-      if @commits.present? && @commits.last.present?
-        @commits.last["author"]["user"]["nickname"]
-      end
+      @commits.last&.dig("author", "user", "nickname")
     end
 
     # ✔️

--- a/github_hooks/lib/repo_host/bitbucket/payload.rb
+++ b/github_hooks/lib/repo_host/bitbucket/payload.rb
@@ -120,7 +120,7 @@ module RepoHost::Bitbucket
     end
 
     # ✔️
-  def author_name
+    def author_name
       @data.dig("actor", "nickname") || @data.dig("actor", "username") || ""
     end
 

--- a/github_hooks/spec/lib/repo_host/bitbucket/payload_spec.rb
+++ b/github_hooks/spec/lib/repo_host/bitbucket/payload_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe RepoHost::Bitbucket::Payload, :vcr => vcr_options do
         expect(payload_for_new_branch_with_new_commits.author_email).to eq ""
         expect(payload_for_new_branch_without_new_commits.author_email).to eq ""
         expect(payload_for_branch_deletion.commit_author).to eq ""
-        expect(payload_for_new_branch_with_new_commits.commit_author).to eq ""
+        expect(payload_for_new_branch_with_new_commits.commit_author).to eq "milana_stojadinov"
         expect(payload_for_new_branch_without_new_commits.commit_author).to eq ""
       end
     end

--- a/github_hooks/spec/lib/repo_host/bitbucket/payload_spec.rb
+++ b/github_hooks/spec/lib/repo_host/bitbucket/payload_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe RepoHost::Bitbucket::Payload, :vcr => vcr_options do
         expect(payload_for_new_branch_without_new_commits.author_email).to eq ""
         expect(payload_for_branch_deletion.commit_author).to eq ""
         expect(payload_for_new_branch_with_new_commits.commit_author).to eq "milana_stojadinov"
-        expect(payload_for_new_branch_without_new_commits.commit_author).to eq ""
+        expect(payload_for_new_branch_without_new_commits.commit_author).to eq "milana_stojadinov"
       end
     end
 

--- a/github_hooks/spec/lib/repo_host/bitbucket/payload_spec.rb
+++ b/github_hooks/spec/lib/repo_host/bitbucket/payload_spec.rb
@@ -115,6 +115,9 @@ RSpec.describe RepoHost::Bitbucket::Payload, :vcr => vcr_options do
         expect(payload_for_branch_deletion.author_email).to eq ""
         expect(payload_for_new_branch_with_new_commits.author_email).to eq ""
         expect(payload_for_new_branch_without_new_commits.author_email).to eq ""
+        expect(payload_for_branch_deletion.commit_author).to eq ""
+        expect(payload_for_new_branch_with_new_commits.commit_author).to eq ""
+        expect(payload_for_new_branch_without_new_commits.commit_author).to eq ""
       end
     end
 


### PR DESCRIPTION
## 📝 Description
In really specific cases where the author is bitbucket pipelines, it will not contain a user. So the author will be:

```rb
{..., "author"=>{"raw"=>"bitbucket-pipelines <commits-noreply@bitbucket.org>", "type"=>"author"}}
```
It was breaking the parsing since the nickname would raise a MethodNotFound for nil ERROR.


## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
