### PR TITLE
feat(guard): create soft delete for organizations

### DIFF
--- a/github_hooks/db/migrate/20250409112220_add_deleted_at_for_organizations.rb
+++ b/github_hooks/db/migrate/20250409112220_add_deleted_at_for_organizations.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtForOrganizations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :organizations, :deleted_at, :datetime, null: true, default: nil
+    add_column :organizations, :deleted_by, :uuid, null: true, default: nil
+  end
+end

--- a/github_hooks/db/migrate/20250409112220_add_deleted_at_for_organizations.rb
+++ b/github_hooks/db/migrate/20250409112220_add_deleted_at_for_organizations.rb
@@ -1,6 +1,5 @@
 class AddDeletedAtForOrganizations < ActiveRecord::Migration[5.1]
   def change
     add_column :organizations, :deleted_at, :datetime, null: true, default: nil
-    add_column :organizations, :deleted_by, :uuid, null: true, default: nil
   end
 end

--- a/guard/lib/guard/events/organization_deleted.ex
+++ b/guard/lib/guard/events/organization_deleted.ex
@@ -3,7 +3,7 @@ defmodule Guard.Events.OrganizationDeleted do
   Event emitted when an organization is deleted.
   """
 
-  @spec publish(String.t()) :: :ok
+  @spec publish(String.t(), Keyword.t()) :: :ok
   def publish(organization_id, opts \\ []) do
     event =
       InternalApi.Organization.OrganizationDeleted.new(

--- a/guard/lib/guard/events/organization_deleted.ex
+++ b/guard/lib/guard/events/organization_deleted.ex
@@ -23,8 +23,6 @@ defmodule Guard.Events.OrganizationDeleted do
 
     message = InternalApi.Organization.OrganizationDeleted.encode(event)
 
-    exchange_name = "organization_exchange"
-
     {:ok, channel} = AMQP.Application.get_channel(:organization)
     :ok = AMQP.Basic.publish(channel, "organization_exchange", routing_key, message)
   end

--- a/guard/lib/guard/events/organization_deleted.ex
+++ b/guard/lib/guard/events/organization_deleted.ex
@@ -3,8 +3,17 @@ defmodule Guard.Events.OrganizationDeleted do
   Event emitted when an organization is deleted.
   """
 
-  @spec publish(String.t(), Keyword.t()) :: :ok
-  def publish(organization_id, opts \\ []) do
+  @spec publish(String.t(), Keyword.t()) :: :ok | {:error, :missing_event_type}
+  def publish(organization_id, opts) do
+    case opts[:type] do
+      :soft_delete -> do_publish(organization_id, "soft_deleted")
+      :hard_delete -> do_publish(organization_id, "deleted")
+      nil -> {:error, :missing_event_type}
+      _ -> {:error, :invalid_event_type}
+    end
+  end
+
+  defp do_publish(organization_id, routing_key) do
     event =
       InternalApi.Organization.OrganizationDeleted.new(
         org_id: organization_id,
@@ -15,9 +24,8 @@ defmodule Guard.Events.OrganizationDeleted do
     message = InternalApi.Organization.OrganizationDeleted.encode(event)
 
     exchange_name = "organization_exchange"
-    routing_key = if opts[:soft_delete], do: "soft_deleted", else: "deleted"
 
     {:ok, channel} = AMQP.Application.get_channel(:organization)
-    :ok = AMQP.Basic.publish(channel, exchange_name, routing_key, message)
+    :ok = AMQP.Basic.publish(channel, "organization_exchange", routing_key, message)
   end
 end

--- a/guard/lib/guard/events/organization_deleted.ex
+++ b/guard/lib/guard/events/organization_deleted.ex
@@ -4,7 +4,7 @@ defmodule Guard.Events.OrganizationDeleted do
   """
 
   @spec publish(String.t()) :: :ok
-  def publish(organization_id) do
+  def publish(organization_id, opts \\ []) do
     event =
       InternalApi.Organization.OrganizationDeleted.new(
         org_id: organization_id,
@@ -15,7 +15,7 @@ defmodule Guard.Events.OrganizationDeleted do
     message = InternalApi.Organization.OrganizationDeleted.encode(event)
 
     exchange_name = "organization_exchange"
-    routing_key = "deleted"
+    routing_key = if opts[:soft_delete], do: "soft_deleted", else: "deleted"
 
     {:ok, channel} = AMQP.Application.get_channel(:organization)
     :ok = AMQP.Basic.publish(channel, exchange_name, routing_key, message)

--- a/guard/lib/guard/front_repo/organization.ex
+++ b/guard/lib/guard/front_repo/organization.ex
@@ -17,6 +17,7 @@ defmodule Guard.FrontRepo.Organization do
     field(:deny_member_workflows, :boolean)
     field(:deny_non_member_workflows, :boolean)
     field(:settings, :map)
+    field(:deleted_at, :utc_datetime)
 
     has_many(:contacts, Guard.FrontRepo.OrganizationContact, on_delete: :delete_all)
     has_many(:suspensions, Guard.FrontRepo.OrganizationSuspension, on_delete: :delete_all)
@@ -47,7 +48,8 @@ defmodule Guard.FrontRepo.Organization do
         :deny_member_workflows,
         :deny_non_member_workflows,
         :settings,
-        :created_at
+        :created_at,
+        :deleted_at
       ],
       empty_values: []
     )

--- a/guard/lib/guard/grpc_servers/organization_server.ex
+++ b/guard/lib/guard/grpc_servers/organization_server.ex
@@ -421,9 +421,9 @@ defmodule Guard.GrpcServers.OrganizationServer do
     observe("destroy", fn ->
       case fetch_organization(org_id, "") do
         {:ok, organization} ->
-          case Guard.Store.Organization.destroy(organization) do
+          case Guard.Store.Organization.soft_destroy(organization) do
             {:ok, _} ->
-              Guard.Events.OrganizationDeleted.publish(organization.id)
+              Guard.Events.OrganizationDeleted.publish(organization.id, soft_delete: true)
 
               %Google.Protobuf.Empty{}
 

--- a/guard/lib/guard/grpc_servers/organization_server.ex
+++ b/guard/lib/guard/grpc_servers/organization_server.ex
@@ -423,8 +423,6 @@ defmodule Guard.GrpcServers.OrganizationServer do
         {:ok, organization} ->
           case Guard.Store.Organization.soft_destroy(organization) do
             {:ok, _} ->
-              Guard.Events.OrganizationDeleted.publish(organization.id, soft_delete: true)
-
               %Google.Protobuf.Empty{}
 
             {:error, changeset} ->

--- a/guard/lib/guard/store/organization.ex
+++ b/guard/lib/guard/store/organization.ex
@@ -312,7 +312,7 @@ defmodule Guard.Store.Organization do
       |> Guard.FrontRepo.Organization.changeset(%{deleted_at: DateTime.utc_now()})
       |> Guard.FrontRepo.update()
 
-    Guard.Events.OrganizationDeleted.publish(organization.id, soft_delete: true)
+    :ok = Guard.Events.OrganizationDeleted.publish(organization.id, type: :soft_delete)
 
     result
   end
@@ -326,7 +326,7 @@ defmodule Guard.Store.Organization do
   def hard_destroy(%Guard.FrontRepo.Organization{} = organization) do
     result = Guard.FrontRepo.delete(organization)
 
-    Guard.Events.OrganizationDeleted.publish(organization.id)
+    :ok = Guard.Events.OrganizationDeleted.publish(organization.id, type: :hard_delete)
 
     result
   end

--- a/guard/lib/guard/store/organization.ex
+++ b/guard/lib/guard/store/organization.ex
@@ -312,9 +312,14 @@ defmodule Guard.Store.Organization do
       |> Guard.FrontRepo.Organization.changeset(%{deleted_at: DateTime.utc_now()})
       |> Guard.FrontRepo.update()
 
-    :ok = Guard.Events.OrganizationDeleted.publish(organization.id, type: :soft_delete)
+    case result do
+      {:ok, _} ->
+        :ok = Guard.Events.OrganizationDeleted.publish(organization.id, type: :soft_delete)
+        result
 
-    result
+      _ ->
+        result
+    end
   end
 
   @doc """
@@ -326,9 +331,14 @@ defmodule Guard.Store.Organization do
   def hard_destroy(%Guard.FrontRepo.Organization{} = organization) do
     result = Guard.FrontRepo.delete(organization)
 
-    :ok = Guard.Events.OrganizationDeleted.publish(organization.id, type: :hard_delete)
+    case result do
+      {:ok, _} ->
+        :ok = Guard.Events.OrganizationDeleted.publish(organization.id, type: :hard_delete)
+        result
 
-    result
+      _ ->
+        result
+    end
   end
 
   defp where_undeleted(query) do

--- a/guard/priv/front_repo/migrations/20250409190912_add_deleted_at_for_organizations.exs
+++ b/guard/priv/front_repo/migrations/20250409190912_add_deleted_at_for_organizations.exs
@@ -1,0 +1,9 @@
+defmodule Guard.FrontRepo.Migrations.AddDeletedAtForOrganizations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:organizations) do
+      add :deleted_at, :utc_datetime, null: true, default: nil
+    end
+  end
+end

--- a/guard/test/guard/grpc_servers/organization_server_test.exs
+++ b/guard/test/guard/grpc_servers/organization_server_test.exs
@@ -1196,15 +1196,24 @@ defmodule Guard.GrpcServers.OrganizationServerTest do
       grpc_channel: channel,
       organization: organization
     } do
-      with_mocks [{Guard.Events.OrganizationDeleted, [], [publish: fn _ -> :ok end]}] do
+      with_mocks [{Guard.Events.OrganizationDeleted, [], [publish: fn _, _ -> :ok end]}] do
         request = Organization.DestroyRequest.new(org_id: organization.id)
 
         {:ok, _} = channel |> Organization.OrganizationService.Stub.destroy(request)
 
-        # Verify organization was deleted
-        assert is_nil(Guard.FrontRepo.get(Guard.FrontRepo.Organization, organization.id))
+        # Verify organization was soft deleted
+        soft_deleted_org = Guard.FrontRepo.get(Guard.FrontRepo.Organization, organization.id)
+        assert soft_deleted_org.deleted_at != nil
 
-        assert_called(Guard.Events.OrganizationDeleted.publish(organization.id))
+        assert {:error, {:not_found, _message}} =
+                 Guard.Store.Organization.get_by_id(soft_deleted_org.id)
+
+        assert {:error, {:not_found, _message}} =
+                 Guard.Store.Organization.get_by_username(soft_deleted_org.username)
+
+        assert_called(
+          Guard.Events.OrganizationDeleted.publish(organization.id, soft_delete: true)
+        )
       end
     end
 

--- a/guard/test/guard/grpc_servers/organization_server_test.exs
+++ b/guard/test/guard/grpc_servers/organization_server_test.exs
@@ -1212,19 +1212,19 @@ defmodule Guard.GrpcServers.OrganizationServerTest do
                  Guard.Store.Organization.get_by_username(soft_deleted_org.username)
 
         assert_called(
-          Guard.Events.OrganizationDeleted.publish(organization.id, soft_delete: true)
+          Guard.Events.OrganizationDeleted.publish(organization.id, type: :soft_delete)
         )
       end
     end
 
     test "returns error for non-existent organization", %{grpc_channel: channel} do
-      with_mocks [{Guard.Events.OrganizationDeleted, [], [publish: fn _ -> :ok end]}] do
+      with_mocks [{Guard.Events.OrganizationDeleted, [], [publish: fn _, _ -> :ok end]}] do
         non_existent_id = Ecto.UUID.generate()
         request = Organization.DestroyRequest.new(org_id: non_existent_id)
 
         assert {:error, %GRPC.RPCError{message: message}} = Stub.destroy(channel, request)
         assert message =~ "Organization '#{non_existent_id}' not found."
-        assert_not_called(Guard.Events.OrganizationDeleted.publish(:_))
+        assert_not_called(Guard.Events.OrganizationDeleted.publish(:_, type: :soft_delete))
       end
     end
   end

--- a/guard/test/guard/store/organization_test.exs
+++ b/guard/test/guard/store/organization_test.exs
@@ -558,9 +558,6 @@ defmodule Guard.Store.OrganizationTest do
     test "marks an organization as deleted", %{org_id: org_id} do
       organization = Guard.FrontRepo.get!(Guard.FrontRepo.Organization, org_id)
 
-      contact = Support.Factories.Organization.insert_contact!(organization.id)
-      suspension = Support.Factories.Organization.insert_suspension!(organization.id)
-
       assert {:ok, deleted_org} = Organization.soft_destroy(organization)
       assert deleted_org.id == org_id
 


### PR DESCRIPTION
## 📝 Description
As a plan for making organizations restorable. We are implementing a soft-delete for them.
In another PR, a garbage collector for projects will be implemented in guard.

Main changes:
Organization GET operations only searches for orgs where deleted_at is null
Created Deleted At column to know when it was deleted for the GarbageCollector

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
