### PR TITLE
feat(front): use a job to fetch yamls in workflow editor

### DIFF
--- a/front/assets/js/workflow_editor/editor.js
+++ b/front/assets/js/workflow_editor/editor.js
@@ -138,9 +138,9 @@ export class WorkflowEditor {
     })
     .then((data) => {
       if(!data.finished) {
-        setTimeout(this.fetchYamls.bind(this), 1000);
+        setTimeout(this.waitForFetchingJob.bind(this), 1000);
       } else {
-        this.fetchFilesAndShowEditor(data.urls);
+        this.fetchFilesAndShowEditor(data.signed_urls);
       }
     })
     .catch(

--- a/front/assets/js/workflow_editor/editor.js
+++ b/front/assets/js/workflow_editor/editor.js
@@ -69,40 +69,40 @@ export class WorkflowEditor {
   }
 
   constructor(config) {
-    this.config = config
+    this.config = config;
 
-    Promotion.setProjectName(this.config.projectName)
-    Promotion.setValidDeploymentTargets(this.config.deploymentTargets)
-    Secrets.setValidSecretNames(this.config.orgSecretNames, this.config.projectSecretNames)
-    Agent.setValidAgentTypes(this.config.agentTypes)
+    Promotion.setProjectName(this.config.projectName);
+    Promotion.setValidDeploymentTargets(this.config.deploymentTargets);
+    Secrets.setValidSecretNames(this.config.orgSecretNames, this.config.projectSecretNames);
+    Agent.setValidAgentTypes(this.config.agentTypes);
 
     if(Features.isEnabled("useFetchingJob")) {
-      this.registerLeavePageHandler() 
+      this.registerLeavePageHandler(); 
       
-      this.disableButtonsInHeader()
+      this.disableButtonsInHeader();
 
-      this.toggleWorkflowEditor()
+      this.toggleWorkflowEditor();
 
-      this.toggleZeroState()
+      this.toggleZeroState();
 
-      this.waitForFetchingJob()
+      this.waitForFetchingJob();
     } else {
-      this.setUpModelComponentEventLoop()
+      this.setUpModelComponentEventLoop();
 
-      this.registerLeavePageHandler()
+      this.registerLeavePageHandler();
   
-      this.preselectFirstBlock()
+      this.preselectFirstBlock();
     }
   }
 
   disableButtonsInHeader() {
-    $("[data-action=editorDismiss]").disabled = true;
-    $("[data-action=toggleCommitDialog]").disabled = true;
+    $("[data-action=editorDismiss]").prop("disabled", true);
+    $("[data-action=toggleCommitDialog]").prop("disabled", true);
   }
 
   enableButtonsInHeader() {
-    $("[data-action=editorDismiss]").disabled = false;
-    $("[data-action=toggleCommitDialog]").disabled = false;
+    $("[data-action=editorDismiss]").prop("disabled", false);
+    $("[data-action=toggleCommitDialog]").prop("disabled", false);
   }
 
   toggleWorkflowEditor() {
@@ -115,13 +115,13 @@ export class WorkflowEditor {
   }
 
   waitForFetchingJob() {
-    var url = this.config.checkFetchingJobPath + `?job_id=${this.config.fetching_job_id}` 
+    let url = this.config.checkFetchingJobPath + `?job_id=${this.config.fetchingJobId}`;
 
-    console.log(`Checking fetching job ${url}`)
+    console.log(`Checking fetching job ${url}`);
 
     fetch(url)
     .then((res) => {
-      var contentType = res.headers.get("content-type");
+      const contentType = res.headers.get("content-type");
 
       if(contentType && contentType.includes("application/json")) {
         return res.json();
@@ -138,37 +138,35 @@ export class WorkflowEditor {
     })
     .then((data) => {
       if(!data.finished) {
-        setTimeout(this.fetchYamls.bind(this), 1000)
+        setTimeout(this.fetchYamls.bind(this), 1000);
       } else {
-        this.fetchFilesAndShowEditor(data.urls)
+        this.fetchFilesAndShowEditor(data.urls);
       }
     })
     .catch(
       (reason) => { 
         console.log(reason); 
-
         this.enableExitAndShowErrorMessage();
       }
     )
   }
 
   enableExitAndShowErrorMessage() {
-    this.disableOnLeaveConfirm()
-    ("[data-action=editorDismiss]").disabled = false;
+    this.disableOnLeaveConfirm();
+    $("[data-action=editorDismiss]").prop("disabled", false);
 
-    $('#zero-state-title').text('Searching git repository for .yml files has failed.');
+    $("#zero-state-title").text('Searching git repository for .yml files has failed.');
 
-    var message1 = "There was an issue with searching your git repository for .yml files."
+    const message1 = "There was an issue with searching your git repository for .yml files.";
     $("#zero-state-paragraph-one").text(message1);
     $("#zero-state-paragraph-one").addClass("red");
 
-    var message2 = 'Please try reloading the page and contact support if the issue persists.';
+    const message2 = 'Please try reloading the page and contact support if the issue persists.';
     $("#zero-state-paragraph-two").text(message2);
     $("#zero-state-paragraph-two").addClass("red");
   }
 
   fetchFilesAndShowEditor(urls) {
-
    fetchFilesWithConcurrencyLimit(urls)
     .then(({ fetchedFiles, errors }) => {
       if (errors.length > 0) {
@@ -178,17 +176,17 @@ export class WorkflowEditor {
       } else {
         console.log("All .yml files were fetched successfully.");
 
-        this.config.workflowData.yamls = fetchedFiles
+        this.config.workflowData.yamls = fetchedFiles;
 
-        this.toggleZeroState()
+        this.toggleZeroState();
 
-        this.toggleWorkflowEditor()
+        this.toggleWorkflowEditor();
 
-        this.enableButtonsInHeader()
+        this.enableButtonsInHeader();
         
-        this.setUpModelComponentEventLoop()
+        this.setUpModelComponentEventLoop();
     
-        this.preselectFirstBlock()
+        this.preselectFirstBlock();
       }
     });
   }
@@ -352,11 +350,9 @@ async function fetchFilesWithConcurrencyLimit(fileList, maxConcurrency = 3) {
       errors.push({ filePath, error: err });
     }
 
-    // Keep the pipeline going
     await fetchNext();
   };
 
-  // Start up to `maxConcurrency` parallel fetchers
   const tasks = [];
   for (let i = 0; i < maxConcurrency; i++) {
     tasks.push(fetchNext());
@@ -366,6 +362,6 @@ async function fetchFilesWithConcurrencyLimit(fileList, maxConcurrency = 3) {
 
   return {
     updatedFiles: fileList,
-    errors, // List of { filePath, error } if any failed
+    errors,
   };
 }

--- a/front/config/.credo.exs
+++ b/front/config/.credo.exs
@@ -35,7 +35,7 @@
         # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
         # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
         #
-        {Credo.Check.Design.DuplicatedCode, excluded_macros: [:test], mass_threshold: 45},
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: [:test], mass_threshold: 55},
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).

--- a/front/lib/front/models/artifacthub.ex
+++ b/front/lib/front/models/artifacthub.ex
@@ -127,10 +127,10 @@ defmodule Front.Models.Artifacthub do
   def list_and_sign_urls(project_id, source_kind, source_id, relative_path) do
     case list(project_id, source_kind, source_id, relative_path, true) do
       {:ok, artifacts} ->
-        Enum.reduce_while(artifacts, {:ok, []}, fn artifact, {_, urls} ->
+        Enum.reduce_while(artifacts, {:ok, %{}}, fn artifact, {_, urls} ->
           case signed_url(project_id, source_kind, source_id, artifact.path) do
             {:ok, url} ->
-              {:cont, {:ok, urls ++ [%{artifact.path => url}]}}
+              {:cont, {:ok, Map.put(urls, artifact.path, url)}}
 
             e ->
               {:halt, {:error, "error generating signed URL for #{artifact.path}: #{inspect(e)}"}}

--- a/front/lib/front/models/artifacthub.ex
+++ b/front/lib/front/models/artifacthub.ex
@@ -130,7 +130,7 @@ defmodule Front.Models.Artifacthub do
         Enum.reduce_while(artifacts, {:ok, []}, fn artifact, {_, urls} ->
           case signed_url(project_id, source_kind, source_id, artifact.path) do
             {:ok, url} ->
-              {:cont, {:ok, urls ++ [url]}}
+              {:cont, {:ok, urls ++ [%{artifact.path => url}]}}
 
             e ->
               {:halt, {:error, "error generating signed URL for #{artifact.path}: #{inspect(e)}"}}

--- a/front/lib/front/models/fetching_job.ex
+++ b/front/lib/front/models/fetching_job.ex
@@ -1,0 +1,95 @@
+defmodule Front.Models.FetchingJob do
+  @moduledoc """
+  Module encapsulates all functions needed to define the job used for fetching
+  the yaml files needed in workflow editor from the git repository.
+  """
+
+  alias Front.Models.OrganizationSettings
+  alias InternalApi.ServerFarm.Job.JobSpec
+
+  def get_agent(project) do
+    case OrganizationSettings.fetch(project.organization_id) do
+      {:ok, settings} -> decide_on_agent(settings)
+      error -> {:error, :fetch_agent, error}
+    end
+  end
+
+  defp decide_on_agent(%{"custom_machine_type" => type, "custom_os_image" => os_image})
+       when is_binary(type) and type != "" do
+    {:ok, %{type: type, os_image: os_image}}
+  end
+
+  defp decide_on_agent(%{"plan_machine_type" => type, "plan_os_image" => os_image})
+       when is_binary(type) and type != "" do
+    {:ok, %{type: type, os_image: os_image}}
+  end
+
+  defp decide_on_agent(_seetings), do: {:error, :settings_without_agent_def}
+
+  def create_job_spec(agent, params) do
+    {:ok,
+     %JobSpec{
+       job_name: "Workflow editor fetching files * #{params.project.name} * #{params.hook.name}",
+       agent: %JobSpec.Agent{
+         machine: %JobSpec.Agent.Machine{
+           os_image: agent.os_image,
+           type: agent.type
+         },
+         containers: [],
+         image_pull_secrets: []
+       },
+       secrets: [],
+       env_vars: [],
+       files: [],
+       commands: generate_commands(params),
+       epilogue_always_commands: [],
+       epilogue_on_pass_commands: [],
+       epilogue_on_fail_commands: [],
+       priority: 95,
+       execution_time_limit: 10
+     }}
+  end
+
+  defp generate_commands(params) do
+    [
+      "export SEMAPHORE_GIT_DEPTH=5",
+      configure_env_vars_for_checkout(params),
+      "checkout",
+      "artifact push job .semaphore -d .workflow_editor/.semaphore"
+    ]
+    |> List.flatten()
+  end
+
+  defp configure_env_vars_for_checkout(params) do
+    case params.hook.type do
+      "branch" -> set_branch_env_vars(params.hook)
+      "tag" -> set_tag_env_vars(params.hook)
+      "pr" -> set_pr_env_vars(params.hook)
+      :skip -> []
+    end
+  end
+
+  defp set_branch_env_vars(hook) do
+    [
+      "export SEMAPHORE_GIT_REF_TYPE=branch",
+      "export SEMAPHORE_GIT_BRANCH=#{hook.branch_name}",
+      "export SEMAPHORE_GIT_SHA=#{hook.head_commit_sha}"
+    ]
+  end
+
+  defp set_tag_env_vars(hook) do
+    [
+      "export SEMAPHORE_GIT_REF_TYPE=tag",
+      "export SEMAPHORE_GIT_TAG_NAME=#{hook.tag_name}",
+      "export SEMAPHORE_GIT_SHA=#{hook.head_commit_sha}"
+    ]
+  end
+
+  defp set_pr_env_vars(hook) do
+    [
+      "export SEMAPHORE_GIT_REF_TYPE=pull-request",
+      "export SEMAPHORE_GIT_REF=refs/pull/#{hook.pr_number}/merge",
+      "export SEMAPHORE_GIT_SHA=#{hook.head_commit_sha}"
+    ]
+  end
+end

--- a/front/lib/front_web/controllers/project_controller.ex
+++ b/front/lib/front_web/controllers/project_controller.ex
@@ -19,6 +19,7 @@ defmodule FrontWeb.ProjectController do
     Job,
     Artifacthub,
     CommitJob,
+    FetchingJob,
     User
   }
 
@@ -169,6 +170,16 @@ defmodule FrontWeb.ProjectController do
   end
 
   defp render_default_branch(conn) do
+    org_id = conn.assigns.organization_id
+
+    if FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: org_id) do
+      render_default_branch_fetching_job(conn)
+    else
+      render_default_branch_repohub(conn)
+    end
+  end
+
+  defp render_default_branch_repohub(conn) do
     project = conn.assigns.project
     user_id = conn.assigns.user_id
 
@@ -213,14 +224,16 @@ defmodule FrontWeb.ProjectController do
     {initial_yaml, yamls, alert} =
       extract_yamls(yaml_files, project.initial_pipeline_file, org_id)
 
+    workflow_data = %{createdInEditor: false, initialYAML: initial_yaml, yamls: yamls}
+
     params = [
       title: "Edit workflow・#{project.name}・#{organization.name}",
       js: :workflow_editor,
       secrets: secrets,
       project: project,
       commiter_avatar: user.avatar_url,
-      initial_yaml: initial_yaml,
-      yamls: yamls,
+      workflow_data: workflow_data,
+      fetching_job_id: "",
       agent_types: combine_agent_types(hosted_agent_types, self_hosted_agent_types),
       deployment_targets: Enum.map(deployment_targets, & &1.name),
       hide_promotions: Application.get_env(:front, :hide_promotions, false)
@@ -229,6 +242,105 @@ defmodule FrontWeb.ProjectController do
     conn
     |> put_flash(:alert, alert)
     |> render("edit_workflow.html", params)
+  end
+
+  defp render_default_branch_fetching_job(conn) do
+    project = conn.assigns.project
+    user_id = conn.assigns.user_id
+
+    user = Models.User.find(user_id)
+
+    org_id = conn.assigns.organization_id
+
+    fetch_secrets =
+      Async.run(fn -> Secret.list(user.id, org_id, project.id, :ORGANIZATION, true) end,
+        metric: "workflow.edit.fetch_secrets"
+      )
+
+    fetch_deployment_targets =
+      Async.run(fn -> Deployments.fetch_targets(project.id) end,
+        metric: "workflow.edit.fetch_deployment_targets"
+      )
+
+    fetch_organization =
+      Async.run(fn -> Organization.find(org_id) end, metric: "workflow.edit.fetch_organization")
+
+    fetch_agent_types =
+      Async.run(fn -> AgentType.list(org_id) end, metric: "workflow.edit.fetch_agent_types")
+
+    fetch_self_hosted_agent_types =
+      Async.run(fn -> Front.SelfHostedAgents.AgentType.list(org_id) end,
+        metric: "workflow.edit.fetch_self_hosted_agent_types"
+      )
+
+    job_params = [
+      user_id: user.id,
+      project: project,
+      target_branch: "default_branch",
+      restricted_job: true,
+      commit_sha: "",
+      hook: %{
+        name: "default_branch",
+        type: :skip
+      }
+    ]
+
+    start_fetching_job =
+      Async.run(fn -> start_fetching_job(job_params) end, metric: "workflow.edit.start_job")
+
+    {:ok, secrets} = Async.await(fetch_secrets)
+    {:ok, organization} = Async.await(fetch_organization)
+    {:ok, {:ok, hosted_agent_types}} = Async.await(fetch_agent_types)
+    {:ok, {:ok, self_hosted_agent_types}} = Async.await(fetch_self_hosted_agent_types)
+    {:ok, {:ok, deployment_targets}} = Async.await(fetch_deployment_targets)
+    {:ok, {:ok, job_id}} = Async.await(start_fetching_job)
+
+    workflow_data = %{
+      createdInEditor: false,
+      initialYAML: project.initial_pipeline_file,
+      yamls: []
+    }
+
+    params = [
+      title: "Edit workflow・#{project.name}・#{organization.name}",
+      js: :workflow_editor,
+      secrets: secrets,
+      project: project,
+      commiter_avatar: user.avatar_url,
+      workflow_data: workflow_data,
+      fetching_job_id: job_id,
+      agent_types: combine_agent_types(hosted_agent_types, self_hosted_agent_types),
+      deployment_targets: Enum.map(deployment_targets, & &1.name),
+      hide_promotions: Application.get_env(:front, :hide_promotions, false)
+    ]
+
+    conn
+    |> put_flash(:alert, nil)
+    |> render("edit_workflow.html", params)
+  end
+
+  defp start_fetching_job(params) do
+    with {:ok, agent} <- FetchingJob.get_agent(params.project),
+         {:ok, job_spec} <- FetchingJob.create_job_spec(agent, params),
+         {:ok, job} <- Job.create(job_spec, params) do
+      {:ok, job.id}
+    else
+      error ->
+        Logger.error(
+          Enum.join(
+            [
+              "Could not create fetching job",
+              "project: #{params.project.id}",
+              "branch: #{params.target_branch}",
+              "user: #{params.user_id}",
+              "error: #{inspect(error)}"
+            ],
+            ", "
+          )
+        )
+
+        {:error, :fetching_job_creation_failed}
+    end
   end
 
   defp combine_agent_types(hosted_agent_types, self_hosted_agent_types) do
@@ -523,10 +635,10 @@ defmodule FrontWeb.ProjectController do
     find_job(job_id, project)
     |> fetch_yamls_for_job(project.id)
     |> case do
-      {:ok, urls} ->
+      {:ok, urls, finished} ->
         conn
         |> put_status(200)
-        |> json(%{signed_urls: urls})
+        |> json(%{signed_urls: urls, finished: finished})
 
       {:error, e} ->
         Logger.error(
@@ -620,11 +732,25 @@ defmodule FrontWeb.ProjectController do
   end
 
   defp fetch_yamls_for_job({:ok, %{id: job_id, state: "passed"}}, project_id) do
-    Artifacthub.list_and_sign_urls(project_id, "jobs", job_id, @yaml_artifact_directory)
+    case Artifacthub.list_and_sign_urls(project_id, "jobs", job_id, @yaml_artifact_directory) do
+      {:ok, urls} ->
+        updated_urls =
+          Enum.map(urls, fn map ->
+            Map.new(map, fn {path, url} ->
+              new_path = String.replace_prefix(path, ".workflow_editor/", "")
+              {new_path, url}
+            end)
+          end)
+
+        {:ok, updated_urls, true}
+
+      error ->
+        error
+    end
   end
 
   defp fetch_yamls_for_job({:ok, %{state: state}}, _) when state in ["pending", "running"],
-    do: {:ok, []}
+    do: {:ok, [], false}
 
   defp fetch_yamls_for_job({:ok, %{state: state}}, _) when state in ["failed", "stopped"],
     do: {:error, "Job for fetching YAMLs failed"}

--- a/front/lib/front_web/controllers/project_controller.ex
+++ b/front/lib/front_web/controllers/project_controller.ex
@@ -28,6 +28,7 @@ defmodule FrontWeb.ProjectController do
   @public_proj_pages ~w(show workflows queues)a
   @edit_workflows ~w(edit_workflow blocked build_blocked commit_config check_commit_job fetch_yaml_artifacts)a
   @skip_for_page_authorization @org_pages ++ @public_proj_pages
+  @yaml_artifact_directory ".workflow_editor/.semaphore"
 
   plug(FetchPermissions, [scope: "org"] when action in @org_pages)
   plug(PageAccess, [permissions: "organization.view"] when action in @org_pages)
@@ -619,7 +620,7 @@ defmodule FrontWeb.ProjectController do
   end
 
   defp fetch_yamls_for_job({:ok, %{id: job_id, state: "passed"}}, project_id) do
-    Artifacthub.list_and_sign_urls(project_id, "jobs", job_id, ".workflow-editor/.semaphore")
+    Artifacthub.list_and_sign_urls(project_id, "jobs", job_id, @yaml_artifact_directory)
   end
 
   defp fetch_yamls_for_job({:ok, %{state: state}}, _) when state in ["pending", "running"],

--- a/front/lib/front_web/controllers/project_controller.ex
+++ b/front/lib/front_web/controllers/project_controller.ex
@@ -199,7 +199,7 @@ defmodule FrontWeb.ProjectController do
 
     fetch_files_or_create_job =
       if FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: org_id) do
-        job_params = [
+        job_params = %{
           user_id: user.id,
           project: project,
           target_branch: "default_branch",
@@ -209,7 +209,7 @@ defmodule FrontWeb.ProjectController do
             name: "default_branch",
             type: :skip
           }
-        ]
+        }
 
         Async.run(fn -> FetchingJob.start_fetching_job(job_params) end,
           metric: "workflow.edit.start_job"

--- a/front/lib/front_web/controllers/project_controller.ex
+++ b/front/lib/front_web/controllers/project_controller.ex
@@ -652,11 +652,9 @@ defmodule FrontWeb.ProjectController do
     case Artifacthub.list_and_sign_urls(project_id, "jobs", job_id, @yaml_artifact_directory) do
       {:ok, urls} ->
         updated_urls =
-          Enum.map(urls, fn map ->
-            Map.new(map, fn {path, url} ->
-              new_path = String.replace_prefix(path, ".workflow_editor/", "")
-              {new_path, url}
-            end)
+          Enum.reduce(urls, %{}, fn {path, url}, acc ->
+            new_path = String.replace_prefix(path, ".workflow_editor/", "")
+            Map.put(acc, new_path, url)
           end)
 
         {:ok, updated_urls, true}
@@ -667,7 +665,7 @@ defmodule FrontWeb.ProjectController do
   end
 
   defp fetch_yamls_for_job({:ok, %{state: state}}, _) when state in ["pending", "running"],
-    do: {:ok, [], false}
+    do: {:ok, %{}, false}
 
   defp fetch_yamls_for_job({:ok, %{state: state}}, _) when state in ["failed", "stopped"],
     do: {:error, "Job for fetching YAMLs failed"}

--- a/front/lib/front_web/controllers/project_controller.ex
+++ b/front/lib/front_web/controllers/project_controller.ex
@@ -211,7 +211,9 @@ defmodule FrontWeb.ProjectController do
           }
         ]
 
-        Async.run(fn -> FetchingJob.start_fetching_job(job_params) end, metric: "workflow.edit.start_job")
+        Async.run(fn -> FetchingJob.start_fetching_job(job_params) end,
+          metric: "workflow.edit.start_job"
+        )
       else
         Async.run(
           fn -> Repohub.fetch_semaphore_files(project.repo_id, project.initial_pipeline_file) end,
@@ -231,7 +233,10 @@ defmodule FrontWeb.ProjectController do
         {project.initial_pipeline_file, [], job_id, nil}
       else
         {:ok, {:ok, yaml_files}} = Async.await(fetch_files_or_create_job)
-        {initial_yaml, yamls, alert} = extract_yamls(yaml_files, project.initial_pipeline_file, org_id)
+
+        {initial_yaml, yamls, alert} =
+          extract_yamls(yaml_files, project.initial_pipeline_file, org_id)
+
         {initial_yaml, yamls, "", alert}
       end
 

--- a/front/lib/front_web/controllers/project_controller.ex
+++ b/front/lib/front_web/controllers/project_controller.ex
@@ -171,21 +171,10 @@ defmodule FrontWeb.ProjectController do
 
   defp render_default_branch(conn) do
     org_id = conn.assigns.organization_id
-
-    if FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: org_id) do
-      render_default_branch_fetching_job(conn)
-    else
-      render_default_branch_repohub(conn)
-    end
-  end
-
-  defp render_default_branch_repohub(conn) do
     project = conn.assigns.project
     user_id = conn.assigns.user_id
 
     user = Models.User.find(user_id)
-
-    org_id = conn.assigns.organization_id
 
     fetch_secrets =
       Async.run(fn -> Secret.list(user.id, org_id, project.id, :ORGANIZATION, true) end,
@@ -208,98 +197,45 @@ defmodule FrontWeb.ProjectController do
         metric: "workflow.edit.fetch_self_hosted_agent_types"
       )
 
-    fetch_yaml_files =
-      Async.run(
-        fn -> Repohub.fetch_semaphore_files(project.repo_id, project.initial_pipeline_file) end,
-        metric: "workflow.edit.load_all_yaml_files"
-      )
+    fetch_files_or_create_job =
+      if FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: org_id) do
+        job_params = [
+          user_id: user.id,
+          project: project,
+          target_branch: "default_branch",
+          restricted_job: true,
+          commit_sha: "",
+          hook: %{
+            name: "default_branch",
+            type: :skip
+          }
+        ]
+
+        Async.run(fn -> FetchingJob.start_fetching_job(job_params) end, metric: "workflow.edit.start_job")
+      else
+        Async.run(
+          fn -> Repohub.fetch_semaphore_files(project.repo_id, project.initial_pipeline_file) end,
+          metric: "workflow.edit.load_all_yaml_files"
+        )
+      end
 
     {:ok, secrets} = Async.await(fetch_secrets)
     {:ok, organization} = Async.await(fetch_organization)
     {:ok, {:ok, hosted_agent_types}} = Async.await(fetch_agent_types)
     {:ok, {:ok, self_hosted_agent_types}} = Async.await(fetch_self_hosted_agent_types)
-    {:ok, {:ok, yaml_files}} = Async.await(fetch_yaml_files)
     {:ok, {:ok, deployment_targets}} = Async.await(fetch_deployment_targets)
 
-    {initial_yaml, yamls, alert} =
-      extract_yamls(yaml_files, project.initial_pipeline_file, org_id)
+    {initial_yaml, yamls, job_id, alert} =
+      if FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: org_id) do
+        {:ok, {:ok, job_id}} = Async.await(fetch_files_or_create_job)
+        {project.initial_pipeline_file, [], job_id, nil}
+      else
+        {:ok, {:ok, yaml_files}} = Async.await(fetch_files_or_create_job)
+        {initial_yaml, yamls, alert} = extract_yamls(yaml_files, project.initial_pipeline_file, org_id)
+        {initial_yaml, yamls, "", alert}
+      end
 
     workflow_data = %{createdInEditor: false, initialYAML: initial_yaml, yamls: yamls}
-
-    params = [
-      title: "Edit workflow・#{project.name}・#{organization.name}",
-      js: :workflow_editor,
-      secrets: secrets,
-      project: project,
-      commiter_avatar: user.avatar_url,
-      workflow_data: workflow_data,
-      fetching_job_id: "",
-      agent_types: combine_agent_types(hosted_agent_types, self_hosted_agent_types),
-      deployment_targets: Enum.map(deployment_targets, & &1.name),
-      hide_promotions: Application.get_env(:front, :hide_promotions, false)
-    ]
-
-    conn
-    |> put_flash(:alert, alert)
-    |> render("edit_workflow.html", params)
-  end
-
-  defp render_default_branch_fetching_job(conn) do
-    project = conn.assigns.project
-    user_id = conn.assigns.user_id
-
-    user = Models.User.find(user_id)
-
-    org_id = conn.assigns.organization_id
-
-    fetch_secrets =
-      Async.run(fn -> Secret.list(user.id, org_id, project.id, :ORGANIZATION, true) end,
-        metric: "workflow.edit.fetch_secrets"
-      )
-
-    fetch_deployment_targets =
-      Async.run(fn -> Deployments.fetch_targets(project.id) end,
-        metric: "workflow.edit.fetch_deployment_targets"
-      )
-
-    fetch_organization =
-      Async.run(fn -> Organization.find(org_id) end, metric: "workflow.edit.fetch_organization")
-
-    fetch_agent_types =
-      Async.run(fn -> AgentType.list(org_id) end, metric: "workflow.edit.fetch_agent_types")
-
-    fetch_self_hosted_agent_types =
-      Async.run(fn -> Front.SelfHostedAgents.AgentType.list(org_id) end,
-        metric: "workflow.edit.fetch_self_hosted_agent_types"
-      )
-
-    job_params = [
-      user_id: user.id,
-      project: project,
-      target_branch: "default_branch",
-      restricted_job: true,
-      commit_sha: "",
-      hook: %{
-        name: "default_branch",
-        type: :skip
-      }
-    ]
-
-    start_fetching_job =
-      Async.run(fn -> start_fetching_job(job_params) end, metric: "workflow.edit.start_job")
-
-    {:ok, secrets} = Async.await(fetch_secrets)
-    {:ok, organization} = Async.await(fetch_organization)
-    {:ok, {:ok, hosted_agent_types}} = Async.await(fetch_agent_types)
-    {:ok, {:ok, self_hosted_agent_types}} = Async.await(fetch_self_hosted_agent_types)
-    {:ok, {:ok, deployment_targets}} = Async.await(fetch_deployment_targets)
-    {:ok, {:ok, job_id}} = Async.await(start_fetching_job)
-
-    workflow_data = %{
-      createdInEditor: false,
-      initialYAML: project.initial_pipeline_file,
-      yamls: []
-    }
 
     params = [
       title: "Edit workflow・#{project.name}・#{organization.name}",
@@ -315,32 +251,8 @@ defmodule FrontWeb.ProjectController do
     ]
 
     conn
-    |> put_flash(:alert, nil)
+    |> put_flash(:alert, alert)
     |> render("edit_workflow.html", params)
-  end
-
-  defp start_fetching_job(params) do
-    with {:ok, agent} <- FetchingJob.get_agent(params.project),
-         {:ok, job_spec} <- FetchingJob.create_job_spec(agent, params),
-         {:ok, job} <- Job.create(job_spec, params) do
-      {:ok, job.id}
-    else
-      error ->
-        Logger.error(
-          Enum.join(
-            [
-              "Could not create fetching job",
-              "project: #{params.project.id}",
-              "branch: #{params.target_branch}",
-              "user: #{params.user_id}",
-              "error: #{inspect(error)}"
-            ],
-            ", "
-          )
-        )
-
-        {:error, :fetching_job_creation_failed}
-    end
   end
 
   defp combine_agent_types(hosted_agent_types, self_hosted_agent_types) do

--- a/front/lib/front_web/controllers/workflow_controller.ex
+++ b/front/lib/front_web/controllers/workflow_controller.ex
@@ -14,7 +14,9 @@ defmodule FrontWeb.WorkflowController do
     Repohub,
     RepoProxy,
     Secret,
-    User
+    User,
+    FetchingJob,
+    Job
   }
 
   alias Front.Async
@@ -40,80 +42,199 @@ defmodule FrontWeb.WorkflowController do
 
   def edit(conn, _params) do
     Watchman.benchmark("workflow.edit.duration", fn ->
-      project = conn.assigns.project
-      user = User.find(conn.assigns.user_id)
-
       org_id = conn.assigns.organization_id
-      hook_id = conn.assigns.workflow.hook_id
 
-      fetch_org_secrets =
-        Async.run(fn -> Secret.list(user.id, org_id, project.id, :ORGANIZATION, true) end,
-          metric: "workflow.edit.fetch_secrets"
-        )
-
-      fetch_project_secrets =
-        Async.run(fn -> Secret.list(user.id, org_id, project.id, :PROJECT, true) end,
-          metric: "workflow.edit.fetch_project_secrets"
-        )
-
-      fetch_deployment_targets =
-        Async.run(fn -> Deployments.fetch_targets(project.id) end,
-          metric: "workflow.edit.fetch_deployment_targets"
-        )
-
-      fetch_organization =
-        Async.run(fn -> Organization.find(org_id) end, metric: "workflow.edit.fetch_organization")
-
-      fetch_hook =
-        Async.run(fn -> RepoProxy.find(hook_id) end, metric: "workflow.edit.fetch_hook")
-
-      fetch_agent_types =
-        Async.run(fn -> AgentType.list(org_id) end, metric: "workflow.edit.fetch_agent_types")
-
-      fetch_self_hosted_agent_types =
-        Async.run(fn -> Front.SelfHostedAgents.AgentType.list(org_id) end,
-          metric: "workflow.edit.fetch_self_hosted_agent_types"
-        )
-
-      {:ok, hook} = Async.await(fetch_hook)
-
-      fetch_yaml_files =
-        Async.run(
-          fn -> fetch_yaml_files(project.repo_id, hook, project.initial_pipeline_file) end,
-          metric: "workflow.edit.load_all_yaml_files"
-        )
-
-      {:ok, org_secrets} = Async.await(fetch_org_secrets)
-      {:ok, project_secrets} = Async.await(fetch_project_secrets)
-      {:ok, organization} = Async.await(fetch_organization)
-      {:ok, {:ok, hosted_agent_types}} = Async.await(fetch_agent_types)
-      {:ok, {:ok, self_hosted_agent_types}} = Async.await(fetch_self_hosted_agent_types)
-      {:ok, {:ok, yaml_files}} = Async.await(fetch_yaml_files)
-      {:ok, {:ok, deployment_targets}} = Async.await(fetch_deployment_targets)
-
-      {initial_yaml, yamls, alert} =
-        extract_yamls(yaml_files, project.initial_pipeline_file, org_id)
-
-      params = [
-        title: "Edit workflow・#{hook.name}・#{project.name}・#{organization.name}",
-        js: :workflow_editor,
-        org_secrets: org_secrets,
-        project_secrets: project_secrets,
-        project: project,
-        hook: hook,
-        sidebar_selected_item: project.id,
-        commiter_avatar: user.avatar_url,
-        initial_yaml: initial_yaml,
-        yamls: yamls,
-        agent_types: combine_agent_types(hosted_agent_types, self_hosted_agent_types),
-        deployment_targets: Enum.map(deployment_targets, & &1.name),
-        hide_promotions: Application.get_env(:front, :hide_promotions, false)
-      ]
-
-      conn
-      |> put_flash(:alert, alert)
-      |> render("edit.html", params)
+      if FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: org_id) do
+        edit_using_fetching_job(conn)
+      else
+        edit_using_repohub(conn)
+      end
     end)
+  end
+
+  defp edit_using_fetching_job(conn) do
+    project = conn.assigns.project
+    user = User.find(conn.assigns.user_id)
+
+    org_id = conn.assigns.organization_id
+    hook_id = conn.assigns.workflow.hook_id
+
+    fetch_org_secrets =
+      Async.run(fn -> Secret.list(user.id, org_id, project.id, :ORGANIZATION, true) end,
+        metric: "workflow.edit.fetch_secrets"
+      )
+
+    fetch_project_secrets =
+      Async.run(fn -> Secret.list(user.id, org_id, project.id, :PROJECT, true) end,
+        metric: "workflow.edit.fetch_project_secrets"
+      )
+
+    fetch_deployment_targets =
+      Async.run(fn -> Deployments.fetch_targets(project.id) end,
+        metric: "workflow.edit.fetch_deployment_targets"
+      )
+
+    fetch_organization =
+      Async.run(fn -> Organization.find(org_id) end, metric: "workflow.edit.fetch_organization")
+
+    fetch_hook = Async.run(fn -> RepoProxy.find(hook_id) end, metric: "workflow.edit.fetch_hook")
+
+    fetch_agent_types =
+      Async.run(fn -> AgentType.list(org_id) end, metric: "workflow.edit.fetch_agent_types")
+
+    fetch_self_hosted_agent_types =
+      Async.run(fn -> Front.SelfHostedAgents.AgentType.list(org_id) end,
+        metric: "workflow.edit.fetch_self_hosted_agent_types"
+      )
+
+    {:ok, hook} = Async.await(fetch_hook)
+
+    job_params = [
+      user_id: user.id,
+      project: project,
+      target_branch: hook.branch_name,
+      restricted_job: true,
+      commit_sha: hook.head_commit_sha,
+      hook: hook
+    ]
+
+    start_fetching_job =
+      Async.run(fn -> start_fetching_job(job_params) end, metric: "workflow.edit.start_job")
+
+    {:ok, org_secrets} = Async.await(fetch_org_secrets)
+    {:ok, project_secrets} = Async.await(fetch_project_secrets)
+    {:ok, organization} = Async.await(fetch_organization)
+    {:ok, {:ok, hosted_agent_types}} = Async.await(fetch_agent_types)
+    {:ok, {:ok, self_hosted_agent_types}} = Async.await(fetch_self_hosted_agent_types)
+    {:ok, {:ok, deployment_targets}} = Async.await(fetch_deployment_targets)
+    {:ok, {:ok, job_id}} = Async.await(start_fetching_job)
+
+    workflow_data = %{
+      createdInEditor: false,
+      initialYAML: project.initial_pipeline_file,
+      yamls: []
+    }
+
+    params = [
+      title: "Edit workflow・#{hook.name}・#{project.name}・#{organization.name}",
+      js: :workflow_editor,
+      org_secrets: org_secrets,
+      project_secrets: project_secrets,
+      project: project,
+      hook: hook,
+      sidebar_selected_item: project.id,
+      commiter_avatar: user.avatar_url,
+      workflow_data: workflow_data,
+      fetching_job_id: job_id,
+      agent_types: combine_agent_types(hosted_agent_types, self_hosted_agent_types),
+      deployment_targets: Enum.map(deployment_targets, & &1.name),
+      hide_promotions: Application.get_env(:front, :hide_promotions, false)
+    ]
+
+    conn
+    |> put_flash(:alert, nil)
+    |> render("edit.html", params)
+  end
+
+  defp start_fetching_job(params) do
+    with {:ok, agent} <- FetchingJob.get_agent(params.project),
+         {:ok, job_spec} <- FetchingJob.create_job_spec(agent, params),
+         {:ok, job} <- Job.create(job_spec, params) do
+      {:ok, job.id}
+    else
+      error ->
+        Logger.error(
+          Enum.join(
+            [
+              "Could not create fetching job",
+              "project: #{params.project.id}",
+              "branch: #{params.target_branch}",
+              "user: #{params.user_id}",
+              "error: #{inspect(error)}"
+            ],
+            ", "
+          )
+        )
+
+        {:error, :fetching_job_creation_failed}
+    end
+  end
+
+  defp edit_using_repohub(conn) do
+    project = conn.assigns.project
+    user = User.find(conn.assigns.user_id)
+
+    org_id = conn.assigns.organization_id
+    hook_id = conn.assigns.workflow.hook_id
+
+    fetch_org_secrets =
+      Async.run(fn -> Secret.list(user.id, org_id, project.id, :ORGANIZATION, true) end,
+        metric: "workflow.edit.fetch_secrets"
+      )
+
+    fetch_project_secrets =
+      Async.run(fn -> Secret.list(user.id, org_id, project.id, :PROJECT, true) end,
+        metric: "workflow.edit.fetch_project_secrets"
+      )
+
+    fetch_deployment_targets =
+      Async.run(fn -> Deployments.fetch_targets(project.id) end,
+        metric: "workflow.edit.fetch_deployment_targets"
+      )
+
+    fetch_organization =
+      Async.run(fn -> Organization.find(org_id) end, metric: "workflow.edit.fetch_organization")
+
+    fetch_hook = Async.run(fn -> RepoProxy.find(hook_id) end, metric: "workflow.edit.fetch_hook")
+
+    fetch_agent_types =
+      Async.run(fn -> AgentType.list(org_id) end, metric: "workflow.edit.fetch_agent_types")
+
+    fetch_self_hosted_agent_types =
+      Async.run(fn -> Front.SelfHostedAgents.AgentType.list(org_id) end,
+        metric: "workflow.edit.fetch_self_hosted_agent_types"
+      )
+
+    {:ok, hook} = Async.await(fetch_hook)
+
+    fetch_yaml_files =
+      Async.run(
+        fn -> fetch_yaml_files(project.repo_id, hook, project.initial_pipeline_file) end,
+        metric: "workflow.edit.load_all_yaml_files"
+      )
+
+    {:ok, org_secrets} = Async.await(fetch_org_secrets)
+    {:ok, project_secrets} = Async.await(fetch_project_secrets)
+    {:ok, organization} = Async.await(fetch_organization)
+    {:ok, {:ok, hosted_agent_types}} = Async.await(fetch_agent_types)
+    {:ok, {:ok, self_hosted_agent_types}} = Async.await(fetch_self_hosted_agent_types)
+    {:ok, {:ok, yaml_files}} = Async.await(fetch_yaml_files)
+    {:ok, {:ok, deployment_targets}} = Async.await(fetch_deployment_targets)
+
+    {initial_yaml, yamls, alert} =
+      extract_yamls(yaml_files, project.initial_pipeline_file, org_id)
+
+    workflow_data = %{createdInEditor: false, initialYAML: initial_yaml, yamls: yamls}
+
+    params = [
+      title: "Edit workflow・#{hook.name}・#{project.name}・#{organization.name}",
+      js: :workflow_editor,
+      org_secrets: org_secrets,
+      project_secrets: project_secrets,
+      project: project,
+      hook: hook,
+      sidebar_selected_item: project.id,
+      commiter_avatar: user.avatar_url,
+      workflow_data: workflow_data,
+      fetching_job_id: "",
+      agent_types: combine_agent_types(hosted_agent_types, self_hosted_agent_types),
+      deployment_targets: Enum.map(deployment_targets, & &1.name),
+      hide_promotions: Application.get_env(:front, :hide_promotions, false)
+    ]
+
+    conn
+    |> put_flash(:alert, alert)
+    |> render("edit.html", params)
   end
 
   defp fetch_yaml_files(repo_id, hook, initial_yaml) do
@@ -138,7 +259,7 @@ defmodule FrontWeb.WorkflowController do
         Repohub.fetch_semaphore_files(
           repo_id,
           initial_yaml,
-          hook.pr_sha,
+          hook.head_commit_sha,
           "refs/heads/#{hook.branch_name}"
         )
 
@@ -146,7 +267,7 @@ defmodule FrontWeb.WorkflowController do
         Repohub.fetch_semaphore_files(
           repo_id,
           initial_yaml,
-          hook.pr_sha,
+          hook.head_commit_sha,
           "refs/tags/#{hook.tag_name}"
         )
     end

--- a/front/lib/front_web/controllers/workflow_controller.ex
+++ b/front/lib/front_web/controllers/workflow_controller.ex
@@ -65,7 +65,8 @@ defmodule FrontWeb.WorkflowController do
       fetch_organization =
         Async.run(fn -> Organization.find(org_id) end, metric: "workflow.edit.fetch_organization")
 
-      fetch_hook = Async.run(fn -> RepoProxy.find(hook_id) end, metric: "workflow.edit.fetch_hook")
+      fetch_hook =
+        Async.run(fn -> RepoProxy.find(hook_id) end, metric: "workflow.edit.fetch_hook")
 
       fetch_agent_types =
         Async.run(fn -> AgentType.list(org_id) end, metric: "workflow.edit.fetch_agent_types")
@@ -88,7 +89,9 @@ defmodule FrontWeb.WorkflowController do
             hook: hook
           ]
 
-          Async.run(fn -> FetchingJob.start_fetching_job(job_params) end, metric: "workflow.edit.start_job")
+          Async.run(fn -> FetchingJob.start_fetching_job(job_params) end,
+            metric: "workflow.edit.start_job"
+          )
         else
           Async.run(
             fn -> fetch_yaml_files(project.repo_id, hook, project.initial_pipeline_file) end,
@@ -109,7 +112,10 @@ defmodule FrontWeb.WorkflowController do
           {project.initial_pipeline_file, [], job_id, nil}
         else
           {:ok, {:ok, yaml_files}} = Async.await(fetch_files_or_create_job)
-          {initial_yaml, yamls, alert} = extract_yamls(yaml_files, project.initial_pipeline_file, org_id)
+
+          {initial_yaml, yamls, alert} =
+            extract_yamls(yaml_files, project.initial_pipeline_file, org_id)
+
           {initial_yaml, yamls, "", alert}
         end
 

--- a/front/lib/front_web/controllers/workflow_controller.ex
+++ b/front/lib/front_web/controllers/workflow_controller.ex
@@ -80,14 +80,14 @@ defmodule FrontWeb.WorkflowController do
 
       fetch_files_or_create_job =
         if FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: org_id) do
-          job_params = [
+          job_params = %{
             user_id: user.id,
             project: project,
             target_branch: hook.branch_name,
             restricted_job: true,
             commit_sha: hook.head_commit_sha,
             hook: hook
-          ]
+          }
 
           Async.run(fn -> FetchingJob.start_fetching_job(job_params) end,
             metric: "workflow.edit.start_job"

--- a/front/lib/front_web/router.ex
+++ b/front/lib/front_web/router.ex
@@ -294,6 +294,7 @@ defmodule FrontWeb.Router do
     post("/projects/:name_or_id/commit_config", ProjectController, :commit_config)
 
     get("/projects/:name_or_id/check_commit_job", ProjectController, :check_commit_job)
+    get("/projects/:name_or_id/fetch_yaml_artifacts", ProjectController, :fetch_yaml_artifacts)
 
     # Project Onboarding
 

--- a/front/lib/front_web/templates/project/edit_workflow.html.eex
+++ b/front/lib/front_web/templates/project/edit_workflow.html.eex
@@ -26,7 +26,8 @@
     "isOS" => Front.os?(),
     "deploymentTargets" => FeatureProvider.feature_enabled?(:deployment_targets, param: @conn.assigns.organization_id),
     "uiMonacoWorkflowCodeEditor" => FeatureProvider.feature_enabled?(:ui_monaco_workflow_code_editor, param: @conn.assigns.organization_id),
-    "useCommitJob" => FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: @conn.assigns.organization_id)
+    "useCommitJob" => FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: @conn.assigns.organization_id),
+    "useFetchingJob" => FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: @conn.assigns.organization_id)
   }) %>;
 
   window.InjectedDataByBackend.SecretNameList = <%= raw Poison.encode!(
@@ -38,11 +39,11 @@
 
   window.InjectedDataByBackend.AgentTypes = <%= raw Poison.encode!(@agent_types) %>;
 
-  window.InjectedDataByBackend.WorkflowData = {
-    createdInEditor: false,
-    initialYAML: <%= raw Poison.encode!(@project.initial_pipeline_file, escape: :html_safe) %>,
-    yamls: <%= raw Poison.encode!(@yamls, escape: :html_safe) %>
-  };
+  window.InjectedDataByBackend.WorkflowData = <%= raw Poison.encode!(@workflow_data, escape: :html_safe) %>;
+
+  window.InjectedDataByBackend.CheckFetchingJobPath = <%= project_path(@conn, :fetch_yaml_artifacts, @project.name) %>;
+
+  window.InjectedDataByBackend.FetchingJobId = <%= @fetching_job_id %>;
 
   window.InjectedDataByBackend.CommitForm = <%= raw Poison.encode!(%{
     "CommitPath" => project_path(@conn, :commit_config, @project.name),

--- a/front/lib/front_web/templates/project/edit_workflow.html.eex
+++ b/front/lib/front_web/templates/project/edit_workflow.html.eex
@@ -41,9 +41,9 @@
 
   window.InjectedDataByBackend.WorkflowData = <%= raw Poison.encode!(@workflow_data, escape: :html_safe) %>;
 
-  window.InjectedDataByBackend.CheckFetchingJobPath = <%= project_path(@conn, :fetch_yaml_artifacts, @project.name) %>;
+  window.InjectedDataByBackend.CheckFetchingJobPath = "<%= project_path(@conn, :fetch_yaml_artifacts, @project.name) %>";
 
-  window.InjectedDataByBackend.FetchingJobId = <%= @fetching_job_id %>;
+  window.InjectedDataByBackend.FetchingJobId = "<%= @fetching_job_id %>";
 
   window.InjectedDataByBackend.CommitForm = <%= raw Poison.encode!(%{
     "CommitPath" => project_path(@conn, :commit_config, @project.name),

--- a/front/lib/front_web/templates/workflow/edit.html.eex
+++ b/front/lib/front_web/templates/workflow/edit.html.eex
@@ -12,7 +12,8 @@
     "isOS" => Front.os?(),
     "deploymentTargets" => FeatureProvider.feature_enabled?(:deployment_targets, param: @conn.assigns.organization_id),
     "uiMonacoWorkflowCodeEditor" => FeatureProvider.feature_enabled?(:ui_monaco_workflow_code_editor, param: @conn.assigns.organization_id),
-    "useCommitJob" => FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: @conn.assigns.organization_id)
+    "useCommitJob" => FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: @conn.assigns.organization_id),
+    "useFetchingJob" => FeatureProvider.feature_enabled?(:wf_editor_via_jobs, param: @conn.assigns.organization_id)
   }) %>;
 
   window.InjectedDataByBackend.OrgSecretNameList = <%= raw Poison.encode!(
@@ -28,11 +29,11 @@
 
   window.InjectedDataByBackend.AgentTypes = <%= raw Poison.encode!(@agent_types) %>;
 
-  window.InjectedDataByBackend.WorkflowData = {
-    createdInEditor: false,
-    initialYAML: <%= raw Poison.encode!(@initial_yaml, escape: :html_safe) %>,
-    yamls: <%= raw Poison.encode!(@yamls, escape: :html_safe) %>
-  };
+  window.InjectedDataByBackend.WorkflowData = <%= raw Poison.encode!(@workflow_data, escape: :html_safe) %>;
+
+  window.InjectedDataByBackend.CheckFetchingJobPath = <%= project_path(@conn, :fetch_yaml_artifacts, @project.name) %>;
+
+  window.InjectedDataByBackend.FetchingJobId = <%= @fetching_job_id %>;
 
   window.InjectedDataByBackend.CommitForm = <%= raw Poison.encode!(%{
     "CommitPath" => project_path(@conn, :commit_config, @project.name),

--- a/front/lib/front_web/templates/workflow/edit.html.eex
+++ b/front/lib/front_web/templates/workflow/edit.html.eex
@@ -31,9 +31,9 @@
 
   window.InjectedDataByBackend.WorkflowData = <%= raw Poison.encode!(@workflow_data, escape: :html_safe) %>;
 
-  window.InjectedDataByBackend.CheckFetchingJobPath = <%= project_path(@conn, :fetch_yaml_artifacts, @project.name) %>;
+  window.InjectedDataByBackend.CheckFetchingJobPath = "<%= project_path(@conn, :fetch_yaml_artifacts, @project.name) %>";
 
-  window.InjectedDataByBackend.FetchingJobId = <%= @fetching_job_id %>;
+  window.InjectedDataByBackend.FetchingJobId = "<%= @fetching_job_id %>";
 
   window.InjectedDataByBackend.CommitForm = <%= raw Poison.encode!(%{
     "CommitPath" => project_path(@conn, :commit_config, @project.name),

--- a/front/lib/front_web/templates/workflow/edit/frame.html.eex
+++ b/front/lib/front_web/templates/workflow/edit/frame.html.eex
@@ -1,7 +1,7 @@
 <div id="workflow-editor-tabs" class="pv2">
 </div>
 
-<div class="nb4">
+<div class="nb4" id="workflow-editor-container">
   <div id="workflow-editor-visual-editor" class="bg-white relative bt b--lighter-gray nh4">
     <div class="flex">
       <div class="flex-auto">
@@ -23,5 +23,21 @@
   </div>
 
   <div id="workflow-editor-code-editor" class="code-mirror-style-semaphore bg-white f5 lh-title bg-white relative mt3 mt4-m <%= code_editor_border_classes(@org_id) %>">
+  </div>
+</div>
+
+<div id="zero-state-loading-message" class="bg-white relative" style="display: none;">
+  <div class="pa5-m">
+    <div class="mw6 center shadow-1-m pa4-m">
+      <div class="flex items-start justify-between mb3">
+        <div>
+          <h1 id="zero-state-title" class="f3 mb4">Searching git repository for .yml files
+            <img class="ml2" width="18" height="18" src="<%= assets_path() %>/images/spinner-2.svg">
+          </h1>
+          <p id="zero-state-paragraph-one" class="pr4 mb1 measure"> We are searching your git repository for Seamphore pipeline .yml files.</p>
+          <p id="zero-state-paragraph-two" class="pr4 mb0 measure"> This can take up to a few minutes for repositories that are large or have a lot of commits.</p>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/front/lib/internal_api/artifacthub.pb.ex
+++ b/front/lib/internal_api/artifacthub.pb.ex
@@ -175,12 +175,14 @@ defmodule InternalApi.Artifacthub.ListPathRequest do
 
   @type t :: %__MODULE__{
           artifact_id: String.t(),
-          path: String.t()
+          path: String.t(),
+          unwrap_directories: boolean
         }
-  defstruct [:artifact_id, :path]
+  defstruct [:artifact_id, :path, :unwrap_directories]
 
   field(:artifact_id, 1, type: :string)
   field(:path, 2, type: :string)
+  field(:unwrap_directories, 3, type: :bool)
 end
 
 defmodule InternalApi.Artifacthub.ListPathResponse do

--- a/front/test/front_web/controllers/project_controller_test.exs
+++ b/front/test/front_web/controllers/project_controller_test.exs
@@ -400,16 +400,12 @@ defmodule FrontWeb.ProjectControllerTest do
 
       assert response = json_response(conn, 200)
 
-      assert response["signed_urls"] == [
-               %{
-                 ".semaphore/semaphore.yml" =>
-                   "https://localhost:9000/.workflow_editor/.semaphore/semaphore.yml"
-               },
-               %{
-                 ".semaphore/release.yml" =>
-                   "https://localhost:9000/.workflow_editor/.semaphore/release.yml"
-               }
-             ]
+      assert response["signed_urls"] == %{
+               ".semaphore/semaphore.yml" =>
+                 "https://localhost:9000/.workflow_editor/.semaphore/semaphore.yml",
+               ".semaphore/release.yml" =>
+                 "https://localhost:9000/.workflow_editor/.semaphore/release.yml"
+             }
 
       assert response["finished"] == true
     end
@@ -449,7 +445,7 @@ defmodule FrontWeb.ProjectControllerTest do
       assert response["error"] == message
     end
 
-    test "if job is still running, return empty list of signed URLs and set finished to false",
+    test "if job is still running, return empty map of signed URLs and set finished to false",
          %{conn: conn, project: project, organization: organization, user: user} do
       Support.Stubs.PermissionPatrol.allow_everything(organization.id, user.id)
 
@@ -461,7 +457,7 @@ defmodule FrontWeb.ProjectControllerTest do
         |> get("/projects/#{project.name}/fetch_yaml_artifacts?job_id=#{job.id}")
 
       assert response = json_response(conn, 200)
-      assert response["signed_urls"] == []
+      assert response["signed_urls"] == %{}
       assert response["finished"] == false
     end
   end

--- a/front/test/front_web/controllers/project_controller_test.exs
+++ b/front/test/front_web/controllers/project_controller_test.exs
@@ -338,9 +338,17 @@ defmodule FrontWeb.ProjectControllerTest do
       assert response = json_response(conn, 200)
 
       assert response["signed_urls"] == [
-               "https://localhost:9000/.workflow_editor/.semaphore/semaphore.yml",
-               "https://localhost:9000/.workflow_editor/.semaphore/release.yml"
+               %{
+                 ".semaphore/semaphore.yml" =>
+                   "https://localhost:9000/.workflow_editor/.semaphore/semaphore.yml"
+               },
+               %{
+                 ".semaphore/release.yml" =>
+                   "https://localhost:9000/.workflow_editor/.semaphore/release.yml"
+               }
              ]
+
+      assert response["finished"] == true
     end
 
     test "returns error if job can not be found",
@@ -378,7 +386,7 @@ defmodule FrontWeb.ProjectControllerTest do
       assert response["error"] == message
     end
 
-    test "if job is still running, return empty list of signed URLs",
+    test "if job is still running, return empty list of signed URLs and set finished to false",
          %{conn: conn, project: project, organization: organization, user: user} do
       Support.Stubs.PermissionPatrol.allow_everything(organization.id, user.id)
 
@@ -391,6 +399,7 @@ defmodule FrontWeb.ProjectControllerTest do
 
       assert response = json_response(conn, 200)
       assert response["signed_urls"] == []
+      assert response["finished"] == false
     end
   end
 


### PR DESCRIPTION
## 📝 Description

The workflow editor currently fetches yaml files in a synchronous call before the page is rendered, which is very unstable for large repositories and can lead to 500 errors.
This PR changes this behavior so the workflow editor starts with a zero state screen with the spinner, and the job is started in the background to fetch yaml files asynchronously. 
Once the files are fetched successfully, the workflow editor is fully rendered with visual and text editor components.
This behavior will remain behind a feature flag until we verify that it works as expected at scale.

**Note for reviewers**: 

I had to slightly increase the limit for linting the code duplication since we currently have two very similar endpoints for the workflow editor in project_controller and workflow_controller. 
An ideal solution would be to remove the endpoint in project_controller and consolidate everything in workflow_controller, but that would require significant additional work that could also impact the stability of the old implementation.

## ✅ Checklist
- [x] I have tested this change
- ~[x] This change requires a documentation update~ -N/A
