### PR TITLE
fix(repository_hub): Propagate error to the user

### DIFF
--- a/repository_hub/lib/repository_hub/clients/github_client.ex
+++ b/repository_hub/lib/repository_hub/clients/github_client.ex
@@ -383,13 +383,15 @@ defmodule RepositoryHub.GithubClient do
             "response: #{inspect_response(resp)}"
           ])
 
-          error_message = case payload do
-            %{"errors" => errors} when is_list(errors) ->
-              messages = errors |> Enum.map(fn %{"message" => msg} -> msg end) |> Enum.join(", ")
-              "Error while setting deploy key on GitHub. #{messages}"
-            _ ->
-              "Error while setting deploy key on GitHub. Please contact support."
-          end
+          error_message =
+            case payload do
+              %{"errors" => errors} when is_list(errors) ->
+                messages = errors |> Enum.map(fn %{"message" => msg} -> msg end) |> Enum.join(", ")
+                "Error while setting deploy key on GitHub. #{messages}"
+
+              _ ->
+                "Error while setting deploy key on GitHub. Please contact support."
+            end
 
           fail_with(:precondition, error_message)
 

--- a/repository_hub/lib/repository_hub/clients/github_client.ex
+++ b/repository_hub/lib/repository_hub/clients/github_client.ex
@@ -377,6 +377,22 @@ defmodule RepositoryHub.GithubClient do
               fail_with(:precondition, "Error while setting deploy key on GitHub. Please contact support.")
           end
 
+        {422, payload, resp} ->
+          log_warn([
+            "deploy could not be created in #{params.repo_owner}/#{params.repo_name}. Possibly due to disabled deploy keys on the repo.",
+            "response: #{inspect_response(resp)}"
+          ])
+
+          error_message = case payload do
+            %{"errors" => errors} when is_list(errors) ->
+              messages = errors |> Enum.map(fn %{"message" => msg} -> msg end) |> Enum.join(", ")
+              "Error while setting deploy key on GitHub. #{messages}"
+            _ ->
+              "Error while setting deploy key on GitHub. Please contact support."
+          end
+
+          fail_with(:precondition, error_message)
+
         {status, _, resp} ->
           log_error([
             "creating deploy key #{params.repo_owner}/#{params.repo_name}",


### PR DESCRIPTION
## 📝 Description
Since GitHub is now by default not allowing creation of deploy keys, we need to propagate the error that we get when Semaphore fails to create the deploy key.
Example of the error from GitHub:
```
%{"documentation_url" => "https://docs.github.com/rest/deploy-keys/deploy-keys#create-a-deploy-key", "errors" => [%{"code" => "custom", "message" => "Deploy keys are disabled for this repository", "resource" => "PublicKey"}], "message" => "Validation Failed", "status" => "422"}
```
This extracts the message from the errors list and propagates it to the user.

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
