### PR TITLE
Api/rbac remove user from org

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,10 +30,6 @@ global_job_config:
       commands:
         # Trivyfs security scan
         - 'if [ -f docker-scan-junit.xml ];            then test-results --name "Docker scan"         --suite-prefix "[$SERVICE_NAME]"  publish docker-scan-junit.xml; fi'
-        - ls -la
-        - cd out
-        - ls -la
-        - pwd
         - 'if [ -f junit.xml ];                        then test-results --name "$SEMAPHORE_JOB_NAME"                                     publish junit.xml; fi'
         - 'if [ -f results.xml ];                      then test-results --name "$SEMAPHORE_JOB_NAME"                                     publish results.xml; fi'
         - 'if [ -f out/results.xml ];                  then test-results --name "${TEST_RESULTS_NAME:-$SEMAPHORE_JOB_NAME}"               publish out/results.xml; fi'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,6 +30,10 @@ global_job_config:
       commands:
         # Trivyfs security scan
         - 'if [ -f docker-scan-junit.xml ];            then test-results --name "Docker scan"         --suite-prefix "[$SERVICE_NAME]"  publish docker-scan-junit.xml; fi'
+        - ls -la
+        - cd out
+        - ls -la
+        - pwd
         - 'if [ -f junit.xml ];                        then test-results --name "$SEMAPHORE_JOB_NAME"                                     publish junit.xml; fi'
         - 'if [ -f results.xml ];                      then test-results --name "$SEMAPHORE_JOB_NAME"                                     publish results.xml; fi'
         - 'if [ -f out/results.xml ];                  then test-results --name "${TEST_RESULTS_NAME:-$SEMAPHORE_JOB_NAME}"               publish out/results.xml; fi'

--- a/ee/rbac/lib/rbac/grpc_servers/rbac_server.ex
+++ b/ee/rbac/lib/rbac/grpc_servers/rbac_server.ex
@@ -289,8 +289,8 @@ defmodule Rbac.GrpcServers.RbacServer do
     is_owner? =
       Rbac.RoleManagement.fetch_subject_role_bindings(rbi)
       |> elem(0)
-      |> List.first()
-      |> Map.get(:role_bindings)
+      |> List.first(%{})
+      |> Map.get(:role_bindings, [])
       |> Enum.map(&Rbac.Repo.RbacRole.get_role_by_id(&1["role_id"]))
       |> Enum.any?(&(&1.name == "Owner"))
 

--- a/public-api/v1alpha/Dockerfile
+++ b/public-api/v1alpha/Dockerfile
@@ -21,7 +21,7 @@ RUN ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 RUN mix local.hex --force && mix local.rebar --force
 
 RUN mkdir api
-WORKDIR /app/api
+WORKDIR /app
 
 # install mix dependencies
 COPY public-api/v1alpha/mix.exs public-api/v1alpha/mix.lock ./
@@ -86,7 +86,7 @@ RUN \
 USER "${USER}"
 
 # copy release executables
-COPY --from=builder --chown="${USER}":"${USER}" /app/api/_build/"${MIX_ENV}"/rel/pipelines_api ./
+COPY --from=builder --chown="${USER}":"${USER}" /app/_build/"${MIX_ENV}"/rel/pipelines_api ./
 
 ENTRYPOINT ["bin/pipelines_api"]
 

--- a/public-api/v1alpha/Makefile
+++ b/public-api/v1alpha/Makefile
@@ -3,7 +3,7 @@ export MIX_ENV?=dev
 include ../../Makefile
 
 DOCKER_BUILD_PATH=../..
-OUT_VOLUME=$(PWD)/out:/app/api/out
+OUT_VOLUME=$(PWD)/out:/app/out
 INTERNAL_API_BRANCH?=master
 TMP_INTERNAL_REPO_DIR?=/tmp/internal_api
 RELATIVE_INTERNAL_PB_OUTPUT_DIR=lib/internal_api
@@ -62,7 +62,7 @@ test.ex.setup: export MIX_ENV=test
 test.ex.setup:
 ifeq ($(CI),)
 # Localy we use database supplied by docker-compose
-	docker compose $(DOCKER_COMPOSE_OPTS) run -e MIX_ENV=$(MIX_ENV) --build app mix do deps.get, test $(FILE)
+	docker compose $(DOCKER_COMPOSE_OPTS) run -e MIX_ENV=$(MIX_ENV) --build app mix do deps.get
 else
 	docker run --network host -v $(PWD)/out:/app/out $(CONTAINER_ENV_VARS) $(IMAGE):$(IMAGE_TAG) sh
 endif

--- a/public-api/v1alpha/Makefile
+++ b/public-api/v1alpha/Makefile
@@ -32,6 +32,7 @@ PROJECTHUB_API_GRPC_URL?=127.0.0.1:50052
 LOG_LEVEL?=debug
 API_VERSION?=v1alpha
 ON_PREM?="false"
+TMP_REPO_DIR ?= /tmp/internal_api
 
 CONTAINER_ENV_VARS= \
   -e IN_DOCKER=$(IN_DOCKER) \

--- a/public-api/v1alpha/Makefile
+++ b/public-api/v1alpha/Makefile
@@ -3,7 +3,6 @@ export MIX_ENV?=dev
 include ../../Makefile
 
 DOCKER_BUILD_PATH=../..
-OUT_VOLUME=$(PWD)/out:/app/out
 INTERNAL_API_BRANCH?=master
 TMP_INTERNAL_REPO_DIR?=/tmp/internal_api
 RELATIVE_INTERNAL_PB_OUTPUT_DIR=lib/internal_api

--- a/public-api/v1alpha/lib/internal_api/rbac.pb.ex
+++ b/public-api/v1alpha/lib/internal_api/rbac.pb.ex
@@ -306,6 +306,30 @@ defmodule InternalApi.RBAC.ListMembersResponse.Member do
   field(:subject_role_bindings, 3, repeated: true, type: InternalApi.RBAC.SubjectRoleBinding)
 end
 
+defmodule InternalApi.RBAC.CountMembersRequest do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          org_id: String.t()
+        }
+  defstruct [:org_id]
+
+  field(:org_id, 1, type: :string)
+end
+
+defmodule InternalApi.RBAC.CountMembersResponse do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          members: integer
+        }
+  defstruct [:members]
+
+  field(:members, 1, type: :int32)
+end
+
 defmodule InternalApi.RBAC.SubjectRoleBinding do
   @moduledoc false
   use Protobuf, syntax: :proto3
@@ -406,6 +430,25 @@ defmodule InternalApi.RBAC.Subject do
   field(:display_name, 3, type: :string)
 end
 
+defmodule InternalApi.RBAC.RefreshCollaboratorsRequest do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          org_id: String.t()
+        }
+  defstruct [:org_id]
+
+  field(:org_id, 1, type: :string)
+end
+
+defmodule InternalApi.RBAC.RefreshCollaboratorsResponse do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  defstruct []
+end
+
 defmodule InternalApi.RBAC.Role do
   @moduledoc false
   use Protobuf, syntax: :proto3
@@ -493,6 +536,7 @@ defmodule InternalApi.RBAC.RoleBindingSource do
   field(:ROLE_BINDING_SOURCE_GITLAB, 4)
   field(:ROLE_BINDING_SOURCE_SCIM, 5)
   field(:ROLE_BINDING_SOURCE_INHERITED_FROM_ORG_ROLE, 6)
+  field(:ROLE_BINDING_SOURCE_SAML_JIT, 7)
 end
 
 defmodule InternalApi.RBAC.RBAC.Service do
@@ -525,6 +569,7 @@ defmodule InternalApi.RBAC.RBAC.Service do
   rpc(:ModifyRole, InternalApi.RBAC.ModifyRoleRequest, InternalApi.RBAC.ModifyRoleResponse)
   rpc(:DestroyRole, InternalApi.RBAC.DestroyRoleRequest, InternalApi.RBAC.DestroyRoleResponse)
   rpc(:ListMembers, InternalApi.RBAC.ListMembersRequest, InternalApi.RBAC.ListMembersResponse)
+  rpc(:CountMembers, InternalApi.RBAC.CountMembersRequest, InternalApi.RBAC.CountMembersResponse)
 
   rpc(
     :ListAccessibleOrgs,
@@ -536,6 +581,12 @@ defmodule InternalApi.RBAC.RBAC.Service do
     :ListAccessibleProjects,
     InternalApi.RBAC.ListAccessibleProjectsRequest,
     InternalApi.RBAC.ListAccessibleProjectsResponse
+  )
+
+  rpc(
+    :RefreshCollaborators,
+    InternalApi.RBAC.RefreshCollaboratorsRequest,
+    InternalApi.RBAC.RefreshCollaboratorsResponse
   )
 end
 

--- a/public-api/v1alpha/lib/pipelines_api/rbac_client.ex
+++ b/public-api/v1alpha/lib/pipelines_api/rbac_client.ex
@@ -38,4 +38,11 @@ defmodule PipelinesAPI.RBACClient do
       )
     end)
   end
+
+  def retract_role(params) do
+    params
+    |> RequestFormatter.form_list_roles_request()
+    |> GrpcClient.list_roles()
+    |> ResponseFormatter.process_list_roles_response(InternalApi.RBAC.Scope.value(:SCOPE_PROJECT))
+  end
 end

--- a/public-api/v1alpha/lib/pipelines_api/rbac_client.ex
+++ b/public-api/v1alpha/lib/pipelines_api/rbac_client.ex
@@ -40,9 +40,13 @@ defmodule PipelinesAPI.RBACClient do
   end
 
   def retract_role(params) do
-    params
-    |> RequestFormatter.form_list_roles_request()
-    |> GrpcClient.list_roles()
-    |> ResponseFormatter.process_list_roles_response(InternalApi.RBAC.Scope.value(:SCOPE_PROJECT))
+    LogTee.debug(params, "RBACClient.retract_role")
+
+    Metrics.benchmark("PipelinesAPI.RBAC_client", ["retract_role"], fn ->
+      params
+      |> RequestFormatter.form_retract_role_request()
+      |> GrpcClient.retract_role()
+      |> ResponseFormatter.process_retract_role_response()
+    end)
   end
 end

--- a/public-api/v1alpha/lib/pipelines_api/rbac_client/request_formatter.ex
+++ b/public-api/v1alpha/lib/pipelines_api/rbac_client/request_formatter.ex
@@ -97,4 +97,13 @@ defmodule PipelinesAPI.RBACClient.RequestFormatter do
 
   def form_list_roles_request(_),
     do: ToTuple.user_error("organization id is required to make list roles request")
+
+  def form_retract_role_request(_params = %{"user_id" => user_id}) do
+  end
+
+  def form_retract_role_request(_params = %{"user_email" => user_id}) do
+  end
+
+  def form_retract_role_request(_),
+    do: ToTuple.user_error("user id is required to make retract role request")
 end

--- a/public-api/v1alpha/lib/pipelines_api/rbac_client/request_formatter.ex
+++ b/public-api/v1alpha/lib/pipelines_api/rbac_client/request_formatter.ex
@@ -98,12 +98,19 @@ defmodule PipelinesAPI.RBACClient.RequestFormatter do
   def form_list_roles_request(_),
     do: ToTuple.user_error("organization id is required to make list roles request")
 
-  def form_retract_role_request(_params = %{"user_id" => user_id}) do
-  end
-
-  def form_retract_role_request(_params = %{"user_email" => user_id}) do
+  def form_retract_role_request(%{user_id: user_id, org_id: org_id, requester_id: requester_id}) do
+    ToTuple.ok(
+      RBAC.RetractRoleRequest.new(
+        role_assignment:
+          RBAC.RoleAssignment.new(
+            subject: RBAC.Subject.new(subject_id: user_id),
+            org_id: org_id
+          ),
+        requester_id: requester_id
+      )
+    )
   end
 
   def form_retract_role_request(_),
-    do: ToTuple.user_error("user id is required to make retract role request")
+    do: ToTuple.user_error("Bad retract role request")
 end

--- a/public-api/v1alpha/lib/pipelines_api/rbac_client/response_formatter.ex
+++ b/public-api/v1alpha/lib/pipelines_api/rbac_client/response_formatter.ex
@@ -32,4 +32,8 @@ defmodule PipelinesAPI.RBACClient.ResponseFormatter do
     do: ToTuple.error({:internal_error, "internal error"})
 
   def process_list_roles_response(error, _), do: error
+
+  def process_retract_role_response({:ok, _response}), do: ToTuple.ok(true)
+
+  def process_retract_role_response({:error, _} = error), do: error
 end

--- a/public-api/v1alpha/lib/pipelines_api/rbac_client/response_formatter.ex
+++ b/public-api/v1alpha/lib/pipelines_api/rbac_client/response_formatter.ex
@@ -35,5 +35,5 @@ defmodule PipelinesAPI.RBACClient.ResponseFormatter do
 
   def process_retract_role_response({:ok, _response}), do: ToTuple.ok(true)
 
-  def process_retract_role_response({:error, _} = error), do: error
+  def process_retract_role_response(error = {:error, _}), do: error
 end

--- a/public-api/v1alpha/lib/pipelines_api/role_bindings/delete.ex
+++ b/public-api/v1alpha/lib/pipelines_api/role_bindings/delete.ex
@@ -1,6 +1,6 @@
 defmodule PipelinesAPI.RoleBindings.Delete do
   @moduledoc """
-  Plug deletes a deployment target.
+  Plug deletes a role binding (removes role from the subject).
   """
   use Plug.Builder
   require Logger
@@ -107,7 +107,7 @@ defmodule PipelinesAPI.RoleBindings.Delete do
 
   defp lookup_user_by_email(conn, email) do
     case UserApiClient.describe_by_email(email) do
-      {:ok, user} when not is_nil(user) ->
+      {:ok, user} ->
         conn |> Plug.Conn.assign(:user_id, user.id)
 
       {:error, :not_found} ->

--- a/public-api/v1alpha/lib/pipelines_api/role_bindings/delete.ex
+++ b/public-api/v1alpha/lib/pipelines_api/role_bindings/delete.ex
@@ -4,6 +4,7 @@ defmodule PipelinesAPI.RoleBindings.Delete do
   """
 
   use Plug.Builder
+  require Logger
 
   alias PipelinesAPI.Util.Metrics
   # alias PipelinesAPI.RBACClient
@@ -21,6 +22,8 @@ defmodule PipelinesAPI.RoleBindings.Delete do
 
   def delete(conn, _opts) do
     Metrics.benchmark("PipelinesAPI.router", ["dt_delete"], fn ->
+      Logger.info("INSIDE")
+      Logger.info("#{inspect(conn.query_params)}")
       Common.respond({:ok, %{filed_name: "VALUE"}}, conn)
     end)
   end

--- a/public-api/v1alpha/lib/pipelines_api/role_bindings/delete.ex
+++ b/public-api/v1alpha/lib/pipelines_api/role_bindings/delete.ex
@@ -22,6 +22,8 @@ defmodule PipelinesAPI.RoleBindings.Delete do
       org_id = conn.assigns.org_id
       user_id = conn.assigns.user_id
 
+      Logger.info("Removing role: #{user_id} - #{org_id}. Action performed by #{requester_id}")
+
       resp =
         RBACClient.retract_role(%{requester_id: requester_id, user_id: user_id, org_id: org_id})
 

--- a/public-api/v1alpha/lib/pipelines_api/role_bindings/delete.ex
+++ b/public-api/v1alpha/lib/pipelines_api/role_bindings/delete.ex
@@ -1,0 +1,43 @@
+defmodule PipelinesAPI.RoleBindings.Delete do
+  @moduledoc """
+  Plug deletes a deployment target.
+  """
+
+  use Plug.Builder
+
+  alias PipelinesAPI.Util.Metrics
+  # alias PipelinesAPI.RBACClient
+  alias PipelinesAPI.Pipelines.Common
+
+  # import PipelinesAPI.Deployments.Authorize, only: [authorize_manage_project: 2]
+
+  # alias PipelinesAPI.Util.VerifyData, as: VD
+
+  # @enabled_fields ~w(unique_token id target_id)
+
+  # plug(:verify_params)
+  # plug(:authorize_manage_project)
+  plug(:delete)
+
+  def delete(conn, _opts) do
+    Metrics.benchmark("PipelinesAPI.router", ["dt_delete"], fn ->
+      Common.respond({:ok, %{filed_name: "VALUE"}}, conn)
+    end)
+  end
+
+  def verify_params(conn, _otps) do
+    VD.verify(
+      VD.is_valid_uuid?(conn.params["unique_token"]),
+      "unique_token must be a valid UUID"
+    )
+    |> VD.verify(
+      VD.is_valid_uuid?(conn.params["id"]),
+      "target_id must be a valid UUID"
+    )
+    |> VD.verify(
+      VD.is_valid_uuid?(conn.params["target_id"]),
+      "target_id must be a valid UUID"
+    )
+    |> VD.finalize_verification(conn, @enabled_fields)
+  end
+end

--- a/public-api/v1alpha/lib/pipelines_api/role_bindings/delete.ex
+++ b/public-api/v1alpha/lib/pipelines_api/role_bindings/delete.ex
@@ -2,45 +2,113 @@ defmodule PipelinesAPI.RoleBindings.Delete do
   @moduledoc """
   Plug deletes a deployment target.
   """
-
   use Plug.Builder
   require Logger
 
   alias PipelinesAPI.Util.Metrics
-  # alias PipelinesAPI.RBACClient
+  alias PipelinesAPI.RBACClient
   alias PipelinesAPI.Pipelines.Common
+  alias PipelinesAPI.Util.VerifyData, as: VD
+  alias PipelinesAPI.UserApiClient
 
-  # import PipelinesAPI.Deployments.Authorize, only: [authorize_manage_project: 2]
-
-  # alias PipelinesAPI.Util.VerifyData, as: VD
-
-  # @enabled_fields ~w(unique_token id target_id)
-
-  # plug(:verify_params)
-  # plug(:authorize_manage_project)
+  plug(:put_assigns)
+  plug(:authorize)
+  plug(:fetch_user_to_be_deleted)
   plug(:delete)
 
   def delete(conn, _opts) do
-    Metrics.benchmark("PipelinesAPI.router", ["dt_delete"], fn ->
-      Logger.info("INSIDE")
-      Logger.info("#{inspect(conn.query_params)}")
-      Common.respond({:ok, %{filed_name: "VALUE"}}, conn)
+    Metrics.benchmark("PipelinesAPI.router", ["rbac_delete"], fn ->
+      requester_id = conn.assigns.requester_id
+      org_id = conn.assigns.org_id
+      user_id = conn.assigns.user_id
+
+      resp =
+        RBACClient.retract_role(%{requester_id: requester_id, user_id: user_id, org_id: org_id})
+
+      resp |> Common.respond(conn)
     end)
   end
 
-  def verify_params(conn, _otps) do
-    VD.verify(
-      VD.is_valid_uuid?(conn.params["unique_token"]),
-      "unique_token must be a valid UUID"
-    )
-    |> VD.verify(
-      VD.is_valid_uuid?(conn.params["id"]),
-      "target_id must be a valid UUID"
-    )
-    |> VD.verify(
-      VD.is_valid_uuid?(conn.params["target_id"]),
-      "target_id must be a valid UUID"
-    )
-    |> VD.finalize_verification(conn, @enabled_fields)
+  defp put_assigns(conn, _opts) do
+    requester_id = conn |> Plug.Conn.get_req_header("x-semaphore-user-id") |> List.first()
+    org_id = conn |> Plug.Conn.get_req_header("x-semaphore-org-id") |> List.first()
+
+    cond do
+      is_nil(requester_id) ->
+        Common.respond({:error, {:user, "Missing user id in request header"}}, conn)
+
+      not VD.is_valid_uuid?(requester_id) ->
+        Common.respond({:error, {:user, "Invalid user id format"}}, conn)
+
+      is_nil(org_id) ->
+        Common.respond({:error, {:user, "Missing organization id in request header"}}, conn)
+
+      not VD.is_valid_uuid?(org_id) ->
+        Common.respond({:error, {:user, "Invalid organization id format"}}, conn)
+
+      true ->
+        conn
+        |> Plug.Conn.assign(:requester_id, requester_id)
+        |> Plug.Conn.assign(:org_id, org_id)
+    end
+  end
+
+  defp authorize(conn, _opts) do
+    requester_id = conn.assigns.requester_id
+    org_id = conn.assigns.org_id
+
+    params = %{user_id: requester_id, org_id: org_id}
+
+    case RBACClient.list_user_permissions(params) do
+      {:ok, permissions} ->
+        if Enum.member?(permissions, "organization.people.manage") do
+          conn |> Plug.Conn.assign(:permissions, permissions)
+        else
+          Common.respond({:error, {:user, "Permission denied"}}, conn)
+        end
+
+      error ->
+        Logger.error("Error when listing permissions: #{inspect(error)}")
+        Common.respond({:error, {:internal, "Internal error"}}, conn)
+    end
+  end
+
+  defp fetch_user_to_be_deleted(conn, _opts) do
+    user_id = conn.query_params["user_id"]
+    email = conn.query_params["email"]
+
+    cond do
+      not is_nil(user_id) ->
+        case UserApiClient.describe_many([user_id]) do
+          {:ok, %{users: users}} when is_list(users) and length(users) > 0 ->
+            [user | _] = users
+            conn |> Plug.Conn.assign(:user_id, user.id)
+
+          {:ok, _} ->
+            Logger.info("User with id #{user_id} not found")
+            Common.respond({:error, {:user, "User with id #{user_id} not found"}}, conn)
+
+          error ->
+            Logger.error("Error when fetching user by ID: #{inspect(error)}")
+            Common.respond({:error, {:internal, "Internal error"}}, conn)
+        end
+
+      not is_nil(email) ->
+        case UserApiClient.describe_by_email(email) do
+          {:ok, user} when not is_nil(user) ->
+            conn |> Plug.Conn.assign(:user_id, user.id)
+
+          {:error, :not_found} ->
+            Logger.info("User with email #{email} not found")
+            Common.respond({:error, {:user, "User with email #{email} not found"}}, conn)
+
+          error ->
+            Logger.error("Error when fetching user by email: #{inspect(error)}")
+            Common.respond({:error, {:internal, "Internal error"}}, conn)
+        end
+
+      true ->
+        Common.respond({:error, {:user, "Missing user_id or email in query parameters"}}, conn)
+    end
   end
 end

--- a/public-api/v1alpha/lib/pipelines_api/router.ex
+++ b/public-api/v1alpha/lib/pipelines_api/router.ex
@@ -99,7 +99,7 @@ defmodule PipelinesAPI.Router do
 
   match("/deployment_targets/:target_id", via: :delete, to: DeleteDeploymentTarget)
 
-  match("/rbac/", via: :delete, to: DeleteRoleBindings)
+  match("/role_bindings", via: :delete, to: DeleteRoleBindings)
 
   match("/schedules", via: :post, to: ApplySchedule)
 

--- a/public-api/v1alpha/lib/pipelines_api/router.ex
+++ b/public-api/v1alpha/lib/pipelines_api/router.ex
@@ -22,6 +22,7 @@ defmodule PipelinesAPI.Router do
   alias PipelinesAPI.Deployments.History, as: HistoryDeployments
   alias PipelinesAPI.Deployments.Cordon, as: CordonDeploymentTarget
   alias PipelinesAPI.Deployments.Uncordon, as: UnCordonDeploymentTarget
+  alias PipelinesAPI.RoleBindings.Delete, as: DeleteRoleBindings
   alias PipelinesAPI.Schedules.Apply, as: ApplySchedule
   alias PipelinesAPI.Schedules.Describe, as: DescribeSchedule
   alias PipelinesAPI.Schedules.Delete, as: DeleteSchedule
@@ -97,6 +98,8 @@ defmodule PipelinesAPI.Router do
   match("/deployment_targets/:target_id", via: :patch, to: UpdateDeploymentTarget)
 
   match("/deployment_targets/:target_id", via: :delete, to: DeleteDeploymentTarget)
+
+  match("/rbac/", via: :delete, to: DeleteRoleBindings)
 
   match("/schedules", via: :post, to: ApplySchedule)
 

--- a/public-api/v1alpha/lib/pipelines_api/user_api_client.ex
+++ b/public-api/v1alpha/lib/pipelines_api/user_api_client.ex
@@ -4,6 +4,7 @@ defmodule PipelinesAPI.UserApiClient do
   """
 
   alias InternalApi.User.DescribeManyRequest
+  alias InternalApi.User.DescribeByEmailRequest
   alias InternalApi.User.UserService.Stub
   alias PipelinesAPI.Util.{Metrics, ToTuple}
   alias Util.Proto
@@ -18,8 +19,8 @@ defmodule PipelinesAPI.UserApiClient do
 
       case Wormhole.capture(
              __MODULE__,
-             :call_user_api,
-             [request],
+             :call_api,
+             [request, :describe_many],
              stacktrace: true,
              skip_log: true,
              timeout_ms: @wormhole_timeout,
@@ -35,8 +36,31 @@ defmodule PipelinesAPI.UserApiClient do
     end)
   end
 
-  def call_user_api(request) do
+  def describe_by_email(email) do
+    Metrics.benchmark(__MODULE__, ["describe_by_email"], fn ->
+      request = DescribeByEmailRequest.new(email: email)
+
+      case Wormhole.capture(
+             __MODULE__,
+             :call_api,
+             [request, :describe_by_email],
+             stacktrace: true,
+             skip_log: true,
+             timeout_ms: @wormhole_timeout,
+             ok_tuple: true
+           ) do
+        {:ok, result} ->
+          Proto.to_map(result)
+
+        {:error, reason} ->
+          reason |> LogTee.error("Error describing user by email: #{inspect(reason)}")
+          ToTuple.internal_error("Internal error")
+      end
+    end)
+  end
+
+  def call_api(request, method) do
     {:ok, channel} = url() |> GRPC.Stub.connect()
-    Stub.describe_many(channel, request, timeout: @wormhole_timeout)
+    apply(Stub, method, [channel, request, [timeout: @wormhole_timeout]])
   end
 end

--- a/public-api/v1alpha/mix.lock
+++ b/public-api/v1alpha/mix.lock
@@ -30,7 +30,7 @@
   "idna": {:hex, :idna, "6.1.1", "8a63070e9f7d0c62eb9d9fcb360a7de382448200fbbd1b106cc96d3d8099df8d", [:rebar3], [{:unicode_util_compat, "~> 0.7.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm", "92376eb7894412ed19ac475e4a86f7b413c1b9fbb5bd16dccd57934157944cea"},
   "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
   "jumper": {:hex, :jumper, "1.0.2", "68cdcd84472a00ac596b4e6459a41b3062d4427cbd4f1e8c8793c5b54f1406a7", [:mix], [], "hexpm", "9b7782409021e01ab3c08270e26f36eb62976a38c1aa64b2eaf6348422f165e1"},
-  "junit_formatter": {:hex, :junit_formatter, "3.3.1", "c729befb848f1b9571f317d2fefa648e9d4869befc4b2980daca7c1edc468e40", [:mix], [], "hexpm", "761fc5be4b4c15d8ba91a6dafde0b2c2ae6db9da7b8832a55b5a1deb524da72b"},
+  "junit_formatter": {:hex, :junit_formatter, "3.4.0", "d0e8db6c34dab6d3c4154c3b46b21540db1109ae709d6cf99ba7e7a2ce4b1ac2", [:mix], [], "hexpm", "bb36e2ae83f1ced6ab931c4ce51dd3dbef1ef61bb4932412e173b0cfa259dacd"},
   "lager": {:hex, :lager, "3.6.1", "9d29c5ff7f926d25ecd9899990867c9152dcf34eee65bac8ec0dfc0d16a26e0c", [:rebar3], [{:goldrush, "0.1.9", [hex: :goldrush, repo: "hexpm", optional: false]}], "hexpm", "4e8bdedd636fcc606e58bad137ec7fdd1286d1fe5c739cca70d8fe79c61091d7"},
   "log_tee": {:git, "https://github.com/renderedtext/log-tee.git", "30c69704d583bda8cffb324b8936ffd3680e6ae4", []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},

--- a/public-api/v1alpha/test/router/role_bindings/delete_test.exs
+++ b/public-api/v1alpha/test/router/role_bindings/delete_test.exs
@@ -20,7 +20,7 @@ defmodule Router.RoleBindings.Delete.Test do
      }}
   end
 
-  describe "DELETE /rbac/ - endpoint to delete role binding" do
+  describe "DELETE /role_bindings - endpoint to delete role binding" do
     test "returns 400 when user_id header is missing", ctx do
       {:ok, resp} =
         create_delete_request(%{}, ctx, [
@@ -138,7 +138,7 @@ defmodule Router.RoleBindings.Delete.Test do
   end
 
   defp create_delete_request(params, _ctx, headers) do
-    url = url() <> "/rbac/" <> "?" <> Plug.Conn.Query.encode(params)
+    url = url() <> "/role_bindings/" <> "?" <> Plug.Conn.Query.encode(params)
     HTTPoison.delete(url, headers)
   end
 end

--- a/public-api/v1alpha/test/router/role_bindings/delete_test.exs
+++ b/public-api/v1alpha/test/router/role_bindings/delete_test.exs
@@ -112,9 +112,7 @@ defmodule Router.RoleBindings.Delete.Test do
     end
 
     test "When user exists and is passed via email, successfully deletes role bindings", ctx do
-      user_to_delete =
-        Support.Stubs.User.create(user_id: UUID.uuid4(), email: "delete-me@example.com")
-
+      Support.Stubs.User.create(user_id: UUID.uuid4(), email: "delete-me@example.com")
       {:ok, resp} = create_delete_request(%{email: "delete-me@example.com"}, ctx)
 
       assert resp.status_code == 200

--- a/public-api/v1alpha/test/router/role_bindings/delete_test.exs
+++ b/public-api/v1alpha/test/router/role_bindings/delete_test.exs
@@ -1,0 +1,146 @@
+defmodule Router.RoleBindings.Delete.Test do
+  use ExUnit.Case
+
+  setup do
+    on_exit(fn ->
+      Support.Stubs.reset()
+    end)
+
+    Support.Stubs.reset()
+    Support.Stubs.build_shared_factories()
+    Support.Stubs.grant_all_permissions()
+
+    org = Support.Stubs.Organization.create_default()
+    user = Support.Stubs.User.create_default()
+
+    {:ok,
+     extra_args: %{
+       "organization_id" => org.id,
+       "requester_id" => user.id
+     }}
+  end
+
+  describe "DELETE /rbac/ - endpoint to delete role binding" do
+    test "returns 400 when user_id header is missing", ctx do
+      {:ok, resp} =
+        create_delete_request(%{}, ctx, [
+          {"Content-type", "application/json"},
+          {"x-semaphore-org-id", ctx.extra_args["organization_id"]}
+        ])
+
+      assert resp.status_code == 400
+      assert resp.body =~ "Missing user id in request header"
+    end
+
+    test "returns 400 when org_id header is missing", ctx do
+      {:ok, resp} =
+        create_delete_request(%{}, ctx, [
+          {"Content-type", "application/json"},
+          {"x-semaphore-user-id", ctx.extra_args["requester_id"]}
+        ])
+
+      assert resp.status_code == 400
+      assert resp.body =~ "Missing organization id in request header"
+    end
+
+    test "returns 400 when user_id is not a valid UUID", ctx do
+      {:ok, resp} =
+        create_delete_request(%{}, ctx, [
+          {"Content-type", "application/json"},
+          {"x-semaphore-user-id", "not-a-uuid"},
+          {"x-semaphore-org-id", ctx.extra_args["organization_id"]}
+        ])
+
+      assert resp.status_code == 400
+      assert resp.body =~ "Invalid user id format"
+    end
+
+    test "returns 400 when org_id is not a valid UUID", ctx do
+      {:ok, resp} =
+        create_delete_request(%{}, ctx, [
+          {"Content-type", "application/json"},
+          {"x-semaphore-user-id", ctx.extra_args["requester_id"]},
+          {"x-semaphore-org-id", "not-a-uuid"}
+        ])
+
+      assert resp.status_code == 400
+      assert resp.body =~ "Invalid organization id format"
+    end
+
+    test "when user_id is not authorized then returns 401", ctx do
+      GrpcMock.stub(RBACMock, :list_user_permissions, fn _, _ ->
+        InternalApi.RBAC.ListUserPermissionsResponse.new(
+          permissions: Support.Stubs.all_permissions_except("organization.people.manage")
+        )
+      end)
+
+      {:ok, resp} = create_delete_request(%{user_id: UUID.uuid4()}, ctx)
+      assert resp.status_code == 400
+      assert resp.body =~ "Permission denied"
+    end
+
+    test "When a non-existent user_id is provided returns 400", ctx do
+      random_uuid = UUID.uuid4()
+
+      {:ok, resp} = create_delete_request(%{user_id: random_uuid}, ctx)
+      assert resp.status_code == 400
+      assert resp.body =~ "User with id #{random_uuid} not found"
+    end
+
+    test "When a non-existent email is provided returns 400", ctx do
+      random_email = "test@gmail.com"
+
+      {:ok, resp} = create_delete_request(%{email: random_email}, ctx)
+      assert resp.status_code == 400
+      assert resp.body =~ "User with email #{random_email} not found"
+    end
+
+    test "When neither user_id nor email is provided returns 400", ctx do
+      {:ok, resp} = create_delete_request(%{}, ctx)
+      assert resp.status_code == 400
+      assert resp.body =~ "Missing user_id or email in query parameters"
+    end
+
+    test "When user exists and is passed via user_id, successfully deletes role bindings", ctx do
+      user_to_delete =
+        Support.Stubs.User.create(user_id: UUID.uuid4(), email: "delete-me@example.com")
+
+      {:ok, resp} = create_delete_request(%{user_id: user_to_delete.id, email: "test"}, ctx)
+
+      assert resp.status_code == 200
+      assert resp.body =~ "true"
+    end
+
+    test "When user exists and is passed via email, successfully deletes role bindings", ctx do
+      user_to_delete =
+        Support.Stubs.User.create(user_id: UUID.uuid4(), email: "delete-me@example.com")
+
+      {:ok, resp} = create_delete_request(%{email: "delete-me@example.com"}, ctx)
+
+      assert resp.status_code == 200
+      assert resp.body =~ "true"
+    end
+  end
+
+  defp url, do: "localhost:4004"
+
+  defp headers(user_id, org_id),
+    do: [
+      {"Content-type", "application/json"},
+      {"x-semaphore-user-id", user_id},
+      {"x-semaphore-org-id", org_id}
+    ]
+
+  defp create_delete_request(params, ctx) do
+    create_delete_request(
+      params,
+      ctx,
+      headers(ctx.extra_args["requester_id"], ctx.extra_args["organization_id"])
+    )
+  end
+
+  defp create_delete_request(params, _ctx, headers) do
+    url = url() <> "/rbac/" <> "?" <> Plug.Conn.Query.encode(params)
+    HTTPoison.delete(url, headers)
+  end
+end

--- a/public-api/v1alpha/test/support/stubs.ex
+++ b/public-api/v1alpha/test/support/stubs.ex
@@ -75,6 +75,7 @@ defmodule Support.Stubs do
       "project.job.stop",
       "organization.self_hosted_agents.manage",
       "organization.self_hosted_agents.view",
+      "organization.people.manage",
       "project.general_settings.view",
       "project.general_settings.manage",
       "project.scheduler.manage",

--- a/public-api/v1alpha/test/support/stubs/user.ex
+++ b/public-api/v1alpha/test/support/stubs/user.ex
@@ -183,10 +183,10 @@ defmodule Support.Stubs.User do
           repository_providers: user_model.repository_providers
         )
       else
-        %Google.Rpc.Status{
-          code: 5,
-          message: "User with email #{req.email} not found"
-        }
+        raise(GRPC.RPCError,
+          message: "User with email #{req.email} not found",
+          status: GRPC.Status.not_found()
+        )
       end
     end
 

--- a/public-api/v1alpha/test/support/stubs/user.ex
+++ b/public-api/v1alpha/test/support/stubs/user.ex
@@ -10,6 +10,7 @@ defmodule Support.Stubs.User do
   alias Support.Stubs.{DB, Time, UUID}
 
   def default_user_id, do: "78114608-be8a-465a-b9cd-81970fb802c5"
+  def default_user_email, do: "madeup@mail.com"
 
   def init do
     DB.add_table(:users, [:id, :api_model])
@@ -30,6 +31,7 @@ defmodule Support.Stubs.User do
   def create_default(params \\ []) do
     defaults = [
       user_id: default_user_id(),
+      email: default_user_email(),
       github_repositry_scope: "private"
     ]
 
@@ -63,12 +65,11 @@ defmodule Support.Stubs.User do
           code: InternalApi.ResponseStatus.Code.value(:OK),
           message: ""
         ),
-      user_id: UUID.gen(),
+      user_id: params[:user_id],
       name: "Milica",
-      email: "dhh@basecamp.com",
+      email: params[:email],
       created_at: Time.now(),
       avatar_url: "https://gravatar.com/avatar/c716c3715a66612b070b6408b89c1190.png",
-      api_token: "q8u38dj3dd83jd83j",
       github_token: "c716c3715a66612b070b6408b89c1190",
       github_scope: map_github_scope(params[:github_repositry_scope]),
       github_login: "milica-nerlovic",
@@ -100,7 +101,6 @@ defmodule Support.Stubs.User do
       name: "Milica",
       avatar_url: "https://gravatar.com/avatar/c716c3715a66612b070b6408b89c1190.png",
       github_uid: "githubuid",
-      api_token: "skjelkejfde",
       github_login: "milica-nerlovic",
       single_org_user: false
     ]
@@ -116,6 +116,7 @@ defmodule Support.Stubs.User do
     def init do
       GrpcMock.stub(UserMock, :describe, &__MODULE__.describe/2)
       GrpcMock.stub(UserMock, :describe_many, &__MODULE__.describe_many/2)
+      GrpcMock.stub(UserMock, :describe_by_email, &__MODULE__.describe_by_email/2)
       GrpcMock.stub(UserMock, :update, &__MODULE__.update/2)
       GrpcMock.stub(UserMock, :regenerate_token, &__MODULE__.regenerate_token/2)
       GrpcMock.stub(UserMock, :list_favorites, &__MODULE__.list_favorites/2)
@@ -153,7 +154,6 @@ defmodule Support.Stubs.User do
             avatar_url: u.avatar_url,
             github_uid: u.github_uid,
             name: u.name,
-            api_token: u.api_token,
             company: u.company,
             email: u.email,
             repository_providers: u.repository_providers
@@ -161,6 +161,33 @@ defmodule Support.Stubs.User do
         end)
 
       Response.new(status: internal_status(:OK), users: users)
+    end
+
+    def describe_by_email(req, _) do
+      alias InternalApi.User.User, as: Response
+
+      user =
+        DB.all(:users)
+        |> Enum.find(fn u -> u.api_model.email == req.email end)
+
+      if user do
+        user_model = DB.extract(user, :api_model)
+
+        Response.new(
+          id: user_model.user_id,
+          avatar_url: user_model.avatar_url,
+          github_uid: user_model.github_uid,
+          name: user_model.name,
+          company: user_model.company,
+          email: user_model.email,
+          repository_providers: user_model.repository_providers
+        )
+      else
+        %Google.Rpc.Status{
+          code: 5,
+          message: "User with email #{req.email} not found"
+        }
+      end
     end
 
     def update(req, _) do
@@ -267,7 +294,6 @@ defmodule Support.Stubs.User do
         name: user.name,
         email: user.email,
         avatar_url: user.avatar_url,
-        api_token: user.api_token,
         company: user.company,
         repository_scopes:
           RS.new(
@@ -293,7 +319,6 @@ defmodule Support.Stubs.User do
         avatar_url: user.avatar_url,
         github_uid: user.repository_scopes.github.uid,
         name: user.name,
-        api_token: user.api_token,
         github_login: user.repository_scopes.github.login,
         company: user.company,
         email: user.email,

--- a/public-api/v1alpha/test/test_helper.exs
+++ b/public-api/v1alpha/test/test_helper.exs
@@ -2,7 +2,7 @@ Support.Stubs.init()
 
 ExUnit.configure(
   exclude: [integration: true, router: true, gofer_integration: true],
-  formatters: [JUnitFormatter, PipelinesAPI.CustomExUnitFormatter]
+  formatters: [ExUnit.CLIFormatter]
 )
 
 ExUnit.start(trace: true, capture_log: true)

--- a/public-api/v1alpha/test/test_helper.exs
+++ b/public-api/v1alpha/test/test_helper.exs
@@ -1,8 +1,20 @@
 Support.Stubs.init()
 
+formatters = [PipelinesAPI.CustomExUnitFormatter]
+
+formatters =
+  System.get_env("CI", "")
+  |> case do
+    "" ->
+      formatters
+
+    _ ->
+      [JUnitFormatter | formatters]
+  end
+
 ExUnit.configure(
   exclude: [integration: true, router: true, gofer_integration: true],
-  formatters: [ExUnit.CLIFormatter, PipelinesAPI.CustomExUnitFormatter]
+  formatters: formatters
 )
 
 ExUnit.start(trace: true, capture_log: true)

--- a/public-api/v1alpha/test/test_helper.exs
+++ b/public-api/v1alpha/test/test_helper.exs
@@ -2,7 +2,7 @@ Support.Stubs.init()
 
 ExUnit.configure(
   exclude: [integration: true, router: true, gofer_integration: true],
-  formatters: [ExUnit.CLIFormatter]
+  formatters: [ExUnit.CLIFormatter, PipelinesAPI.CustomExUnitFormatter]
 )
 
 ExUnit.start(trace: true, capture_log: true)


### PR DESCRIPTION
## 📝 Description

Http api for removing a user from the org (clevertap): https://github.com/renderedtext/tasks/issues/7779

Changes made to RBAC are only here so that the endpoint for retracting roles would not crash if the user is already not part of the organization

I made changes to the plumber Dockerfile, Makefile and test_helper in order to be able to run tests both locally (using make test.ex) and on CI

(tested pipelines API as well, it works)

## ✅ Checklist
- [x] I have tested this change
- [x] This change requires documentation update (for now we will only have private docs for clevertap)
