### PR TITLE
docs: Update changelog

### DIFF
--- a/docs/docs/getting-started/changelog.md
+++ b/docs/docs/getting-started/changelog.md
@@ -54,8 +54,6 @@ To learn more about this image, check our [macOS Xcode 16](https://docs.semaphor
 - Gitlfs: 3.6.0 -> 3.6.1
 - Gh: 2.63.2 -> 2.69.0
 - Geckodriver: 0.35.0 -> 0.36.0
-- Chrome: 131.0.6778.139 -> 134.0.6998.117
-- Chromedriver: 131.0.6778.139 -> 134.0.6998.117
 - Docker: 27.4.0 -> 28.0.2
 - Docker compose v2: 2.32.1 -> 2.34.0
 - Dockerize: 0.9.0 -> 0.9.3
@@ -105,8 +103,6 @@ To learn more about this image, check our [Ubuntu 20.04 page](https://docs.semap
 - Gitlfs: 3.6.0 -> 3.6.1
 - Gh: 2.63.2 -> 2.69.0
 - Geckodriver: 0.35.0 -> 0.36.0
-- Chrome: 131.0.6778.139 -> 134.0.6998.117
-- Chromedriver: 131.0.6778.139 -> 134.0.6998.117
 - Docker: 27.4.0 -> 28.0.2
 - Docker compose v2: 2.32.1 -> 2.34.0
 - Dockerize: 0.9.0 -> 0.9.3
@@ -157,8 +153,6 @@ To learn more about this image, check our [Ubuntu 22.04 page](https://docs.semap
 - Gitlfs: 3.6.0 -> 3.6.1
 - Gh: 2.63.2 -> 2.69.0
 - Geckodriver: 0.35.0 -> 0.36.0
-- Chrome: 131.0.6778.139 -> 134.0.6998.117
-- Chromedriver: 131.0.6778.139 -> 134.0.6998.117
 - Docker: 27.4.0 -> 28.0.2
 - Docker compose v2: 2.32.1 -> 2.34.0
 - Dockerize: 0.9.0 -> 0.9.3

--- a/docs/docs/reference/os-ubuntu-images/ubuntu-2004-image.md
+++ b/docs/docs/reference/os-ubuntu-images/ubuntu-2004-image.md
@@ -61,8 +61,8 @@ Following version control tools are pre-installed:
 
 - Firefox 68.9 (`68`, `esr-old`), 78.1 (`78`, `default`, `esr`), 102.11.0 (`102`, `esr-new`, `esr-latest`)
 - Geckodriver 0.36.0
-- Google Chrome 134.0.6998.117
-- ChromeDriver 134.0.6998.117
+- Google Chrome 131.0.6778.139
+- ChromeDriver 131.0.6778.139
 - Xvfb (X Virtual Framebuffer)
 - Phantomjs 2.1.1
 

--- a/docs/docs/reference/os-ubuntu-images/ubuntu-2204-image.md
+++ b/docs/docs/reference/os-ubuntu-images/ubuntu-2204-image.md
@@ -67,8 +67,8 @@ Following version control tools are pre-installed:
 
 - Firefox 102.11.0 (`102`, `default`, `esr`)
 - Geckodriver 0.36.0
-- Google Chrome 134.0.6998.117
-- ChromeDriver 134.0.6998.117
+- Google Chrome 131.0.6778.139
+- ChromeDriver 131.0.6778.139
 - Xvfb (X Virtual Framebuffer)
 - Phantomjs 2.1.1
 

--- a/docs/docs/reference/os-ubuntu-images/ubuntu-2404-image.md
+++ b/docs/docs/reference/os-ubuntu-images/ubuntu-2404-image.md
@@ -67,8 +67,8 @@ Following version control tools are pre-installed:
 
 - Firefox 102.11.0 (`102`, `default`, `esr`)
 - Geckodriver 0.36.0
-- Google Chrome 134.0.6998.117
-- ChromeDriver 134.0.6998.117
+- Google Chrome 131.0.6778.139
+- ChromeDriver 131.0.6778.139
 - Xvfb (X Virtual Framebuffer)
 - Phantomjs 2.1.1
 


### PR DESCRIPTION
## 📝 Description
<!-- Describe your changes in detail -->

- Remove Chrome updates info from docs for new image release since it was downgraded to the previous version.

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
