### PR TITLE
fix(ci): pin versions of Go tools and scan only Dockerfile misconfigurations

### DIFF
--- a/.semaphore/daily-builds.yml
+++ b/.semaphore/daily-builds.yml
@@ -512,6 +512,7 @@ blocks:
             - make check.ex.deps
         - name: "\U0001F6E1️ Check docker"
           commands:
+            - make build
             - make check.docker
   - name: "Dashboardhub: \U0001F9EA QA"
     dependencies: ["Dashboardhub: \U0001F4CB Provision Test Image"]
@@ -3096,6 +3097,7 @@ blocks:
             - make check.js.deps
         - name: "\U0001F6E1️ Check docker"
           commands:
+            - make build
             - make check.docker CHECK_DOCKER_OPTS='--skip-dirs node_modules'
   # Velocity
   - name: "Velocity: \U0001F4CB Provision Prod Image"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -557,6 +557,7 @@ blocks:
             - make check.ex.deps
         - name: "\U0001F6E1️ Check docker"
           commands:
+            - make build
             - make check.docker
   - name: "Dashboardhub: \U0001F9EA QA"
     dependencies: ["Dashboardhub: \U0001F4CB Provision Test Image"]
@@ -3398,6 +3399,7 @@ blocks:
             - make check.js.deps
         - name: "\U0001F6E1️ Check docker"
           commands:
+            - make build
             - make check.docker CHECK_DOCKER_OPTS='--skip-dirs node_modules'
   # Velocity
   - name: "Velocity: \U0001F4CB Provision Prod Image"

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ ifeq ($(CI),)
 		-v $(ROOT_MAKEFILE_PATH)/security-toolbox:$(SECURITY_TOOLBOX_TMP_DIR) \
 		-v $(XDG_RUNTIME_DIR)/docker.sock:/var/run/docker.sock \
 		registry.semaphoreci.com/ruby:3 \
-		bash -c '$(SECURITY_TOOLBOX_TMP_DIR)/docker -d --image $(IMAGE):$(IMAGE_TAG) $(CHECK_DOCKER_OPTS)'
+		bash -c '$(SECURITY_TOOLBOX_TMP_DIR)/docker -d --image $(IMAGE):$(IMAGE_TAG) -s CRITICAL $(CHECK_DOCKER_OPTS)'
 else
 	# ruby version is set in prologue
 	$(ROOT_MAKEFILE_PATH)/security-toolbox/docker -d --image $(IMAGE):$(IMAGE_TAG) -s CRITICAL $(CHECK_DOCKER_OPTS)

--- a/artifacthub/Dockerfile
+++ b/artifacthub/Dockerfile
@@ -36,8 +36,8 @@ RUN curl -sL https://github.com/google/protobuf/releases/download/v3.20.0/protoc
   mv bin/protoc /usr/local/bin/protoc
 
 WORKDIR /app
-RUN go install github.com/mgechev/revive@latest
-RUN go install gotest.tools/gotestsum@latest
+RUN go install github.com/mgechev/revive@v1.7.0
+RUN go install gotest.tools/gotestsum@v1.12.1
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 

--- a/bootstrapper/Dockerfile
+++ b/bootstrapper/Dockerfile
@@ -29,8 +29,8 @@ RUN curl -sL https://github.com/google/protobuf/releases/download/v28.0/protoc-2
   mv bin/protoc /usr/local/bin/protoc
 
 WORKDIR /app
-RUN go install github.com/mgechev/revive@latest
-RUN go install gotest.tools/gotestsum@latest
+RUN go install github.com/mgechev/revive@v1.7.0
+RUN go install gotest.tools/gotestsum@v1.12.1
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 RUN export PATH="$PATH:$(go env GOPATH)/bin"

--- a/ee/velocity/Dockerfile
+++ b/ee/velocity/Dockerfile
@@ -38,8 +38,8 @@ RUN curl -sL https://github.com/google/protobuf/releases/download/v3.3.0/protoc-
   mv bin/protoc /usr/local/bin/protoc
 
 WORKDIR /app
-RUN go install github.com/mgechev/revive@latest
-RUN go install gotest.tools/gotestsum@latest
+RUN go install github.com/mgechev/revive@v1.7.0
+RUN go install gotest.tools/gotestsum@v1.12.1
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 

--- a/encryptor/Dockerfile
+++ b/encryptor/Dockerfile
@@ -30,8 +30,8 @@ RUN curl -sL https://github.com/google/protobuf/releases/download/v3.3.0/protoc-
   mv bin/protoc /usr/local/bin/protoc
 
 WORKDIR /app
-RUN go install github.com/mgechev/revive@latest
-RUN go install gotest.tools/gotestsum@latest
+RUN go install github.com/mgechev/revive@v1.7.0
+RUN go install gotest.tools/gotestsum@v1.12.1
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
 CMD [ "/bin/bash",  "-c \"while sleep 1000; do :; done\"" ]

--- a/loghub2/Dockerfile
+++ b/loghub2/Dockerfile
@@ -30,8 +30,8 @@ RUN curl -sL https://github.com/google/protobuf/releases/download/v3.3.0/protoc-
   mv bin/protoc /usr/local/bin/protoc
 
 WORKDIR /app
-RUN go install github.com/mgechev/revive@latest
-RUN go install gotest.tools/gotestsum@latest
+RUN go install github.com/mgechev/revive@v1.7.0
+RUN go install gotest.tools/gotestsum@v1.12.1
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 

--- a/public-api-gateway/Dockerfile
+++ b/public-api-gateway/Dockerfile
@@ -31,8 +31,8 @@ RUN curl -sL https://github.com/google/protobuf/releases/download/v3.3.0/protoc-
   mv bin/protoc /usr/local/bin/protoc
 
 WORKDIR /app
-RUN go install github.com/mgechev/revive@latest
-RUN go install gotest.tools/gotestsum@latest
+RUN go install github.com/mgechev/revive@v1.7.0
+RUN go install gotest.tools/gotestsum@v1.12.1
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 RUN rm -rf build && CGO_ENABLED=0 go build -o build/server main.go

--- a/security-toolbox/policies/docker/trivy_config.rb
+++ b/security-toolbox/policies/docker/trivy_config.rb
@@ -18,7 +18,8 @@ class Policy::TrivyConfig < Policy
       "trivy",
       "config",
       "--severity #{@severity}",
-      "--exit-code 1"
+      "--exit-code 1",
+      "--misconfig-scanners dockerfile"
     ]
 
     @skip_files.each do |skip_file|

--- a/security-toolbox/policies/docker/trivy_config.rb
+++ b/security-toolbox/policies/docker/trivy_config.rb
@@ -10,12 +10,14 @@ class Policy::TrivyConfig < Policy
     end
 
     @skip_dirs = args[:skip_dirs].to_s.split(",") || []
+    @severity = args[:severity] || "HIGH,CRITICAL"
   end
 
   def test
     command = [
       "trivy",
       "config",
+      "--severity #{@severity}",
       "--exit-code 1"
     ]
 

--- a/self_hosted_hub/Dockerfile
+++ b/self_hosted_hub/Dockerfile
@@ -38,8 +38,8 @@ RUN curl -sL https://github.com/google/protobuf/releases/download/v3.3.0/protoc-
   mv bin/protoc /usr/local/bin/protoc
 
 WORKDIR /app
-RUN go install github.com/mgechev/revive@latest
-RUN go install gotest.tools/gotestsum@latest
+RUN go install github.com/mgechev/revive@v1.7.0
+RUN go install gotest.tools/gotestsum@v1.12.1
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 


### PR DESCRIPTION
## 📝 Description

This pull request fixes a few issues that are making our daily builds fail:
- The newest version of revive requires Go 1.23, which fails the build for some applications which are still on Go 1.22 - [job](https://semaphore.semaphoreci.com/jobs/4a1e5113-c36c-45ed-9514-059510015678#L557). It's always a good practice to pin the versions of the tools used in CI, so we do that here.
- For some applications, we are not building the image before checking it with trivy, which causes the CI job to fail - [job](https://semaphore.semaphoreci.com/jobs/a23a9e73-1a76-4143-b1a4-197e778ed9b6)
- We are currently ignoring the severity in the `trivy config` command, which causes some LOW misconfigurations to fail builds. Also, those LOW misconfigurations come from Kubernetes YAMLs, which is a newer thing that trivy can do. Since our goal with using trivy config was to scan for misconfigurations in Dockerfiles, we should not scan Kubernetes templates at all for now, so we update the security toolbox to be more direct with what we want to scan in `trivy config`

Ref: https://github.com/renderedtext/tasks/issues/7804

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
