### PR TITLE
docs: fix ubuntu image for F1 machines

### DIFF
--- a/docs/docs/reference/os-ubuntu-images/ubuntu-2404-image.md
+++ b/docs/docs/reference/os-ubuntu-images/ubuntu-2404-image.md
@@ -28,7 +28,7 @@ To use this operating system, and choose `ubuntu2404` in the **OS Image** select
 </TabItem>
 <TabItem value="yaml" label="YAML">
 
-To use this operating system,  you must select an [`f1-standard`] machine and use `ubuntu2204` as the `os_image`:
+To use this operating system,  you must select an [`f1-standard`] machine and use `ubuntu2404` as the `os_image`:
 
 ```yaml
 version: 1.0


### PR DESCRIPTION
## 📝 Description
Fix ubuntu image for F1 machines. The current docs advised to use the wrong version of Ubuntu on F1 machines.

See https://github.com/semaphoreio/semaphore/pull/230 for more details

## ✅ Checklist
- [X] I have tested this change
- [ ] This change requires documentation update
