### PR TITLE
Fix/guard/rename org names after soft deletion

### DIFF
--- a/guard/lib/guard/store/organization.ex
+++ b/guard/lib/guard/store/organization.ex
@@ -314,7 +314,10 @@ defmodule Guard.Store.Organization do
 
     result =
       organization
-      |> Guard.FrontRepo.Organization.changeset(%{username: soft_deleted_org_username, deleted_at: DateTime.utc_now()})
+      |> Guard.FrontRepo.Organization.changeset(%{
+        username: soft_deleted_org_username,
+        deleted_at: DateTime.utc_now()
+      })
       |> Guard.FrontRepo.update()
 
     case result do

--- a/guard/lib/guard/store/organization.ex
+++ b/guard/lib/guard/store/organization.ex
@@ -309,9 +309,12 @@ defmodule Guard.Store.Organization do
   @spec soft_destroy(Guard.FrontRepo.Organization.t()) ::
           {:ok, Guard.FrontRepo.Organization.t()} | {:error, Ecto.Changeset.t()}
   def soft_destroy(%Guard.FrontRepo.Organization{} = organization) do
+    timestamp = DateTime.utc_now() |> DateTime.to_unix(:second)
+    soft_deleted_org_username = "#{organization.username}-deleted-#{timestamp}"
+
     result =
       organization
-      |> Guard.FrontRepo.Organization.changeset(%{deleted_at: DateTime.utc_now()})
+      |> Guard.FrontRepo.Organization.changeset(%{username: soft_deleted_org_username, deleted_at: DateTime.utc_now()})
       |> Guard.FrontRepo.update()
 
     case result do

--- a/guard/test/guard/grpc_servers/organization_server_test.exs
+++ b/guard/test/guard/grpc_servers/organization_server_test.exs
@@ -1360,6 +1360,9 @@ defmodule Guard.GrpcServers.OrganizationServerTest do
         soft_deleted_org = Guard.FrontRepo.get(Guard.FrontRepo.Organization, organization.id)
         assert soft_deleted_org.deleted_at != nil
 
+        half_timestamp = Integer.floor_div(DateTime.utc_now() |> DateTime.to_unix(:second), 1000)
+        assert soft_deleted_org.username =~ "#{organization.username}-deleted-#{half_timestamp}"
+
         assert {:error, {:not_found, _message}} =
                  Guard.Store.Organization.get_by_id(soft_deleted_org.id)
 

--- a/guard/test/guard/store/organization_test.exs
+++ b/guard/test/guard/store/organization_test.exs
@@ -570,7 +570,7 @@ defmodule Guard.Store.OrganizationTest do
       assert {:error, {:not_found, _message}} =
                Organization.get_by_username(soft_deleted_org.username)
 
-      half_timestamp = (DateTime.utc_now() |> DateTime.to_unix(:second)) / 1000
+      half_timestamp = Integer.floor_div(DateTime.utc_now() |> DateTime.to_unix(:second), 1000)
       assert soft_deleted_org.username =~ "#{username}-deleted-#{half_timestamp}"
     end
   end

--- a/guard/test/guard/store/organization_test.exs
+++ b/guard/test/guard/store/organization_test.exs
@@ -557,6 +557,7 @@ defmodule Guard.Store.OrganizationTest do
   describe "soft_destroy/1" do
     test "marks an organization as deleted", %{org_id: org_id} do
       organization = Guard.FrontRepo.get!(Guard.FrontRepo.Organization, org_id)
+      username = organization.username
 
       assert {:ok, deleted_org} = Organization.soft_destroy(organization)
       assert deleted_org.id == org_id
@@ -568,6 +569,9 @@ defmodule Guard.Store.OrganizationTest do
 
       assert {:error, {:not_found, _message}} =
                Organization.get_by_username(soft_deleted_org.username)
+
+      half_timestamp = (DateTime.utc_now() |> DateTime.to_unix(:second)) / 1000
+      assert soft_deleted_org.username =~ "#{username}-deleted-#{half_timestamp}"
     end
   end
 


### PR DESCRIPTION
## 📝 Description
Rename org name when it is soft_deleted to avoid conflicting names when creating a new organization

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
