### PR TITLE
fix(front): broken image in deployments history if user is deleted

### DIFF
--- a/front/lib/front/models/deployment_details.ex
+++ b/front/lib/front/models/deployment_details.ex
@@ -64,7 +64,7 @@ defmodule Front.Models.DeploymentDetails do
       %__MODULE__{
         deployment
         | author_name: Application.get_env(:front, :default_user_name),
-          author_avatar_url: FrontWeb.SharedHelpers.assets_path()
+          author_avatar_url: FrontWeb.SharedHelpers.assets_path() <> "/images/org-s.svg"
       }
     end
   end

--- a/front/lib/front/models/deployment_details.ex
+++ b/front/lib/front/models/deployment_details.ex
@@ -61,11 +61,11 @@ defmodule Front.Models.DeploymentDetails do
     end
 
     def preload_triggerer(deployment = %__MODULE__{}, nil) do
-      %__MODULE__{
-        deployment
-        | author_name: Application.get_env(:front, :default_user_name),
-          author_avatar_url: FrontWeb.SharedHelpers.assets_path() <> "/images/org-s.svg"
-      }
+      author_name = Application.get_env(:front, :default_user_name)
+      first_letter = author_name |> String.first() |> String.downcase()
+      avatar_url = "#{FrontWeb.SharedHelpers.assets_path()}/images/org-#{first_letter}.svg"
+
+      %__MODULE__{deployment | author_name: author_name, author_avatar_url: avatar_url}
     end
   end
 


### PR DESCRIPTION
## 📝 Description

https://github.com/renderedtext/tasks/issues/7755

How it currently looks:

![Screenshot 2025-04-03 at 14 24 20](https://github.com/user-attachments/assets/a87cd3df-7aa5-47c9-a7df-0a104b68a780)

How it looks after the change:

![Screenshot 2025-04-03 at 14 38 57](https://github.com/user-attachments/assets/297dede0-2579-4f42-a43f-2244bc033275)

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
