### PR TITLE
fix(repohub): implement Error() for custom errors

### DIFF
--- a/repohub/pkg/fetcher/fetcher.go
+++ b/repohub/pkg/fetcher/fetcher.go
@@ -118,13 +118,6 @@ func (f *Fetcher) Sync(index int, totalRepoCount int, r *models.Repository) bool
 			quarantinedReason = string(gitrekt.QuarantineReasonCloneTimeout)
 		}
 
-		if _, ok := err.(*gitrekt.AuthTimeoutError); ok {
-			f.putRepoInQuarantine(repo, gitrekt.QuarantineReasonAuthTimeout)
-
-			quarantined = true
-			quarantinedReason = string(gitrekt.QuarantineReasonAuthTimeout)
-		}
-
 		if _, ok := err.(*gitrekt.AuthFailedError); ok {
 			f.putRepoInQuarantine(repo, gitrekt.QuarantineReasonNotFound)
 

--- a/repohub/pkg/gitrekt/errors.go
+++ b/repohub/pkg/gitrekt/errors.go
@@ -1,7 +1,27 @@
 package gitrekt
 
-type NotFoundError struct{ error }
-type AuthFailedError struct{ error }
+import "fmt"
 
-type TimeoutError struct{ error }
-type AuthTimeoutError struct{ error }
+type NotFoundError struct {
+	Output string
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("repository not found: %s", e.Output)
+}
+
+type AuthFailedError struct {
+	Output string
+}
+
+func (e *AuthFailedError) Error() string {
+	return fmt.Sprintf("authentication failed: %s", e.Output)
+}
+
+type TimeoutError struct {
+	Output string
+}
+
+func (e *TimeoutError) Error() string {
+	return fmt.Sprintf("timeout: %s", e.Output)
+}

--- a/repohub/pkg/gitrekt/update_or_clone.go
+++ b/repohub/pkg/gitrekt/update_or_clone.go
@@ -227,17 +227,17 @@ func (o *UpdateOrCloneOperation) gitRemoteConfig() error {
 
 func (o *UpdateOrCloneOperation) parseError(output []byte, err error) error {
 	if strings.Contains(string(output), "remote: Repository not found") {
-		return &NotFoundError{}
+		return &NotFoundError{Output: string(output)}
 	}
 
 	if strings.Contains(string(output), "fatal: Authentication failed") {
-		return &AuthFailedError{}
+		return &AuthFailedError{Output: string(output)}
 	}
 
 	if exiterr, ok := err.(*exec.ExitError); ok {
 		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
 			if status.ExitStatus() == -1 && strings.Contains(err.Error(), "killed") {
-				return &TimeoutError{}
+				return &TimeoutError{Output: string(output)}
 			}
 		}
 	}


### PR DESCRIPTION
## 📝 Description

The Error() method was not implemented for custom errors in repohub, so when a caller uses it, we end up with a segfault. This fixes it by implementing that method.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
