### PR TITLE
feat(deliveryhub): implement RabbitMQ events

### DIFF
--- a/ee/delivery-hub/pkg/grpc/actions/approve_stage_event.go
+++ b/ee/delivery-hub/pkg/grpc/actions/approve_stage_event.go
@@ -51,7 +51,7 @@ func ApproveStageEvent(ctx context.Context, req *pb.ApproveStageEventRequest) (*
 		return nil, err
 	}
 
-	err = messages.NewStageEventApprovedMessage(event).Publish()
+	err = messages.NewStageEventApprovedMessage(canvas.ID.String(), event).Publish()
 	if err != nil {
 		logging.ForStage(stage).Errorf("failed to publish event approved message: %v", err)
 	}

--- a/ee/delivery-hub/pkg/grpc/actions/approve_stage_event.go
+++ b/ee/delivery-hub/pkg/grpc/actions/approve_stage_event.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/grpc/actions/messages"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/logging"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
@@ -48,6 +49,11 @@ func ApproveStageEvent(ctx context.Context, req *pb.ApproveStageEventRequest) (*
 	err = event.Approve(req.RequesterId)
 	if err != nil {
 		return nil, err
+	}
+
+	err = messages.NewStageEventApprovedMessage(event).Publish()
+	if err != nil {
+		logging.ForStage(stage).Errorf("failed to publish event approved message: %v", err)
 	}
 
 	logging.ForStage(stage).Infof("event %s approved", event.ID)

--- a/ee/delivery-hub/pkg/grpc/actions/approve_stage_event_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/approve_stage_event_test.go
@@ -106,6 +106,6 @@ func Test__ApproveStageEvent(t *testing.T) {
 		assert.Equal(t, protos.StageEvent_PENDING, res.Event.State)
 		assert.NotNil(t, res.Event.CreatedAt)
 		assert.NotNil(t, res.Event.ApprovedAt)
-		assert.Equal(t, true, testconsumer.HasReceivedMessage())
+		assert.True(t, testconsumer.HasReceivedMessage())
 	})
 }

--- a/ee/delivery-hub/pkg/grpc/actions/approve_stage_event_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/approve_stage_event_test.go
@@ -83,9 +83,9 @@ func Test__ApproveStageEvent(t *testing.T) {
 	})
 
 	t.Run("stage with stage events -> approves and returns event", func(t *testing.T) {
-		amqpUrl, _ := config.RabbitMQURL()
+		amqpURL, _ := config.RabbitMQURL()
 		routingKey := fmt.Sprintf("%s.%s", "approved", r.Stage.ID.String())
-		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.StageEventExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.StageEventExchange", routingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/pkg/grpc/actions/approve_stage_event_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/approve_stage_event_test.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	uuid "github.com/google/uuid"
@@ -16,6 +15,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+const StageEventApprovedRoutingKey = "stage-event-approved"
 
 func Test__ApproveStageEvent(t *testing.T) {
 	r := support.Setup(t)
@@ -84,8 +85,7 @@ func Test__ApproveStageEvent(t *testing.T) {
 
 	t.Run("stage with stage events -> approves and returns event", func(t *testing.T) {
 		amqpURL, _ := config.RabbitMQURL()
-		routingKey := fmt.Sprintf("%s.%s", "approved", r.Stage.ID.String())
-		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.StageEventExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, StageEventApprovedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/pkg/grpc/actions/create_event_source.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_event_source.go
@@ -3,9 +3,11 @@ package actions
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/crypto"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/encryptor"
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/grpc/actions/messages"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/logging"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
@@ -49,6 +51,12 @@ func CreateEventSource(ctx context.Context, encryptor encryptor.Encryptor, req *
 	}
 
 	logger.Infof("Created event source. Request: %v", req)
+
+	err = messages.NewEventSourceCreatedMessage(eventSource).Publish()
+
+	if err != nil {
+		return nil, fmt.Errorf("error sending AMQP message: %v", err)
+	}
 
 	return response, nil
 }

--- a/ee/delivery-hub/pkg/grpc/actions/create_event_source.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_event_source.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/crypto"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/encryptor"
@@ -55,7 +54,7 @@ func CreateEventSource(ctx context.Context, encryptor encryptor.Encryptor, req *
 	err = messages.NewEventSourceCreatedMessage(eventSource).Publish()
 
 	if err != nil {
-		return nil, fmt.Errorf("error sending AMQP message: %v", err)
+		logger.Errorf("failed to publish event source created message: %v", err)
 	}
 
 	return response, nil

--- a/ee/delivery-hub/pkg/grpc/actions/create_event_source_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_event_source_test.go
@@ -36,9 +36,9 @@ func Test__CreateEventSource(t *testing.T) {
 	})
 
 	t.Run("name still not used -> event source is created", func(t *testing.T) {
-		amqpUrl, _ := config.RabbitMQURL()
+		amqpURL, _ := config.RabbitMQURL()
 		routingKey := fmt.Sprintf("%s.%s", "created", r.Canvas.ID.String())
-		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.EventSourceExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.EventSourceExchange", routingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/pkg/grpc/actions/create_event_source_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_event_source_test.go
@@ -2,12 +2,15 @@ package actions
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	uuid "github.com/google/uuid"
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/config"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/encryptor"
 	protos "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"github.com/semaphoreio/semaphore/delivery-hub/test/support"
+	testconsumer "github.com/semaphoreio/semaphore/delivery-hub/test/test_consumer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -33,6 +36,12 @@ func Test__CreateEventSource(t *testing.T) {
 	})
 
 	t.Run("name still not used -> event source is created", func(t *testing.T) {
+		amqpUrl, _ := config.RabbitMQURL()
+		routingKey := fmt.Sprintf("%s.%s", "created", r.Canvas.ID.String())
+		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.EventSourceExchange", routingKey)
+		testconsumer.Start()
+		defer testconsumer.Stop()
+
 		response, err := CreateEventSource(context.Background(), encryptor, &protos.CreateEventSourceRequest{
 			OrganizationId: r.Org.String(),
 			CanvasId:       r.Canvas.ID.String(),
@@ -48,6 +57,7 @@ func Test__CreateEventSource(t *testing.T) {
 		assert.Equal(t, "test", response.EventSource.Name)
 		assert.Equal(t, r.Org.String(), response.EventSource.OrganizationId)
 		assert.Equal(t, r.Canvas.ID.String(), response.EventSource.CanvasId)
+		assert.Equal(t, true, testconsumer.HasReceivedMessage())
 	})
 
 	t.Run("name already used -> error", func(t *testing.T) {

--- a/ee/delivery-hub/pkg/grpc/actions/create_event_source_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_event_source_test.go
@@ -57,7 +57,7 @@ func Test__CreateEventSource(t *testing.T) {
 		assert.Equal(t, "test", response.EventSource.Name)
 		assert.Equal(t, r.Org.String(), response.EventSource.OrganizationId)
 		assert.Equal(t, r.Canvas.ID.String(), response.EventSource.CanvasId)
-		assert.Equal(t, true, testconsumer.HasReceivedMessage())
+		assert.True(t, testconsumer.HasReceivedMessage())
 	})
 
 	t.Run("name already used -> error", func(t *testing.T) {

--- a/ee/delivery-hub/pkg/grpc/actions/create_event_source_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_event_source_test.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	uuid "github.com/google/uuid"
@@ -16,6 +15,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+const EventSourceCreatedRoutingKey = "event-source-created"
 
 func Test__CreateEventSource(t *testing.T) {
 	r := support.SetupWithOptions(t, support.SetupOptions{})
@@ -37,8 +38,7 @@ func Test__CreateEventSource(t *testing.T) {
 
 	t.Run("name still not used -> event source is created", func(t *testing.T) {
 		amqpURL, _ := config.RabbitMQURL()
-		routingKey := fmt.Sprintf("%s.%s", "created", r.Canvas.ID.String())
-		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.EventSourceExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, EventSourceCreatedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/pkg/grpc/actions/create_stage.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_stage.go
@@ -8,6 +8,7 @@ import (
 
 	uuid "github.com/google/uuid"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/grpc/actions/messages"
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/logging"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/grpc/codes"
@@ -62,7 +63,7 @@ func CreateStage(ctx context.Context, req *pb.CreateStageRequest) (*pb.CreateSta
 	err = messages.NewStageCreatedMessage(stage).Publish()
 
 	if err != nil {
-		return nil, fmt.Errorf("error sending AMQP message: %v", err)
+		logging.ForStage(stage).Errorf("failed to publish stage created message: %v", err)
 	}
 
 	return response, nil

--- a/ee/delivery-hub/pkg/grpc/actions/create_stage.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_stage.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	uuid "github.com/google/uuid"
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/grpc/actions/messages"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/grpc/codes"
@@ -56,6 +57,12 @@ func CreateStage(ctx context.Context, req *pb.CreateStageRequest) (*pb.CreateSta
 
 	response := &pb.CreateStageResponse{
 		Stage: serialized,
+	}
+
+	err = messages.NewStageCreatedMessage(stage).Publish()
+
+	if err != nil {
+		return nil, fmt.Errorf("error sending AMQP message: %v", err)
 	}
 
 	return response, nil

--- a/ee/delivery-hub/pkg/grpc/actions/create_stage_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_stage_test.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	uuid "github.com/google/uuid"
@@ -15,6 +14,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+const StageCreatedRoutingKey = "stage-created"
 
 func Test__CreateStage(t *testing.T) {
 	r := support.SetupWithOptions(t, support.SetupOptions{Source: true})
@@ -71,8 +72,7 @@ func Test__CreateStage(t *testing.T) {
 
 	t.Run("stage with connection with filters", func(t *testing.T) {
 		amqpURL, _ := config.RabbitMQURL()
-		routingKey := fmt.Sprintf("%s.%s", "created", r.Canvas.ID.String())
-		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.StageExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, StageCreatedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/pkg/grpc/actions/create_stage_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_stage_test.go
@@ -70,9 +70,9 @@ func Test__CreateStage(t *testing.T) {
 	})
 
 	t.Run("stage with connection with filters", func(t *testing.T) {
-		amqpUrl, _ := config.RabbitMQURL()
+		amqpURL, _ := config.RabbitMQURL()
 		routingKey := fmt.Sprintf("%s.%s", "created", r.Canvas.ID.String())
-		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.StageExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.StageExchange", routingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/pkg/grpc/actions/create_stage_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_stage_test.go
@@ -110,7 +110,7 @@ func Test__CreateStage(t *testing.T) {
 		assert.Len(t, res.Stage.Connections, 1)
 		assert.Len(t, res.Stage.Connections[0].Filters, 1)
 		assert.Equal(t, protos.Connection_FILTER_OPERATOR_AND, res.Stage.Connections[0].FilterOperator)
-		assert.Equal(t, true, testconsumer.HasReceivedMessage())
+		assert.True(t, testconsumer.HasReceivedMessage())
 	})
 
 	t.Run("stage name already used -> error", func(t *testing.T) {

--- a/ee/delivery-hub/pkg/grpc/actions/create_stage_test.go
+++ b/ee/delivery-hub/pkg/grpc/actions/create_stage_test.go
@@ -2,11 +2,14 @@ package actions
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	uuid "github.com/google/uuid"
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/config"
 	protos "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"github.com/semaphoreio/semaphore/delivery-hub/test/support"
+	testconsumer "github.com/semaphoreio/semaphore/delivery-hub/test/test_consumer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -67,6 +70,12 @@ func Test__CreateStage(t *testing.T) {
 	})
 
 	t.Run("stage with connection with filters", func(t *testing.T) {
+		amqpUrl, _ := config.RabbitMQURL()
+		routingKey := fmt.Sprintf("%s.%s", "created", r.Canvas.ID.String())
+		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.StageExchange", routingKey)
+		testconsumer.Start()
+		defer testconsumer.Stop()
+
 		runTemplate := support.ProtoRunTemplate()
 		res, err := CreateStage(context.Background(), &protos.CreateStageRequest{
 			OrganizationId: r.Org.String(),
@@ -101,6 +110,7 @@ func Test__CreateStage(t *testing.T) {
 		assert.Len(t, res.Stage.Connections, 1)
 		assert.Len(t, res.Stage.Connections[0].Filters, 1)
 		assert.Equal(t, protos.Connection_FILTER_OPERATOR_AND, res.Stage.Connections[0].FilterOperator)
+		assert.Equal(t, true, testconsumer.HasReceivedMessage())
 	})
 
 	t.Run("stage name already used -> error", func(t *testing.T) {

--- a/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
@@ -16,6 +16,7 @@ const EventSourceCreatedRoutingKey = "event-source-created"
 func NewEventSourceCreatedMessage(eventSource *models.EventSource) EventSourceCreatedMessage {
 	return EventSourceCreatedMessage{
 		message: &pb.EventSourceCreated{
+			CanvasId:  eventSource.CanvasID.String(),
 			SourceId:  eventSource.ID.String(),
 			Timestamp: timestamppb.Now(),
 		},

--- a/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
@@ -3,20 +3,25 @@ package messages
 import (
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type EventSourceCreatedMessage struct {
 	message *pb.EventSourceCreated
 }
 
+const EventSourceCreatedExchange = "DeliveryHub.EventSourceExchange"
+const EventSourceCreatedRoutingKey = "created"
+
 func NewEventSourceCreatedMessage(eventSource *models.EventSource) EventSourceCreatedMessage {
 	return EventSourceCreatedMessage{
 		message: &pb.EventSourceCreated{
-			SourceId: eventSource.ID.String(),
+			SourceId:  eventSource.ID.String(),
+			Timestamp: timestamppb.Now(),
 		},
 	}
 }
 
 func (m EventSourceCreatedMessage) Publish() error {
-	return Publish(toJSON(m.message), "created")
+	return Publish(EventSourceCreatedExchange, EventSourceCreatedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
@@ -23,5 +23,5 @@ func NewEventSourceCreatedMessage(eventSource *models.EventSource) EventSourceCr
 }
 
 func (m EventSourceCreatedMessage) Publish() error {
-	return Publish(DeliveryHubCanvasExchange, EventSourceCreatedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, EventSourceCreatedRoutingKey, toBytes(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
@@ -10,7 +10,6 @@ type EventSourceCreatedMessage struct {
 	message *pb.EventSourceCreated
 }
 
-const EventSourceCreatedExchange = "DeliveryHub.CanvasExchange"
 const EventSourceCreatedRoutingKey = "event-source-created"
 
 func NewEventSourceCreatedMessage(eventSource *models.EventSource) EventSourceCreatedMessage {
@@ -24,5 +23,5 @@ func NewEventSourceCreatedMessage(eventSource *models.EventSource) EventSourceCr
 }
 
 func (m EventSourceCreatedMessage) Publish() error {
-	return Publish(EventSourceCreatedExchange, EventSourceCreatedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, EventSourceCreatedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
@@ -1,0 +1,22 @@
+package messages
+
+import (
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
+	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
+)
+
+type EventSourceCreatedMessage struct {
+	message *pb.EventSourceCreated
+}
+
+func NewEventSourceCreatedMessage(eventSource *models.EventSource) EventSourceCreatedMessage {
+	return EventSourceCreatedMessage{
+		message: &pb.EventSourceCreated{
+			SourceId: eventSource.ID.String(),
+		},
+	}
+}
+
+func (m EventSourceCreatedMessage) Publish() error {
+	return Publish(toJSON(m.message), "created")
+}

--- a/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
@@ -1,24 +1,20 @@
 package messages
 
 import (
-	"fmt"
-
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type EventSourceCreatedMessage struct {
-	message  *pb.EventSourceCreated
-	canvasId string
+	message *pb.EventSourceCreated
 }
 
-const EventSourceCreatedExchange = "DeliveryHub.EventSourceExchange"
-const EventSourceCreatedRoutingKey = "created"
+const EventSourceCreatedExchange = "DeliveryHub.CanvasExchange"
+const EventSourceCreatedRoutingKey = "event-source-created"
 
 func NewEventSourceCreatedMessage(eventSource *models.EventSource) EventSourceCreatedMessage {
 	return EventSourceCreatedMessage{
-		canvasId: eventSource.CanvasID.String(),
 		message: &pb.EventSourceCreated{
 			SourceId:  eventSource.ID.String(),
 			Timestamp: timestamppb.Now(),
@@ -27,9 +23,5 @@ func NewEventSourceCreatedMessage(eventSource *models.EventSource) EventSourceCr
 }
 
 func (m EventSourceCreatedMessage) Publish() error {
-	return Publish(EventSourceCreatedExchange, m.BuildRoutingKey(), toJSON(m.message))
-}
-
-func (m EventSourceCreatedMessage) BuildRoutingKey() string {
-	return fmt.Sprintf("%s.%s", EventSourceCreatedRoutingKey, m.canvasId)
+	return Publish(EventSourceCreatedExchange, EventSourceCreatedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/event_source_created.go
@@ -1,13 +1,16 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type EventSourceCreatedMessage struct {
-	message *pb.EventSourceCreated
+	message  *pb.EventSourceCreated
+	canvasId string
 }
 
 const EventSourceCreatedExchange = "DeliveryHub.EventSourceExchange"
@@ -15,6 +18,7 @@ const EventSourceCreatedRoutingKey = "created"
 
 func NewEventSourceCreatedMessage(eventSource *models.EventSource) EventSourceCreatedMessage {
 	return EventSourceCreatedMessage{
+		canvasId: eventSource.CanvasID.String(),
 		message: &pb.EventSourceCreated{
 			SourceId:  eventSource.ID.String(),
 			Timestamp: timestamppb.Now(),
@@ -23,5 +27,9 @@ func NewEventSourceCreatedMessage(eventSource *models.EventSource) EventSourceCr
 }
 
 func (m EventSourceCreatedMessage) Publish() error {
-	return Publish(EventSourceCreatedExchange, EventSourceCreatedRoutingKey, toJSON(m.message))
+	return Publish(EventSourceCreatedExchange, m.BuildRoutingKey(), toJSON(m.message))
+}
+
+func (m EventSourceCreatedMessage) BuildRoutingKey() string {
+	return fmt.Sprintf("%s.%s", EventSourceCreatedRoutingKey, m.canvasId)
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
@@ -25,5 +25,5 @@ func NewExecutionCreatedMessage(canvasId string, execution *models.StageExecutio
 }
 
 func (m ExecutionCreatedMessage) Publish() error {
-	return Publish(DeliveryHubCanvasExchange, ExecutionCreatedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, ExecutionCreatedRoutingKey, toBytes(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -10,11 +12,13 @@ const ExecutionCreatedExchange = "DeliveryHub.ExecutionExchange"
 const ExecutionCreatedRoutingKey = "created"
 
 type ExecutionCreatedMessage struct {
+	stageId string
 	message *pb.StageExecutionCreated
 }
 
 func NewExecutionCreatedMessage(execution *models.StageExecution) ExecutionCreatedMessage {
 	return ExecutionCreatedMessage{
+		stageId: execution.StageID.String(),
 		message: &pb.StageExecutionCreated{
 			ExecutionId: execution.ID.String(),
 			StageId:     execution.StageID.String(),
@@ -25,5 +29,9 @@ func NewExecutionCreatedMessage(execution *models.StageExecution) ExecutionCreat
 }
 
 func (m ExecutionCreatedMessage) Publish() error {
-	return Publish(ExecutionCreatedExchange, ExecutionCreatedRoutingKey, toJSON(m.message))
+	return Publish(ExecutionCreatedExchange, m.BuildRoutingKey(), toJSON(m.message))
+}
+
+func (m ExecutionCreatedMessage) BuildRoutingKey() string {
+	return fmt.Sprintf("%s.%s", ExecutionCreatedRoutingKey, m.stageId)
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
@@ -1,0 +1,29 @@
+package messages
+
+import (
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
+	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const ExecutionCreatedExchange = "DeliveryHub.ExecutionExchange"
+const ExecutionCreatedRoutingKey = "created"
+
+type ExecutionCreatedMessage struct {
+	message *pb.StageExecutionCreated
+}
+
+func NewExecutionCreatedMessage(execution *models.StageExecution) ExecutionCreatedMessage {
+	return ExecutionCreatedMessage{
+		message: &pb.StageExecutionCreated{
+			ExecutionId: execution.ID.String(),
+			StageId:     execution.StageID.String(),
+			EventId:     execution.StageEventID.String(),
+			Timestamp:   timestamppb.Now(),
+		},
+	}
+}
+
+func (m ExecutionCreatedMessage) Publish() error {
+	return Publish(ExecutionCreatedExchange, ExecutionCreatedRoutingKey, toJSON(m.message))
+}

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
@@ -6,7 +6,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const ExecutionCreatedExchange = "DeliveryHub.CanvasExchange"
 const ExecutionCreatedRoutingKey = "execution-created"
 
 type ExecutionCreatedMessage struct {
@@ -26,5 +25,5 @@ func NewExecutionCreatedMessage(canvasId string, execution *models.StageExecutio
 }
 
 func (m ExecutionCreatedMessage) Publish() error {
-	return Publish(ExecutionCreatedExchange, ExecutionCreatedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, ExecutionCreatedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
@@ -1,24 +1,20 @@
 package messages
 
 import (
-	"fmt"
-
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const ExecutionCreatedExchange = "DeliveryHub.ExecutionExchange"
-const ExecutionCreatedRoutingKey = "created"
+const ExecutionCreatedExchange = "DeliveryHub.CanvasExchange"
+const ExecutionCreatedRoutingKey = "execution-created"
 
 type ExecutionCreatedMessage struct {
-	stageId string
 	message *pb.StageExecutionCreated
 }
 
 func NewExecutionCreatedMessage(execution *models.StageExecution) ExecutionCreatedMessage {
 	return ExecutionCreatedMessage{
-		stageId: execution.StageID.String(),
 		message: &pb.StageExecutionCreated{
 			ExecutionId: execution.ID.String(),
 			StageId:     execution.StageID.String(),
@@ -29,9 +25,5 @@ func NewExecutionCreatedMessage(execution *models.StageExecution) ExecutionCreat
 }
 
 func (m ExecutionCreatedMessage) Publish() error {
-	return Publish(ExecutionCreatedExchange, m.BuildRoutingKey(), toJSON(m.message))
-}
-
-func (m ExecutionCreatedMessage) BuildRoutingKey() string {
-	return fmt.Sprintf("%s.%s", ExecutionCreatedRoutingKey, m.stageId)
+	return Publish(ExecutionCreatedExchange, ExecutionCreatedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_created.go
@@ -13,9 +13,10 @@ type ExecutionCreatedMessage struct {
 	message *pb.StageExecutionCreated
 }
 
-func NewExecutionCreatedMessage(execution *models.StageExecution) ExecutionCreatedMessage {
+func NewExecutionCreatedMessage(canvasId string, execution *models.StageExecution) ExecutionCreatedMessage {
 	return ExecutionCreatedMessage{
 		message: &pb.StageExecutionCreated{
+			CanvasId:    canvasId,
 			ExecutionId: execution.ID.String(),
 			StageId:     execution.StageID.String(),
 			EventId:     execution.StageEventID.String(),

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
@@ -1,24 +1,20 @@
 package messages
 
 import (
-	"fmt"
-
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const ExecutionFinishedExchange = "DeliveryHub.ExecutionExchange"
-const ExecutionFinishedRoutingKey = "finished"
+const ExecutionFinishedExchange = "DeliveryHub.CanvasExchange"
+const ExecutionFinishedRoutingKey = "execution-finished"
 
 type ExecutionFinishedMessage struct {
-	stageId string
 	message *pb.StageExecutionFinished
 }
 
 func NewExecutionFinishedMessage(execution *models.StageExecution) ExecutionFinishedMessage {
 	return ExecutionFinishedMessage{
-		stageId: execution.StageID.String(),
 		message: &pb.StageExecutionFinished{
 			ExecutionId: execution.ID.String(),
 			StageId:     execution.StageID.String(),
@@ -29,9 +25,5 @@ func NewExecutionFinishedMessage(execution *models.StageExecution) ExecutionFini
 }
 
 func (m ExecutionFinishedMessage) Publish() error {
-	return Publish(ExecutionFinishedExchange, m.BuildRoutingKey(), toJSON(m.message))
-}
-
-func (m ExecutionFinishedMessage) BuildRoutingKey() string {
-	return fmt.Sprintf("%s.%s", ExecutionFinishedRoutingKey, m.stageId)
+	return Publish(ExecutionFinishedExchange, ExecutionFinishedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
@@ -13,9 +13,10 @@ type ExecutionFinishedMessage struct {
 	message *pb.StageExecutionFinished
 }
 
-func NewExecutionFinishedMessage(execution *models.StageExecution) ExecutionFinishedMessage {
+func NewExecutionFinishedMessage(canvasId string, execution *models.StageExecution) ExecutionFinishedMessage {
 	return ExecutionFinishedMessage{
 		message: &pb.StageExecutionFinished{
+			CanvasId:    canvasId,
 			ExecutionId: execution.ID.String(),
 			StageId:     execution.StageID.String(),
 			EventId:     execution.StageEventID.String(),

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
@@ -1,0 +1,29 @@
+package messages
+
+import (
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
+	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const ExecutionFinishedExchange = "DeliveryHub.ExecutionExchange"
+const ExecutionFinishedRoutingKey = "finished"
+
+type ExecutionFinishedMessage struct {
+	message *pb.StageExecutionFinished
+}
+
+func NewExecutionFinishedMessage(execution *models.StageExecution) ExecutionFinishedMessage {
+	return ExecutionFinishedMessage{
+		message: &pb.StageExecutionFinished{
+			ExecutionId: execution.ID.String(),
+			StageId:     execution.StageID.String(),
+			EventId:     execution.StageEventID.String(),
+			Timestamp:   timestamppb.Now(),
+		},
+	}
+}
+
+func (m ExecutionFinishedMessage) Publish() error {
+	return Publish(ExecutionFinishedExchange, ExecutionFinishedRoutingKey, toJSON(m.message))
+}

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
@@ -6,7 +6,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const ExecutionFinishedExchange = "DeliveryHub.CanvasExchange"
 const ExecutionFinishedRoutingKey = "execution-finished"
 
 type ExecutionFinishedMessage struct {
@@ -26,5 +25,5 @@ func NewExecutionFinishedMessage(canvasId string, execution *models.StageExecuti
 }
 
 func (m ExecutionFinishedMessage) Publish() error {
-	return Publish(ExecutionFinishedExchange, ExecutionFinishedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, ExecutionFinishedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
@@ -25,5 +25,5 @@ func NewExecutionFinishedMessage(canvasId string, execution *models.StageExecuti
 }
 
 func (m ExecutionFinishedMessage) Publish() error {
-	return Publish(DeliveryHubCanvasExchange, ExecutionFinishedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, ExecutionFinishedRoutingKey, toBytes(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_finished.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -10,11 +12,13 @@ const ExecutionFinishedExchange = "DeliveryHub.ExecutionExchange"
 const ExecutionFinishedRoutingKey = "finished"
 
 type ExecutionFinishedMessage struct {
+	stageId string
 	message *pb.StageExecutionFinished
 }
 
 func NewExecutionFinishedMessage(execution *models.StageExecution) ExecutionFinishedMessage {
 	return ExecutionFinishedMessage{
+		stageId: execution.StageID.String(),
 		message: &pb.StageExecutionFinished{
 			ExecutionId: execution.ID.String(),
 			StageId:     execution.StageID.String(),
@@ -25,5 +29,9 @@ func NewExecutionFinishedMessage(execution *models.StageExecution) ExecutionFini
 }
 
 func (m ExecutionFinishedMessage) Publish() error {
-	return Publish(ExecutionFinishedExchange, ExecutionFinishedRoutingKey, toJSON(m.message))
+	return Publish(ExecutionFinishedExchange, m.BuildRoutingKey(), toJSON(m.message))
+}
+
+func (m ExecutionFinishedMessage) BuildRoutingKey() string {
+	return fmt.Sprintf("%s.%s", ExecutionFinishedRoutingKey, m.stageId)
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
@@ -6,7 +6,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const ExecutionStartedExchange = "DeliveryHub.CanvasExchange"
 const ExecutionStartedRoutingKey = "execution-started"
 
 type ExecutionStartedMessage struct {
@@ -26,5 +25,5 @@ func NewExecutionStartedMessage(canvasId string, execution *models.StageExecutio
 }
 
 func (m ExecutionStartedMessage) Publish() error {
-	return Publish(ExecutionStartedExchange, ExecutionStartedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, ExecutionStartedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -10,11 +12,13 @@ const ExecutionStartedExchange = "DeliveryHub.ExecutionExchange"
 const ExecutionStartedRoutingKey = "started"
 
 type ExecutionStartedMessage struct {
+	stageId string
 	message *pb.StageExecutionStarted
 }
 
 func NewExecutionStartedMessage(execution *models.StageExecution) ExecutionStartedMessage {
 	return ExecutionStartedMessage{
+		stageId: execution.StageID.String(),
 		message: &pb.StageExecutionStarted{
 			ExecutionId: execution.ID.String(),
 			StageId:     execution.StageID.String(),
@@ -25,5 +29,9 @@ func NewExecutionStartedMessage(execution *models.StageExecution) ExecutionStart
 }
 
 func (m ExecutionStartedMessage) Publish() error {
-	return Publish(ExecutionStartedExchange, ExecutionStartedRoutingKey, toJSON(m.message))
+	return Publish(ExecutionStartedExchange, m.BuildRoutingKey(), toJSON(m.message))
+}
+
+func (m ExecutionStartedMessage) BuildRoutingKey() string {
+	return fmt.Sprintf("%s.%s", ExecutionStartedRoutingKey, m.stageId)
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
@@ -13,9 +13,10 @@ type ExecutionStartedMessage struct {
 	message *pb.StageExecutionStarted
 }
 
-func NewExecutionStartedMessage(execution *models.StageExecution) ExecutionStartedMessage {
+func NewExecutionStartedMessage(canvasId string, execution *models.StageExecution) ExecutionStartedMessage {
 	return ExecutionStartedMessage{
 		message: &pb.StageExecutionStarted{
+			CanvasId:    canvasId,
 			ExecutionId: execution.ID.String(),
 			StageId:     execution.StageID.String(),
 			EventId:     execution.StageEventID.String(),

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
@@ -1,0 +1,29 @@
+package messages
+
+import (
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
+	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const ExecutionStartedExchange = "DeliveryHub.ExecutionExchange"
+const ExecutionStartedRoutingKey = "started"
+
+type ExecutionStartedMessage struct {
+	message *pb.StageExecutionStarted
+}
+
+func NewExecutionStartedMessage(execution *models.StageExecution) ExecutionStartedMessage {
+	return ExecutionStartedMessage{
+		message: &pb.StageExecutionStarted{
+			ExecutionId: execution.ID.String(),
+			StageId:     execution.StageID.String(),
+			EventId:     execution.StageEventID.String(),
+			Timestamp:   timestamppb.Now(),
+		},
+	}
+}
+
+func (m ExecutionStartedMessage) Publish() error {
+	return Publish(ExecutionStartedExchange, ExecutionStartedRoutingKey, toJSON(m.message))
+}

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
@@ -25,5 +25,5 @@ func NewExecutionStartedMessage(canvasId string, execution *models.StageExecutio
 }
 
 func (m ExecutionStartedMessage) Publish() error {
-	return Publish(DeliveryHubCanvasExchange, ExecutionStartedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, ExecutionStartedRoutingKey, toBytes(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/execution_started.go
@@ -1,24 +1,20 @@
 package messages
 
 import (
-	"fmt"
-
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const ExecutionStartedExchange = "DeliveryHub.ExecutionExchange"
-const ExecutionStartedRoutingKey = "started"
+const ExecutionStartedExchange = "DeliveryHub.CanvasExchange"
+const ExecutionStartedRoutingKey = "execution-started"
 
 type ExecutionStartedMessage struct {
-	stageId string
 	message *pb.StageExecutionStarted
 }
 
 func NewExecutionStartedMessage(execution *models.StageExecution) ExecutionStartedMessage {
 	return ExecutionStartedMessage{
-		stageId: execution.StageID.String(),
 		message: &pb.StageExecutionStarted{
 			ExecutionId: execution.ID.String(),
 			StageId:     execution.StageID.String(),
@@ -29,9 +25,5 @@ func NewExecutionStartedMessage(execution *models.StageExecution) ExecutionStart
 }
 
 func (m ExecutionStartedMessage) Publish() error {
-	return Publish(ExecutionStartedExchange, m.BuildRoutingKey(), toJSON(m.message))
-}
-
-func (m ExecutionStartedMessage) BuildRoutingKey() string {
-	return fmt.Sprintf("%s.%s", ExecutionStartedRoutingKey, m.stageId)
+	return Publish(ExecutionStartedExchange, ExecutionStartedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/message_publisher.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/message_publisher.go
@@ -1,0 +1,33 @@
+package messages
+
+import (
+	"encoding/json"
+
+	"github.com/renderedtext/go-tackle"
+	config "github.com/semaphoreio/semaphore/delivery-hub/pkg/config"
+)
+
+const DeliveryHubExchange = "deliveryhub"
+
+func Publish(message []byte, routingKey string) error {
+	amqpURL, err := config.RabbitMQURL()
+
+	if err != nil {
+		return err
+	}
+
+	return tackle.PublishMessage(&tackle.PublishParams{
+		Body:       message,
+		AmqpURL:    amqpURL,
+		RoutingKey: routingKey,
+		Exchange:   DeliveryHubExchange,
+	})
+}
+
+func toJSON(m interface{}) []byte {
+	body, err := json.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	return body
+}

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
@@ -1,0 +1,22 @@
+package messages
+
+import (
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
+	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
+)
+
+type StageCreatedMessage struct {
+	message *pb.StageCreated
+}
+
+func NewStageCreatedMessage(stage *models.Stage) StageCreatedMessage {
+	return StageCreatedMessage{
+		message: &pb.StageCreated{
+			StageId: stage.ID.String(),
+		},
+	}
+}
+
+func (m StageCreatedMessage) Publish() error {
+	return Publish(toJSON(m.message), "created")
+}

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
@@ -1,24 +1,20 @@
 package messages
 
 import (
-	"fmt"
-
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const StageCreatedExchange = "DeliveryHub.StageExchange"
-const StageCreatedRoutingKey = "created"
+const StageCreatedExchange = "DeliveryHub.CanvasExchange"
+const StageCreatedRoutingKey = "stage-created"
 
 type StageCreatedMessage struct {
-	canvasId string
-	message  *pb.StageCreated
+	message *pb.StageCreated
 }
 
 func NewStageCreatedMessage(stage *models.Stage) StageCreatedMessage {
 	return StageCreatedMessage{
-		canvasId: stage.CanvasID.String(),
 		message: &pb.StageCreated{
 			StageId:   stage.ID.String(),
 			Timestamp: timestamppb.Now(),
@@ -27,9 +23,5 @@ func NewStageCreatedMessage(stage *models.Stage) StageCreatedMessage {
 }
 
 func (m StageCreatedMessage) Publish() error {
-	return Publish(StageCreatedExchange, m.BuildRoutingKey(), toJSON(m.message))
-}
-
-func (m StageCreatedMessage) BuildRoutingKey() string {
-	return fmt.Sprintf("%s.%s", StageCreatedRoutingKey, m.canvasId)
+	return Publish(StageCreatedExchange, StageCreatedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
@@ -16,6 +16,7 @@ type StageCreatedMessage struct {
 func NewStageCreatedMessage(stage *models.Stage) StageCreatedMessage {
 	return StageCreatedMessage{
 		message: &pb.StageCreated{
+			CanvasId:  stage.CanvasID.String(),
 			StageId:   stage.ID.String(),
 			Timestamp: timestamppb.Now(),
 		},

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
@@ -23,5 +23,5 @@ func NewStageCreatedMessage(stage *models.Stage) StageCreatedMessage {
 }
 
 func (m StageCreatedMessage) Publish() error {
-	return Publish(DeliveryHubCanvasExchange, StageCreatedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, StageCreatedRoutingKey, toBytes(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
@@ -3,7 +3,11 @@ package messages
 import (
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+const StageCreatedExchange = "DeliveryHub.StageExchange"
+const StageCreatedRoutingKey = "created"
 
 type StageCreatedMessage struct {
 	message *pb.StageCreated
@@ -12,11 +16,12 @@ type StageCreatedMessage struct {
 func NewStageCreatedMessage(stage *models.Stage) StageCreatedMessage {
 	return StageCreatedMessage{
 		message: &pb.StageCreated{
-			StageId: stage.ID.String(),
+			StageId:   stage.ID.String(),
+			Timestamp: timestamppb.Now(),
 		},
 	}
 }
 
 func (m StageCreatedMessage) Publish() error {
-	return Publish(toJSON(m.message), "created")
+	return Publish(StageCreatedExchange, StageCreatedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -10,11 +12,13 @@ const StageCreatedExchange = "DeliveryHub.StageExchange"
 const StageCreatedRoutingKey = "created"
 
 type StageCreatedMessage struct {
-	message *pb.StageCreated
+	canvasId string
+	message  *pb.StageCreated
 }
 
 func NewStageCreatedMessage(stage *models.Stage) StageCreatedMessage {
 	return StageCreatedMessage{
+		canvasId: stage.CanvasID.String(),
 		message: &pb.StageCreated{
 			StageId:   stage.ID.String(),
 			Timestamp: timestamppb.Now(),
@@ -23,5 +27,9 @@ func NewStageCreatedMessage(stage *models.Stage) StageCreatedMessage {
 }
 
 func (m StageCreatedMessage) Publish() error {
-	return Publish(StageCreatedExchange, StageCreatedRoutingKey, toJSON(m.message))
+	return Publish(StageCreatedExchange, m.BuildRoutingKey(), toJSON(m.message))
+}
+
+func (m StageCreatedMessage) BuildRoutingKey() string {
+	return fmt.Sprintf("%s.%s", StageCreatedRoutingKey, m.canvasId)
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_created.go
@@ -6,7 +6,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const StageCreatedExchange = "DeliveryHub.CanvasExchange"
 const StageCreatedRoutingKey = "stage-created"
 
 type StageCreatedMessage struct {
@@ -24,5 +23,5 @@ func NewStageCreatedMessage(stage *models.Stage) StageCreatedMessage {
 }
 
 func (m StageCreatedMessage) Publish() error {
-	return Publish(StageCreatedExchange, StageCreatedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, StageCreatedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
@@ -24,5 +24,5 @@ func NewStageEventApprovedMessage(canvasId string, eventSource *models.StageEven
 }
 
 func (m StageEventApprovedMessage) Publish() error {
-	return Publish(DeliveryHubCanvasExchange, StageEventApprovedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, StageEventApprovedRoutingKey, toBytes(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
@@ -13,9 +13,11 @@ type StageEventApprovedMessage struct {
 	message *pb.StageEventApproved
 }
 
-func NewStageEventApprovedMessage(eventSource *models.StageEvent) StageEventApprovedMessage {
+func NewStageEventApprovedMessage(canvasId string, eventSource *models.StageEvent) StageEventApprovedMessage {
 	return StageEventApprovedMessage{
 		message: &pb.StageEventApproved{
+			CanvasId:  canvasId,
+			StageId:   eventSource.StageID.String(),
 			EventId:   eventSource.ID.String(),
 			Timestamp: timestamppb.Now(),
 		},

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
@@ -1,24 +1,20 @@
 package messages
 
 import (
-	"fmt"
-
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const StageEventApprovedExchange = "DeliveryHub.StageEventExchange"
-const StageEventApprovedRoutingKey = "approved"
+const StageEventApprovedExchange = "DeliveryHub.CanvasExchange"
+const StageEventApprovedRoutingKey = "stage-event-approved"
 
 type StageEventApprovedMessage struct {
 	message *pb.StageEventApproved
-	stageId string
 }
 
 func NewStageEventApprovedMessage(eventSource *models.StageEvent) StageEventApprovedMessage {
 	return StageEventApprovedMessage{
-		stageId: eventSource.StageID.String(),
 		message: &pb.StageEventApproved{
 			EventId:   eventSource.ID.String(),
 			Timestamp: timestamppb.Now(),
@@ -27,9 +23,5 @@ func NewStageEventApprovedMessage(eventSource *models.StageEvent) StageEventAppr
 }
 
 func (m StageEventApprovedMessage) Publish() error {
-	return Publish(StageEventApprovedExchange, m.BuildRoutingKey(), toJSON(m.message))
-}
-
-func (m StageEventApprovedMessage) BuildRoutingKey() string {
-	return fmt.Sprintf("%s.%s", StageEventApprovedRoutingKey, m.stageId)
+	return Publish(StageEventApprovedExchange, StageEventApprovedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
@@ -1,0 +1,27 @@
+package messages
+
+import (
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
+	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const StageEventApprovedExchange = "DeliveryHub.StageEventExchange"
+const StageEventApprovedRoutingKey = "approved"
+
+type StageEventApprovedMessage struct {
+	message *pb.StageEventApproved
+}
+
+func NewStageEventApprovedMessage(eventSource *models.StageEvent) StageEventApprovedMessage {
+	return StageEventApprovedMessage{
+		message: &pb.StageEventApproved{
+			EventId:   eventSource.ID.String(),
+			Timestamp: timestamppb.Now(),
+		},
+	}
+}
+
+func (m StageEventApprovedMessage) Publish() error {
+	return Publish(StageEventApprovedExchange, StageEventApprovedRoutingKey, toJSON(m.message))
+}

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
@@ -6,7 +6,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const StageEventApprovedExchange = "DeliveryHub.CanvasExchange"
 const StageEventApprovedRoutingKey = "stage-event-approved"
 
 type StageEventApprovedMessage struct {
@@ -25,5 +24,5 @@ func NewStageEventApprovedMessage(canvasId string, eventSource *models.StageEven
 }
 
 func (m StageEventApprovedMessage) Publish() error {
-	return Publish(StageEventApprovedExchange, StageEventApprovedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, StageEventApprovedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_approved.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -11,10 +13,12 @@ const StageEventApprovedRoutingKey = "approved"
 
 type StageEventApprovedMessage struct {
 	message *pb.StageEventApproved
+	stageId string
 }
 
 func NewStageEventApprovedMessage(eventSource *models.StageEvent) StageEventApprovedMessage {
 	return StageEventApprovedMessage{
+		stageId: eventSource.StageID.String(),
 		message: &pb.StageEventApproved{
 			EventId:   eventSource.ID.String(),
 			Timestamp: timestamppb.Now(),
@@ -23,5 +27,9 @@ func NewStageEventApprovedMessage(eventSource *models.StageEvent) StageEventAppr
 }
 
 func (m StageEventApprovedMessage) Publish() error {
-	return Publish(StageEventApprovedExchange, StageEventApprovedRoutingKey, toJSON(m.message))
+	return Publish(StageEventApprovedExchange, m.BuildRoutingKey(), toJSON(m.message))
+}
+
+func (m StageEventApprovedMessage) BuildRoutingKey() string {
+	return fmt.Sprintf("%s.%s", StageEventApprovedRoutingKey, m.stageId)
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
@@ -1,0 +1,27 @@
+package messages
+
+import (
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
+	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const StageEventCreatedExchange = "DeliveryHub.StageEventExchange"
+const StageEventCreatedRoutingKey = "created"
+
+type StageEventCreatedMessage struct {
+	message *pb.StageEventCreated
+}
+
+func NewStageEventCreatedMessage(eventSource *models.StageEvent) StageEventCreatedMessage {
+	return StageEventCreatedMessage{
+		message: &pb.StageEventCreated{
+			EventId:   eventSource.ID.String(),
+			Timestamp: timestamppb.Now(),
+		},
+	}
+}
+
+func (m StageEventCreatedMessage) Publish() error {
+	return Publish(StageEventCreatedExchange, StageEventCreatedRoutingKey, toJSON(m.message))
+}

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
@@ -13,9 +13,11 @@ type StageEventCreatedMessage struct {
 	message *pb.StageEventCreated
 }
 
-func NewStageEventCreatedMessage(eventSource *models.StageEvent) StageEventCreatedMessage {
+func NewStageEventCreatedMessage(canvasId string, eventSource *models.StageEvent) StageEventCreatedMessage {
 	return StageEventCreatedMessage{
 		message: &pb.StageEventCreated{
+			CanvasId:  canvasId,
+			StageId:   eventSource.StageID.String(),
 			EventId:   eventSource.ID.String(),
 			Timestamp: timestamppb.Now(),
 		},

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
@@ -1,24 +1,20 @@
 package messages
 
 import (
-	"fmt"
-
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const StageEventCreatedExchange = "DeliveryHub.StageEventExchange"
-const StageEventCreatedRoutingKey = "created"
+const StageEventCreatedExchange = "DeliveryHub.CanvasExchange"
+const StageEventCreatedRoutingKey = "stage-event-created"
 
 type StageEventCreatedMessage struct {
 	message *pb.StageEventCreated
-	stageId string
 }
 
 func NewStageEventCreatedMessage(eventSource *models.StageEvent) StageEventCreatedMessage {
 	return StageEventCreatedMessage{
-		stageId: eventSource.StageID.String(),
 		message: &pb.StageEventCreated{
 			EventId:   eventSource.ID.String(),
 			Timestamp: timestamppb.Now(),
@@ -27,9 +23,5 @@ func NewStageEventCreatedMessage(eventSource *models.StageEvent) StageEventCreat
 }
 
 func (m StageEventCreatedMessage) Publish() error {
-	return Publish(StageEventCreatedExchange, m.BuildRoutingKey(), toJSON(m.message))
-}
-
-func (m StageEventCreatedMessage) BuildRoutingKey() string {
-	return fmt.Sprintf("%s.%s", StageEventCreatedRoutingKey, m.stageId)
+	return Publish(StageEventCreatedExchange, StageEventCreatedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
@@ -24,5 +24,5 @@ func NewStageEventCreatedMessage(canvasId string, eventSource *models.StageEvent
 }
 
 func (m StageEventCreatedMessage) Publish() error {
-	return Publish(DeliveryHubCanvasExchange, StageEventCreatedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, StageEventCreatedRoutingKey, toBytes(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
@@ -6,7 +6,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const StageEventCreatedExchange = "DeliveryHub.CanvasExchange"
 const StageEventCreatedRoutingKey = "stage-event-created"
 
 type StageEventCreatedMessage struct {
@@ -25,5 +24,5 @@ func NewStageEventCreatedMessage(canvasId string, eventSource *models.StageEvent
 }
 
 func (m StageEventCreatedMessage) Publish() error {
-	return Publish(StageEventCreatedExchange, StageEventCreatedRoutingKey, toJSON(m.message))
+	return Publish(DeliveryHubCanvasExchange, StageEventCreatedRoutingKey, toJSON(m.message))
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/stage_event_created.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pb "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/delivery"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -11,10 +13,12 @@ const StageEventCreatedRoutingKey = "created"
 
 type StageEventCreatedMessage struct {
 	message *pb.StageEventCreated
+	stageId string
 }
 
 func NewStageEventCreatedMessage(eventSource *models.StageEvent) StageEventCreatedMessage {
 	return StageEventCreatedMessage{
+		stageId: eventSource.StageID.String(),
 		message: &pb.StageEventCreated{
 			EventId:   eventSource.ID.String(),
 			Timestamp: timestamppb.Now(),
@@ -23,5 +27,9 @@ func NewStageEventCreatedMessage(eventSource *models.StageEvent) StageEventCreat
 }
 
 func (m StageEventCreatedMessage) Publish() error {
-	return Publish(StageEventCreatedExchange, StageEventCreatedRoutingKey, toJSON(m.message))
+	return Publish(StageEventCreatedExchange, m.BuildRoutingKey(), toJSON(m.message))
+}
+
+func (m StageEventCreatedMessage) BuildRoutingKey() string {
+	return fmt.Sprintf("%s.%s", StageEventCreatedRoutingKey, m.stageId)
 }

--- a/ee/delivery-hub/pkg/grpc/actions/messages/utils.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/utils.go
@@ -7,7 +7,7 @@ import (
 	config "github.com/semaphoreio/semaphore/delivery-hub/pkg/config"
 )
 
-const DeliveryHubExchange = "deliveryhub"
+const DeliveryHubCanvasExchange = "DeliveryHub.CanvasExchange"
 
 func Publish(exchange string, routingKey string, message []byte) error {
 	amqpURL, err := config.RabbitMQURL()

--- a/ee/delivery-hub/pkg/grpc/actions/messages/utils.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/utils.go
@@ -1,10 +1,10 @@
 package messages
 
 import (
-	"encoding/json"
-
 	"github.com/renderedtext/go-tackle"
 	config "github.com/semaphoreio/semaphore/delivery-hub/pkg/config"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const DeliveryHubCanvasExchange = "delivery-hub.canvas-exchange"
@@ -24,8 +24,8 @@ func Publish(exchange string, routingKey string, message []byte) error {
 	})
 }
 
-func toJSON(m interface{}) []byte {
-	body, err := json.Marshal(m)
+func toBytes(m protoreflect.ProtoMessage) []byte {
+	body, err := proto.Marshal(m)
 	if err != nil {
 		return nil
 	}

--- a/ee/delivery-hub/pkg/grpc/actions/messages/utils.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/utils.go
@@ -9,7 +9,7 @@ import (
 
 const DeliveryHubExchange = "deliveryhub"
 
-func Publish(message []byte, routingKey string) error {
+func Publish(exchange string, routingKey string, message []byte) error {
 	amqpURL, err := config.RabbitMQURL()
 
 	if err != nil {
@@ -20,7 +20,7 @@ func Publish(message []byte, routingKey string) error {
 		Body:       message,
 		AmqpURL:    amqpURL,
 		RoutingKey: routingKey,
-		Exchange:   DeliveryHubExchange,
+		Exchange:   exchange,
 	})
 }
 

--- a/ee/delivery-hub/pkg/grpc/actions/messages/utils.go
+++ b/ee/delivery-hub/pkg/grpc/actions/messages/utils.go
@@ -7,7 +7,7 @@ import (
 	config "github.com/semaphoreio/semaphore/delivery-hub/pkg/config"
 )
 
-const DeliveryHubCanvasExchange = "DeliveryHub.CanvasExchange"
+const DeliveryHubCanvasExchange = "delivery-hub.canvas-exchange"
 
 func Publish(exchange string, routingKey string, message []byte) error {
 	amqpURL, err := config.RabbitMQURL()

--- a/ee/delivery-hub/pkg/protos/delivery/delivery.pb.go
+++ b/ee/delivery-hub/pkg/protos/delivery/delivery.pb.go
@@ -2130,7 +2130,7 @@ type StageCreated struct {
 
 func (x *StageCreated) Reset() {
 	*x = StageCreated{}
-	mi := &file_delivery_proto_msgTypes[31]
+	mi := &file_delivery_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2142,7 +2142,7 @@ func (x *StageCreated) String() string {
 func (*StageCreated) ProtoMessage() {}
 
 func (x *StageCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[31]
+	mi := &file_delivery_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2154,7 +2154,7 @@ func (x *StageCreated) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{31}
+	return file_delivery_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *StageCreated) GetCanvasId() string {
@@ -2189,7 +2189,7 @@ type EventSourceCreated struct {
 
 func (x *EventSourceCreated) Reset() {
 	*x = EventSourceCreated{}
-	mi := &file_delivery_proto_msgTypes[32]
+	mi := &file_delivery_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2201,7 +2201,7 @@ func (x *EventSourceCreated) String() string {
 func (*EventSourceCreated) ProtoMessage() {}
 
 func (x *EventSourceCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[32]
+	mi := &file_delivery_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2213,7 +2213,7 @@ func (x *EventSourceCreated) ProtoReflect() protoreflect.Message {
 }
 
 func (*EventSourceCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{32}
+	return file_delivery_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *EventSourceCreated) GetCanvasId() string {
@@ -2249,7 +2249,7 @@ type StageEventCreated struct {
 
 func (x *StageEventCreated) Reset() {
 	*x = StageEventCreated{}
-	mi := &file_delivery_proto_msgTypes[33]
+	mi := &file_delivery_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2261,7 +2261,7 @@ func (x *StageEventCreated) String() string {
 func (*StageEventCreated) ProtoMessage() {}
 
 func (x *StageEventCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[33]
+	mi := &file_delivery_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2273,7 +2273,7 @@ func (x *StageEventCreated) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageEventCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{33}
+	return file_delivery_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *StageEventCreated) GetCanvasId() string {
@@ -2316,7 +2316,7 @@ type StageEventApproved struct {
 
 func (x *StageEventApproved) Reset() {
 	*x = StageEventApproved{}
-	mi := &file_delivery_proto_msgTypes[34]
+	mi := &file_delivery_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2328,7 +2328,7 @@ func (x *StageEventApproved) String() string {
 func (*StageEventApproved) ProtoMessage() {}
 
 func (x *StageEventApproved) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[34]
+	mi := &file_delivery_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2340,7 +2340,7 @@ func (x *StageEventApproved) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageEventApproved) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{34}
+	return file_delivery_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *StageEventApproved) GetCanvasId() string {
@@ -2377,7 +2377,7 @@ type StageExecutionCreated struct {
 
 func (x *StageExecutionCreated) Reset() {
 	*x = StageExecutionCreated{}
-	mi := &file_delivery_proto_msgTypes[35]
+	mi := &file_delivery_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2389,7 +2389,7 @@ func (x *StageExecutionCreated) String() string {
 func (*StageExecutionCreated) ProtoMessage() {}
 
 func (x *StageExecutionCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[35]
+	mi := &file_delivery_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2401,7 +2401,7 @@ func (x *StageExecutionCreated) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageExecutionCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{35}
+	return file_delivery_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *StageExecutionCreated) GetCanvasId() string {
@@ -2452,7 +2452,7 @@ type StageExecutionStarted struct {
 
 func (x *StageExecutionStarted) Reset() {
 	*x = StageExecutionStarted{}
-	mi := &file_delivery_proto_msgTypes[36]
+	mi := &file_delivery_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2464,7 +2464,7 @@ func (x *StageExecutionStarted) String() string {
 func (*StageExecutionStarted) ProtoMessage() {}
 
 func (x *StageExecutionStarted) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[36]
+	mi := &file_delivery_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2476,7 +2476,7 @@ func (x *StageExecutionStarted) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageExecutionStarted) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{36}
+	return file_delivery_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *StageExecutionStarted) GetCanvasId() string {
@@ -2527,7 +2527,7 @@ type StageExecutionFinished struct {
 
 func (x *StageExecutionFinished) Reset() {
 	*x = StageExecutionFinished{}
-	mi := &file_delivery_proto_msgTypes[37]
+	mi := &file_delivery_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2539,7 +2539,7 @@ func (x *StageExecutionFinished) String() string {
 func (*StageExecutionFinished) ProtoMessage() {}
 
 func (x *StageExecutionFinished) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[37]
+	mi := &file_delivery_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2551,7 +2551,7 @@ func (x *StageExecutionFinished) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageExecutionFinished) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{37}
+	return file_delivery_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *StageExecutionFinished) GetCanvasId() string {
@@ -2784,7 +2784,7 @@ func file_delivery_proto_rawDescGZIP() []byte {
 }
 
 var file_delivery_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_delivery_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_delivery_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_delivery_proto_goTypes = []any{
 	(Connection_Type)(0),                // 0: InternalApi.Delivery.Connection.Type
 	(Connection_FilterType)(0),          // 1: InternalApi.Delivery.Connection.FilterType

--- a/ee/delivery-hub/pkg/protos/delivery/delivery.pb.go
+++ b/ee/delivery-hub/pkg/protos/delivery/delivery.pb.go
@@ -2023,114 +2023,18 @@ func (x *ApproveStageEventResponse) GetEvent() *StageEvent {
 	return nil
 }
 
-type Connection_Filter struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Type          Connection_FilterType  `protobuf:"varint,1,opt,name=type,proto3,enum=InternalApi.Delivery.Connection_FilterType" json:"type,omitempty"`
-	Data          *Connection_DataFilter `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *Connection_Filter) Reset() {
-	*x = Connection_Filter{}
-	mi := &file_delivery_proto_msgTypes[29]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *Connection_Filter) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*Connection_Filter) ProtoMessage() {}
-
-func (x *Connection_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[29]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use Connection_Filter.ProtoReflect.Descriptor instead.
-func (*Connection_Filter) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{12, 0}
-}
-
-func (x *Connection_Filter) GetType() Connection_FilterType {
-	if x != nil {
-		return x.Type
-	}
-	return Connection_FILTER_TYPE_UNKNOWN
-}
-
-func (x *Connection_Filter) GetData() *Connection_DataFilter {
-	if x != nil {
-		return x.Data
-	}
-	return nil
-}
-
-type Connection_DataFilter struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Expression    string                 `protobuf:"bytes,1,opt,name=expression,proto3" json:"expression,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *Connection_DataFilter) Reset() {
-	*x = Connection_DataFilter{}
-	mi := &file_delivery_proto_msgTypes[30]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *Connection_DataFilter) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*Connection_DataFilter) ProtoMessage() {}
-
-func (x *Connection_DataFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[30]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use Connection_DataFilter.ProtoReflect.Descriptor instead.
-func (*Connection_DataFilter) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{12, 1}
-}
-
-func (x *Connection_DataFilter) GetExpression() string {
-	if x != nil {
-		return x.Expression
-	}
-	return ""
-}
-
 type StageCreated struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
-	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CanvasId      string                 `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	StageId       string                 `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	Timestamp     *timestamp.Timestamp   `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageCreated) Reset() {
 	*x = StageCreated{}
-	mi := &file_delivery_proto_msgTypes[34]
+	mi := &file_delivery_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2142,7 +2046,7 @@ func (x *StageCreated) String() string {
 func (*StageCreated) ProtoMessage() {}
 
 func (x *StageCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[34]
+	mi := &file_delivery_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2153,8 +2057,9 @@ func (x *StageCreated) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
+// Deprecated: Use StageCreated.ProtoReflect.Descriptor instead.
 func (*StageCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{34}
+	return file_delivery_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *StageCreated) GetCanvasId() string {
@@ -2179,17 +2084,17 @@ func (x *StageCreated) GetTimestamp() *timestamp.Timestamp {
 }
 
 type EventSourceCreated struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
-	SourceId      string                      `protobuf:"bytes,2,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CanvasId      string                 `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	SourceId      string                 `protobuf:"bytes,2,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
+	Timestamp     *timestamp.Timestamp   `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EventSourceCreated) Reset() {
 	*x = EventSourceCreated{}
-	mi := &file_delivery_proto_msgTypes[35]
+	mi := &file_delivery_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2201,7 +2106,7 @@ func (x *EventSourceCreated) String() string {
 func (*EventSourceCreated) ProtoMessage() {}
 
 func (x *EventSourceCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[35]
+	mi := &file_delivery_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2212,8 +2117,9 @@ func (x *EventSourceCreated) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
+// Deprecated: Use EventSourceCreated.ProtoReflect.Descriptor instead.
 func (*EventSourceCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{35}
+	return file_delivery_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *EventSourceCreated) GetCanvasId() string {
@@ -2238,18 +2144,18 @@ func (x *EventSourceCreated) GetTimestamp() *timestamp.Timestamp {
 }
 
 type StageEventCreated struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
-	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
-	EventId       string                      `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CanvasId      string                 `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	StageId       string                 `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                 `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp   `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageEventCreated) Reset() {
 	*x = StageEventCreated{}
-	mi := &file_delivery_proto_msgTypes[36]
+	mi := &file_delivery_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2261,7 +2167,7 @@ func (x *StageEventCreated) String() string {
 func (*StageEventCreated) ProtoMessage() {}
 
 func (x *StageEventCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[36]
+	mi := &file_delivery_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2272,8 +2178,9 @@ func (x *StageEventCreated) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
+// Deprecated: Use StageEventCreated.ProtoReflect.Descriptor instead.
 func (*StageEventCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{36}
+	return file_delivery_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *StageEventCreated) GetCanvasId() string {
@@ -2305,18 +2212,18 @@ func (x *StageEventCreated) GetTimestamp() *timestamp.Timestamp {
 }
 
 type StageEventApproved struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
-	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
-	EventId       string                      `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CanvasId      string                 `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	StageId       string                 `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                 `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp   `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageEventApproved) Reset() {
 	*x = StageEventApproved{}
-	mi := &file_delivery_proto_msgTypes[37]
+	mi := &file_delivery_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2328,7 +2235,7 @@ func (x *StageEventApproved) String() string {
 func (*StageEventApproved) ProtoMessage() {}
 
 func (x *StageEventApproved) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[37]
+	mi := &file_delivery_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2339,8 +2246,9 @@ func (x *StageEventApproved) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
+// Deprecated: Use StageEventApproved.ProtoReflect.Descriptor instead.
 func (*StageEventApproved) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{37}
+	return file_delivery_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *StageEventApproved) GetCanvasId() string {
@@ -2357,6 +2265,13 @@ func (x *StageEventApproved) GetStageId() string {
 	return ""
 }
 
+func (x *StageEventApproved) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
 func (x *StageEventApproved) GetTimestamp() *timestamp.Timestamp {
 	if x != nil {
 		return x.Timestamp
@@ -2365,19 +2280,19 @@ func (x *StageEventApproved) GetTimestamp() *timestamp.Timestamp {
 }
 
 type StageExecutionCreated struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
-	ExecutionId   string                      `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
-	StageId       string                      `protobuf:"bytes,3,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
-	EventId       string                      `protobuf:"bytes,4,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CanvasId      string                 `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	ExecutionId   string                 `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	StageId       string                 `protobuf:"bytes,3,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                 `protobuf:"bytes,4,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp   `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageExecutionCreated) Reset() {
 	*x = StageExecutionCreated{}
-	mi := &file_delivery_proto_msgTypes[38]
+	mi := &file_delivery_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2389,7 +2304,7 @@ func (x *StageExecutionCreated) String() string {
 func (*StageExecutionCreated) ProtoMessage() {}
 
 func (x *StageExecutionCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[38]
+	mi := &file_delivery_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2400,8 +2315,9 @@ func (x *StageExecutionCreated) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
+// Deprecated: Use StageExecutionCreated.ProtoReflect.Descriptor instead.
 func (*StageExecutionCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{38}
+	return file_delivery_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *StageExecutionCreated) GetCanvasId() string {
@@ -2440,19 +2356,19 @@ func (x *StageExecutionCreated) GetTimestamp() *timestamp.Timestamp {
 }
 
 type StageExecutionStarted struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
-	ExecutionId   string                      `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
-	StageId       string                      `protobuf:"bytes,3,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
-	EventId       string                      `protobuf:"bytes,4,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CanvasId      string                 `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	ExecutionId   string                 `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	StageId       string                 `protobuf:"bytes,3,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                 `protobuf:"bytes,4,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp   `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageExecutionStarted) Reset() {
 	*x = StageExecutionStarted{}
-	mi := &file_delivery_proto_msgTypes[39]
+	mi := &file_delivery_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2464,7 +2380,7 @@ func (x *StageExecutionStarted) String() string {
 func (*StageExecutionStarted) ProtoMessage() {}
 
 func (x *StageExecutionStarted) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[39]
+	mi := &file_delivery_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2475,8 +2391,9 @@ func (x *StageExecutionStarted) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
+// Deprecated: Use StageExecutionStarted.ProtoReflect.Descriptor instead.
 func (*StageExecutionStarted) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{39}
+	return file_delivery_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *StageExecutionStarted) GetCanvasId() string {
@@ -2515,19 +2432,19 @@ func (x *StageExecutionStarted) GetTimestamp() *timestamp.Timestamp {
 }
 
 type StageExecutionFinished struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
-	ExecutionId   string                      `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
-	StageId       string                      `protobuf:"bytes,3,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
-	EventId       string                      `protobuf:"bytes,4,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CanvasId      string                 `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	ExecutionId   string                 `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	StageId       string                 `protobuf:"bytes,3,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                 `protobuf:"bytes,4,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp   `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageExecutionFinished) Reset() {
 	*x = StageExecutionFinished{}
-	mi := &file_delivery_proto_msgTypes[40]
+	mi := &file_delivery_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2539,7 +2456,7 @@ func (x *StageExecutionFinished) String() string {
 func (*StageExecutionFinished) ProtoMessage() {}
 
 func (x *StageExecutionFinished) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[40]
+	mi := &file_delivery_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2550,8 +2467,9 @@ func (x *StageExecutionFinished) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
+// Deprecated: Use StageExecutionFinished.ProtoReflect.Descriptor instead.
 func (*StageExecutionFinished) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{40}
+	return file_delivery_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *StageExecutionFinished) GetCanvasId() string {
@@ -2587,6 +2505,102 @@ func (x *StageExecutionFinished) GetTimestamp() *timestamp.Timestamp {
 		return x.Timestamp
 	}
 	return nil
+}
+
+type Connection_Filter struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Type          Connection_FilterType  `protobuf:"varint,1,opt,name=type,proto3,enum=InternalApi.Delivery.Connection_FilterType" json:"type,omitempty"`
+	Data          *Connection_DataFilter `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Connection_Filter) Reset() {
+	*x = Connection_Filter{}
+	mi := &file_delivery_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Connection_Filter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Connection_Filter) ProtoMessage() {}
+
+func (x *Connection_Filter) ProtoReflect() protoreflect.Message {
+	mi := &file_delivery_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Connection_Filter.ProtoReflect.Descriptor instead.
+func (*Connection_Filter) Descriptor() ([]byte, []int) {
+	return file_delivery_proto_rawDescGZIP(), []int{12, 0}
+}
+
+func (x *Connection_Filter) GetType() Connection_FilterType {
+	if x != nil {
+		return x.Type
+	}
+	return Connection_FILTER_TYPE_UNKNOWN
+}
+
+func (x *Connection_Filter) GetData() *Connection_DataFilter {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+type Connection_DataFilter struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Expression    string                 `protobuf:"bytes,1,opt,name=expression,proto3" json:"expression,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Connection_DataFilter) Reset() {
+	*x = Connection_DataFilter{}
+	mi := &file_delivery_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Connection_DataFilter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Connection_DataFilter) ProtoMessage() {}
+
+func (x *Connection_DataFilter) ProtoReflect() protoreflect.Message {
+	mi := &file_delivery_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Connection_DataFilter.ProtoReflect.Descriptor instead.
+func (*Connection_DataFilter) Descriptor() ([]byte, []int) {
+	return file_delivery_proto_rawDescGZIP(), []int{12, 1}
+}
+
+func (x *Connection_DataFilter) GetExpression() string {
+	if x != nil {
+		return x.Expression
+	}
+	return ""
 }
 
 var File_delivery_proto protoreflect.FileDescriptor
@@ -2756,7 +2770,43 @@ const file_delivery_proto_rawDesc = "" +
 	"\bevent_id\x18\x04 \x01(\tR\aeventId\x12!\n" +
 	"\frequester_id\x18\x05 \x01(\tR\vrequesterId\"S\n" +
 	"\x19ApproveStageEventResponse\x126\n" +
-	"\x05event\x18\x01 \x01(\v2 .InternalApi.Delivery.StageEventR\x05event2\xbc\t\n" +
+	"\x05event\x18\x01 \x01(\v2 .InternalApi.Delivery.StageEventR\x05event\"\x80\x01\n" +
+	"\fStageCreated\x12\x1b\n" +
+	"\tcanvas_id\x18\x01 \x01(\tR\bcanvasId\x12\x19\n" +
+	"\bstage_id\x18\x02 \x01(\tR\astageId\x128\n" +
+	"\ttimestamp\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\x88\x01\n" +
+	"\x12EventSourceCreated\x12\x1b\n" +
+	"\tcanvas_id\x18\x01 \x01(\tR\bcanvasId\x12\x1b\n" +
+	"\tsource_id\x18\x02 \x01(\tR\bsourceId\x128\n" +
+	"\ttimestamp\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xa0\x01\n" +
+	"\x11StageEventCreated\x12\x1b\n" +
+	"\tcanvas_id\x18\x01 \x01(\tR\bcanvasId\x12\x19\n" +
+	"\bstage_id\x18\x02 \x01(\tR\astageId\x12\x19\n" +
+	"\bevent_id\x18\x03 \x01(\tR\aeventId\x128\n" +
+	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xa1\x01\n" +
+	"\x12StageEventApproved\x12\x1b\n" +
+	"\tcanvas_id\x18\x01 \x01(\tR\bcanvasId\x12\x19\n" +
+	"\bstage_id\x18\x02 \x01(\tR\astageId\x12\x19\n" +
+	"\bevent_id\x18\x03 \x01(\tR\aeventId\x128\n" +
+	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xc7\x01\n" +
+	"\x15StageExecutionCreated\x12\x1b\n" +
+	"\tcanvas_id\x18\x01 \x01(\tR\bcanvasId\x12!\n" +
+	"\fexecution_id\x18\x02 \x01(\tR\vexecutionId\x12\x19\n" +
+	"\bstage_id\x18\x03 \x01(\tR\astageId\x12\x19\n" +
+	"\bevent_id\x18\x04 \x01(\tR\aeventId\x128\n" +
+	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xc7\x01\n" +
+	"\x15StageExecutionStarted\x12\x1b\n" +
+	"\tcanvas_id\x18\x01 \x01(\tR\bcanvasId\x12!\n" +
+	"\fexecution_id\x18\x02 \x01(\tR\vexecutionId\x12\x19\n" +
+	"\bstage_id\x18\x03 \x01(\tR\astageId\x12\x19\n" +
+	"\bevent_id\x18\x04 \x01(\tR\aeventId\x128\n" +
+	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xc8\x01\n" +
+	"\x16StageExecutionFinished\x12\x1b\n" +
+	"\tcanvas_id\x18\x01 \x01(\tR\bcanvasId\x12!\n" +
+	"\fexecution_id\x18\x02 \x01(\tR\vexecutionId\x12\x19\n" +
+	"\bstage_id\x18\x03 \x01(\tR\astageId\x12\x19\n" +
+	"\bevent_id\x18\x04 \x01(\tR\aeventId\x128\n" +
+	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp2\xbc\t\n" +
 	"\bDelivery\x12e\n" +
 	"\fCreateCanvas\x12).InternalApi.Delivery.CreateCanvasRequest\x1a*.InternalApi.Delivery.CreateCanvasResponse\x12t\n" +
 	"\x11CreateEventSource\x12..InternalApi.Delivery.CreateEventSourceRequest\x1a/.InternalApi.Delivery.CreateEventSourceResponse\x12b\n" +
@@ -2784,7 +2834,7 @@ func file_delivery_proto_rawDescGZIP() []byte {
 }
 
 var file_delivery_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_delivery_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+var file_delivery_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_delivery_proto_goTypes = []any{
 	(Connection_Type)(0),                // 0: InternalApi.Delivery.Connection.Type
 	(Connection_FilterType)(0),          // 1: InternalApi.Delivery.Connection.FilterType
@@ -2820,30 +2870,37 @@ var file_delivery_proto_goTypes = []any{
 	(*StageEvent)(nil),                  // 31: InternalApi.Delivery.StageEvent
 	(*ApproveStageEventRequest)(nil),    // 32: InternalApi.Delivery.ApproveStageEventRequest
 	(*ApproveStageEventResponse)(nil),   // 33: InternalApi.Delivery.ApproveStageEventResponse
-	(*Connection_Filter)(nil),           // 34: InternalApi.Delivery.Connection.Filter
-	(*Connection_DataFilter)(nil),       // 35: InternalApi.Delivery.Connection.DataFilter
-	nil,                                 // 36: InternalApi.Delivery.SemaphoreRunTemplate.ParametersEntry
-	(*timestamp.Timestamp)(nil),         // 37: google.protobuf.Timestamp
+	(*StageCreated)(nil),                // 34: InternalApi.Delivery.StageCreated
+	(*EventSourceCreated)(nil),          // 35: InternalApi.Delivery.EventSourceCreated
+	(*StageEventCreated)(nil),           // 36: InternalApi.Delivery.StageEventCreated
+	(*StageEventApproved)(nil),          // 37: InternalApi.Delivery.StageEventApproved
+	(*StageExecutionCreated)(nil),       // 38: InternalApi.Delivery.StageExecutionCreated
+	(*StageExecutionStarted)(nil),       // 39: InternalApi.Delivery.StageExecutionStarted
+	(*StageExecutionFinished)(nil),      // 40: InternalApi.Delivery.StageExecutionFinished
+	(*Connection_Filter)(nil),           // 41: InternalApi.Delivery.Connection.Filter
+	(*Connection_DataFilter)(nil),       // 42: InternalApi.Delivery.Connection.DataFilter
+	nil,                                 // 43: InternalApi.Delivery.SemaphoreRunTemplate.ParametersEntry
+	(*timestamp.Timestamp)(nil),         // 44: google.protobuf.Timestamp
 }
 var file_delivery_proto_depIdxs = []int32{
-	37, // 0: InternalApi.Delivery.Canvas.created_at:type_name -> google.protobuf.Timestamp
+	44, // 0: InternalApi.Delivery.Canvas.created_at:type_name -> google.protobuf.Timestamp
 	5,  // 1: InternalApi.Delivery.CreateCanvasResponse.canvas:type_name -> InternalApi.Delivery.Canvas
 	5,  // 2: InternalApi.Delivery.DescribeCanvasResponse.canvas:type_name -> InternalApi.Delivery.Canvas
-	37, // 3: InternalApi.Delivery.EventSource.created_at:type_name -> google.protobuf.Timestamp
+	44, // 3: InternalApi.Delivery.EventSource.created_at:type_name -> google.protobuf.Timestamp
 	18, // 4: InternalApi.Delivery.DescribeStageResponse.stage:type_name -> InternalApi.Delivery.Stage
 	10, // 5: InternalApi.Delivery.CreateEventSourceResponse.event_source:type_name -> InternalApi.Delivery.EventSource
 	10, // 6: InternalApi.Delivery.DescribeEventSourceResponse.event_source:type_name -> InternalApi.Delivery.EventSource
 	0,  // 7: InternalApi.Delivery.Connection.type:type_name -> InternalApi.Delivery.Connection.Type
-	34, // 8: InternalApi.Delivery.Connection.filters:type_name -> InternalApi.Delivery.Connection.Filter
+	41, // 8: InternalApi.Delivery.Connection.filters:type_name -> InternalApi.Delivery.Connection.Filter
 	2,  // 9: InternalApi.Delivery.Connection.filter_operator:type_name -> InternalApi.Delivery.Connection.FilterOperator
-	37, // 10: InternalApi.Delivery.Stage.created_at:type_name -> google.protobuf.Timestamp
+	44, // 10: InternalApi.Delivery.Stage.created_at:type_name -> google.protobuf.Timestamp
 	17, // 11: InternalApi.Delivery.Stage.connections:type_name -> InternalApi.Delivery.Connection
 	20, // 12: InternalApi.Delivery.Stage.run_template:type_name -> InternalApi.Delivery.RunTemplate
 	17, // 13: InternalApi.Delivery.CreateStageRequest.connections:type_name -> InternalApi.Delivery.Connection
 	20, // 14: InternalApi.Delivery.CreateStageRequest.run_template:type_name -> InternalApi.Delivery.RunTemplate
 	3,  // 15: InternalApi.Delivery.RunTemplate.type:type_name -> InternalApi.Delivery.RunTemplate.Type
 	21, // 16: InternalApi.Delivery.RunTemplate.semaphore:type_name -> InternalApi.Delivery.SemaphoreRunTemplate
-	36, // 17: InternalApi.Delivery.SemaphoreRunTemplate.parameters:type_name -> InternalApi.Delivery.SemaphoreRunTemplate.ParametersEntry
+	43, // 17: InternalApi.Delivery.SemaphoreRunTemplate.parameters:type_name -> InternalApi.Delivery.SemaphoreRunTemplate.ParametersEntry
 	18, // 18: InternalApi.Delivery.CreateStageResponse.stage:type_name -> InternalApi.Delivery.Stage
 	17, // 19: InternalApi.Delivery.UpdateStageRequest.connections:type_name -> InternalApi.Delivery.Connection
 	18, // 20: InternalApi.Delivery.UpdateStageResponse.stage:type_name -> InternalApi.Delivery.Stage
@@ -2853,38 +2910,45 @@ var file_delivery_proto_depIdxs = []int32{
 	31, // 24: InternalApi.Delivery.ListStageEventsResponse.events:type_name -> InternalApi.Delivery.StageEvent
 	0,  // 25: InternalApi.Delivery.StageEvent.source_type:type_name -> InternalApi.Delivery.Connection.Type
 	4,  // 26: InternalApi.Delivery.StageEvent.state:type_name -> InternalApi.Delivery.StageEvent.State
-	37, // 27: InternalApi.Delivery.StageEvent.created_at:type_name -> google.protobuf.Timestamp
-	37, // 28: InternalApi.Delivery.StageEvent.approved_at:type_name -> google.protobuf.Timestamp
+	44, // 27: InternalApi.Delivery.StageEvent.created_at:type_name -> google.protobuf.Timestamp
+	44, // 28: InternalApi.Delivery.StageEvent.approved_at:type_name -> google.protobuf.Timestamp
 	31, // 29: InternalApi.Delivery.ApproveStageEventResponse.event:type_name -> InternalApi.Delivery.StageEvent
-	1,  // 30: InternalApi.Delivery.Connection.Filter.type:type_name -> InternalApi.Delivery.Connection.FilterType
-	35, // 31: InternalApi.Delivery.Connection.Filter.data:type_name -> InternalApi.Delivery.Connection.DataFilter
-	6,  // 32: InternalApi.Delivery.Delivery.CreateCanvas:input_type -> InternalApi.Delivery.CreateCanvasRequest
-	13, // 33: InternalApi.Delivery.Delivery.CreateEventSource:input_type -> InternalApi.Delivery.CreateEventSourceRequest
-	19, // 34: InternalApi.Delivery.Delivery.CreateStage:input_type -> InternalApi.Delivery.CreateStageRequest
-	8,  // 35: InternalApi.Delivery.Delivery.DescribeCanvas:input_type -> InternalApi.Delivery.DescribeCanvasRequest
-	11, // 36: InternalApi.Delivery.Delivery.DescribeStage:input_type -> InternalApi.Delivery.DescribeStageRequest
-	15, // 37: InternalApi.Delivery.Delivery.DescribeEventSource:input_type -> InternalApi.Delivery.DescribeEventSourceRequest
-	25, // 38: InternalApi.Delivery.Delivery.ListStages:input_type -> InternalApi.Delivery.ListStagesRequest
-	27, // 39: InternalApi.Delivery.Delivery.ListEventSources:input_type -> InternalApi.Delivery.ListEventSourcesRequest
-	29, // 40: InternalApi.Delivery.Delivery.ListStageEvents:input_type -> InternalApi.Delivery.ListStageEventsRequest
-	23, // 41: InternalApi.Delivery.Delivery.UpdateStage:input_type -> InternalApi.Delivery.UpdateStageRequest
-	32, // 42: InternalApi.Delivery.Delivery.ApproveStageEvent:input_type -> InternalApi.Delivery.ApproveStageEventRequest
-	7,  // 43: InternalApi.Delivery.Delivery.CreateCanvas:output_type -> InternalApi.Delivery.CreateCanvasResponse
-	14, // 44: InternalApi.Delivery.Delivery.CreateEventSource:output_type -> InternalApi.Delivery.CreateEventSourceResponse
-	22, // 45: InternalApi.Delivery.Delivery.CreateStage:output_type -> InternalApi.Delivery.CreateStageResponse
-	9,  // 46: InternalApi.Delivery.Delivery.DescribeCanvas:output_type -> InternalApi.Delivery.DescribeCanvasResponse
-	12, // 47: InternalApi.Delivery.Delivery.DescribeStage:output_type -> InternalApi.Delivery.DescribeStageResponse
-	16, // 48: InternalApi.Delivery.Delivery.DescribeEventSource:output_type -> InternalApi.Delivery.DescribeEventSourceResponse
-	26, // 49: InternalApi.Delivery.Delivery.ListStages:output_type -> InternalApi.Delivery.ListStagesResponse
-	28, // 50: InternalApi.Delivery.Delivery.ListEventSources:output_type -> InternalApi.Delivery.ListEventSourcesResponse
-	30, // 51: InternalApi.Delivery.Delivery.ListStageEvents:output_type -> InternalApi.Delivery.ListStageEventsResponse
-	24, // 52: InternalApi.Delivery.Delivery.UpdateStage:output_type -> InternalApi.Delivery.UpdateStageResponse
-	33, // 53: InternalApi.Delivery.Delivery.ApproveStageEvent:output_type -> InternalApi.Delivery.ApproveStageEventResponse
-	43, // [43:54] is the sub-list for method output_type
-	32, // [32:43] is the sub-list for method input_type
-	32, // [32:32] is the sub-list for extension type_name
-	32, // [32:32] is the sub-list for extension extendee
-	0,  // [0:32] is the sub-list for field type_name
+	44, // 30: InternalApi.Delivery.StageCreated.timestamp:type_name -> google.protobuf.Timestamp
+	44, // 31: InternalApi.Delivery.EventSourceCreated.timestamp:type_name -> google.protobuf.Timestamp
+	44, // 32: InternalApi.Delivery.StageEventCreated.timestamp:type_name -> google.protobuf.Timestamp
+	44, // 33: InternalApi.Delivery.StageEventApproved.timestamp:type_name -> google.protobuf.Timestamp
+	44, // 34: InternalApi.Delivery.StageExecutionCreated.timestamp:type_name -> google.protobuf.Timestamp
+	44, // 35: InternalApi.Delivery.StageExecutionStarted.timestamp:type_name -> google.protobuf.Timestamp
+	44, // 36: InternalApi.Delivery.StageExecutionFinished.timestamp:type_name -> google.protobuf.Timestamp
+	1,  // 37: InternalApi.Delivery.Connection.Filter.type:type_name -> InternalApi.Delivery.Connection.FilterType
+	42, // 38: InternalApi.Delivery.Connection.Filter.data:type_name -> InternalApi.Delivery.Connection.DataFilter
+	6,  // 39: InternalApi.Delivery.Delivery.CreateCanvas:input_type -> InternalApi.Delivery.CreateCanvasRequest
+	13, // 40: InternalApi.Delivery.Delivery.CreateEventSource:input_type -> InternalApi.Delivery.CreateEventSourceRequest
+	19, // 41: InternalApi.Delivery.Delivery.CreateStage:input_type -> InternalApi.Delivery.CreateStageRequest
+	8,  // 42: InternalApi.Delivery.Delivery.DescribeCanvas:input_type -> InternalApi.Delivery.DescribeCanvasRequest
+	11, // 43: InternalApi.Delivery.Delivery.DescribeStage:input_type -> InternalApi.Delivery.DescribeStageRequest
+	15, // 44: InternalApi.Delivery.Delivery.DescribeEventSource:input_type -> InternalApi.Delivery.DescribeEventSourceRequest
+	25, // 45: InternalApi.Delivery.Delivery.ListStages:input_type -> InternalApi.Delivery.ListStagesRequest
+	27, // 46: InternalApi.Delivery.Delivery.ListEventSources:input_type -> InternalApi.Delivery.ListEventSourcesRequest
+	29, // 47: InternalApi.Delivery.Delivery.ListStageEvents:input_type -> InternalApi.Delivery.ListStageEventsRequest
+	23, // 48: InternalApi.Delivery.Delivery.UpdateStage:input_type -> InternalApi.Delivery.UpdateStageRequest
+	32, // 49: InternalApi.Delivery.Delivery.ApproveStageEvent:input_type -> InternalApi.Delivery.ApproveStageEventRequest
+	7,  // 50: InternalApi.Delivery.Delivery.CreateCanvas:output_type -> InternalApi.Delivery.CreateCanvasResponse
+	14, // 51: InternalApi.Delivery.Delivery.CreateEventSource:output_type -> InternalApi.Delivery.CreateEventSourceResponse
+	22, // 52: InternalApi.Delivery.Delivery.CreateStage:output_type -> InternalApi.Delivery.CreateStageResponse
+	9,  // 53: InternalApi.Delivery.Delivery.DescribeCanvas:output_type -> InternalApi.Delivery.DescribeCanvasResponse
+	12, // 54: InternalApi.Delivery.Delivery.DescribeStage:output_type -> InternalApi.Delivery.DescribeStageResponse
+	16, // 55: InternalApi.Delivery.Delivery.DescribeEventSource:output_type -> InternalApi.Delivery.DescribeEventSourceResponse
+	26, // 56: InternalApi.Delivery.Delivery.ListStages:output_type -> InternalApi.Delivery.ListStagesResponse
+	28, // 57: InternalApi.Delivery.Delivery.ListEventSources:output_type -> InternalApi.Delivery.ListEventSourcesResponse
+	30, // 58: InternalApi.Delivery.Delivery.ListStageEvents:output_type -> InternalApi.Delivery.ListStageEventsResponse
+	24, // 59: InternalApi.Delivery.Delivery.UpdateStage:output_type -> InternalApi.Delivery.UpdateStageResponse
+	33, // 60: InternalApi.Delivery.Delivery.ApproveStageEvent:output_type -> InternalApi.Delivery.ApproveStageEventResponse
+	50, // [50:61] is the sub-list for method output_type
+	39, // [39:50] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_delivery_proto_init() }
@@ -2898,7 +2962,7 @@ func file_delivery_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_delivery_proto_rawDesc), len(file_delivery_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   32,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/ee/delivery-hub/pkg/protos/delivery/delivery.pb.go
+++ b/ee/delivery-hub/pkg/protos/delivery/delivery.pb.go
@@ -2121,15 +2121,16 @@ func (x *Connection_DataFilter) GetExpression() string {
 
 type StageCreated struct {
 	state         protoimpl.MessageState      `protogen:"open.v1"`
-	StageId       string                      `protobuf:"bytes,1,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageCreated) Reset() {
 	*x = StageCreated{}
-	mi := &file_delivery_proto_msgTypes[34] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2141,7 +2142,7 @@ func (x *StageCreated) String() string {
 func (*StageCreated) ProtoMessage() {}
 
 func (x *StageCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[34] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2153,7 +2154,14 @@ func (x *StageCreated) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{34} // Ajuste este índice conforme necessário
+	return file_delivery_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *StageCreated) GetCanvasId() string {
+	if x != nil {
+		return x.CanvasId
+	}
+	return ""
 }
 
 func (x *StageCreated) GetStageId() string {
@@ -2172,15 +2180,16 @@ func (x *StageCreated) GetTimestamp() *timestamp.Timestamp {
 
 type EventSourceCreated struct {
 	state         protoimpl.MessageState      `protogen:"open.v1"`
-	SourceId      string                      `protobuf:"bytes,1,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	SourceId      string                      `protobuf:"bytes,2,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EventSourceCreated) Reset() {
 	*x = EventSourceCreated{}
-	mi := &file_delivery_proto_msgTypes[35] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2192,7 +2201,7 @@ func (x *EventSourceCreated) String() string {
 func (*EventSourceCreated) ProtoMessage() {}
 
 func (x *EventSourceCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[35] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2204,7 +2213,14 @@ func (x *EventSourceCreated) ProtoReflect() protoreflect.Message {
 }
 
 func (*EventSourceCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{35} // Ajuste este índice conforme necessário
+	return file_delivery_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *EventSourceCreated) GetCanvasId() string {
+	if x != nil {
+		return x.CanvasId
+	}
+	return ""
 }
 
 func (x *EventSourceCreated) GetSourceId() string {
@@ -2223,15 +2239,17 @@ func (x *EventSourceCreated) GetTimestamp() *timestamp.Timestamp {
 
 type StageEventCreated struct {
 	state         protoimpl.MessageState      `protogen:"open.v1"`
-	EventId       string                      `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                      `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageEventCreated) Reset() {
 	*x = StageEventCreated{}
-	mi := &file_delivery_proto_msgTypes[36] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2243,7 +2261,7 @@ func (x *StageEventCreated) String() string {
 func (*StageEventCreated) ProtoMessage() {}
 
 func (x *StageEventCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[36] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2255,7 +2273,21 @@ func (x *StageEventCreated) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageEventCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{36} // Ajuste este índice conforme necessário
+	return file_delivery_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *StageEventCreated) GetCanvasId() string {
+	if x != nil {
+		return x.CanvasId
+	}
+	return ""
+}
+
+func (x *StageEventCreated) GetStageId() string {
+	if x != nil {
+		return x.StageId
+	}
+	return ""
 }
 
 func (x *StageEventCreated) GetEventId() string {
@@ -2274,15 +2306,17 @@ func (x *StageEventCreated) GetTimestamp() *timestamp.Timestamp {
 
 type StageEventApproved struct {
 	state         protoimpl.MessageState      `protogen:"open.v1"`
-	EventId       string                      `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                      `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageEventApproved) Reset() {
 	*x = StageEventApproved{}
-	mi := &file_delivery_proto_msgTypes[37] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2294,7 +2328,7 @@ func (x *StageEventApproved) String() string {
 func (*StageEventApproved) ProtoMessage() {}
 
 func (x *StageEventApproved) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[37] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2306,12 +2340,19 @@ func (x *StageEventApproved) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageEventApproved) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{37} // Ajuste este índice conforme necessário
+	return file_delivery_proto_rawDescGZIP(), []int{34}
 }
 
-func (x *StageEventApproved) GetEventId() string {
+func (x *StageEventApproved) GetCanvasId() string {
 	if x != nil {
-		return x.EventId
+		return x.CanvasId
+	}
+	return ""
+}
+
+func (x *StageEventApproved) GetStageId() string {
+	if x != nil {
+		return x.StageId
 	}
 	return ""
 }
@@ -2325,17 +2366,18 @@ func (x *StageEventApproved) GetTimestamp() *timestamp.Timestamp {
 
 type StageExecutionCreated struct {
 	state         protoimpl.MessageState      `protogen:"open.v1"`
-	ExecutionId   string                      `protobuf:"bytes,1,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
-	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
-	EventId       string                      `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	ExecutionId   string                      `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	StageId       string                      `protobuf:"bytes,3,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                      `protobuf:"bytes,4,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageExecutionCreated) Reset() {
 	*x = StageExecutionCreated{}
-	mi := &file_delivery_proto_msgTypes[38] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2347,7 +2389,7 @@ func (x *StageExecutionCreated) String() string {
 func (*StageExecutionCreated) ProtoMessage() {}
 
 func (x *StageExecutionCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[38] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2359,7 +2401,14 @@ func (x *StageExecutionCreated) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageExecutionCreated) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{38} // Ajuste este índice conforme necessário
+	return file_delivery_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *StageExecutionCreated) GetCanvasId() string {
+	if x != nil {
+		return x.CanvasId
+	}
+	return ""
 }
 
 func (x *StageExecutionCreated) GetExecutionId() string {
@@ -2392,17 +2441,18 @@ func (x *StageExecutionCreated) GetTimestamp() *timestamp.Timestamp {
 
 type StageExecutionStarted struct {
 	state         protoimpl.MessageState      `protogen:"open.v1"`
-	ExecutionId   string                      `protobuf:"bytes,1,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
-	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
-	EventId       string                      `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	ExecutionId   string                      `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	StageId       string                      `protobuf:"bytes,3,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                      `protobuf:"bytes,4,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageExecutionStarted) Reset() {
 	*x = StageExecutionStarted{}
-	mi := &file_delivery_proto_msgTypes[39] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2414,7 +2464,7 @@ func (x *StageExecutionStarted) String() string {
 func (*StageExecutionStarted) ProtoMessage() {}
 
 func (x *StageExecutionStarted) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[39] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2426,7 +2476,14 @@ func (x *StageExecutionStarted) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageExecutionStarted) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{39} // Ajuste este índice conforme necessário
+	return file_delivery_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *StageExecutionStarted) GetCanvasId() string {
+	if x != nil {
+		return x.CanvasId
+	}
+	return ""
 }
 
 func (x *StageExecutionStarted) GetExecutionId() string {
@@ -2459,17 +2516,18 @@ func (x *StageExecutionStarted) GetTimestamp() *timestamp.Timestamp {
 
 type StageExecutionFinished struct {
 	state         protoimpl.MessageState      `protogen:"open.v1"`
-	ExecutionId   string                      `protobuf:"bytes,1,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
-	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
-	EventId       string                      `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	CanvasId      string                      `protobuf:"bytes,1,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	ExecutionId   string                      `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	StageId       string                      `protobuf:"bytes,3,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                      `protobuf:"bytes,4,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StageExecutionFinished) Reset() {
 	*x = StageExecutionFinished{}
-	mi := &file_delivery_proto_msgTypes[40] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2481,7 +2539,7 @@ func (x *StageExecutionFinished) String() string {
 func (*StageExecutionFinished) ProtoMessage() {}
 
 func (x *StageExecutionFinished) ProtoReflect() protoreflect.Message {
-	mi := &file_delivery_proto_msgTypes[40] // Ajuste este índice conforme necessário
+	mi := &file_delivery_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2493,7 +2551,14 @@ func (x *StageExecutionFinished) ProtoReflect() protoreflect.Message {
 }
 
 func (*StageExecutionFinished) Descriptor() ([]byte, []int) {
-	return file_delivery_proto_rawDescGZIP(), []int{40} // Ajuste este índice conforme necessário
+	return file_delivery_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *StageExecutionFinished) GetCanvasId() string {
+	if x != nil {
+		return x.CanvasId
+	}
+	return ""
 }
 
 func (x *StageExecutionFinished) GetExecutionId() string {
@@ -2719,7 +2784,7 @@ func file_delivery_proto_rawDescGZIP() []byte {
 }
 
 var file_delivery_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_delivery_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+var file_delivery_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_delivery_proto_goTypes = []any{
 	(Connection_Type)(0),                // 0: InternalApi.Delivery.Connection.Type
 	(Connection_FilterType)(0),          // 1: InternalApi.Delivery.Connection.FilterType

--- a/ee/delivery-hub/pkg/protos/delivery/delivery.pb.go
+++ b/ee/delivery-hub/pkg/protos/delivery/delivery.pb.go
@@ -2119,6 +2119,411 @@ func (x *Connection_DataFilter) GetExpression() string {
 	return ""
 }
 
+type StageCreated struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	StageId       string                      `protobuf:"bytes,1,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StageCreated) Reset() {
+	*x = StageCreated{}
+	mi := &file_delivery_proto_msgTypes[34] // Ajuste este índice conforme necessário
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StageCreated) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StageCreated) ProtoMessage() {}
+
+func (x *StageCreated) ProtoReflect() protoreflect.Message {
+	mi := &file_delivery_proto_msgTypes[34] // Ajuste este índice conforme necessário
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (*StageCreated) Descriptor() ([]byte, []int) {
+	return file_delivery_proto_rawDescGZIP(), []int{34} // Ajuste este índice conforme necessário
+}
+
+func (x *StageCreated) GetStageId() string {
+	if x != nil {
+		return x.StageId
+	}
+	return ""
+}
+
+func (x *StageCreated) GetTimestamp() *timestamp.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+type EventSourceCreated struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	SourceId      string                      `protobuf:"bytes,1,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EventSourceCreated) Reset() {
+	*x = EventSourceCreated{}
+	mi := &file_delivery_proto_msgTypes[35] // Ajuste este índice conforme necessário
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EventSourceCreated) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EventSourceCreated) ProtoMessage() {}
+
+func (x *EventSourceCreated) ProtoReflect() protoreflect.Message {
+	mi := &file_delivery_proto_msgTypes[35] // Ajuste este índice conforme necessário
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (*EventSourceCreated) Descriptor() ([]byte, []int) {
+	return file_delivery_proto_rawDescGZIP(), []int{35} // Ajuste este índice conforme necessário
+}
+
+func (x *EventSourceCreated) GetSourceId() string {
+	if x != nil {
+		return x.SourceId
+	}
+	return ""
+}
+
+func (x *EventSourceCreated) GetTimestamp() *timestamp.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+type StageEventCreated struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	EventId       string                      `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StageEventCreated) Reset() {
+	*x = StageEventCreated{}
+	mi := &file_delivery_proto_msgTypes[36] // Ajuste este índice conforme necessário
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StageEventCreated) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StageEventCreated) ProtoMessage() {}
+
+func (x *StageEventCreated) ProtoReflect() protoreflect.Message {
+	mi := &file_delivery_proto_msgTypes[36] // Ajuste este índice conforme necessário
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (*StageEventCreated) Descriptor() ([]byte, []int) {
+	return file_delivery_proto_rawDescGZIP(), []int{36} // Ajuste este índice conforme necessário
+}
+
+func (x *StageEventCreated) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *StageEventCreated) GetTimestamp() *timestamp.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+type StageEventApproved struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	EventId       string                      `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StageEventApproved) Reset() {
+	*x = StageEventApproved{}
+	mi := &file_delivery_proto_msgTypes[37] // Ajuste este índice conforme necessário
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StageEventApproved) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StageEventApproved) ProtoMessage() {}
+
+func (x *StageEventApproved) ProtoReflect() protoreflect.Message {
+	mi := &file_delivery_proto_msgTypes[37] // Ajuste este índice conforme necessário
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (*StageEventApproved) Descriptor() ([]byte, []int) {
+	return file_delivery_proto_rawDescGZIP(), []int{37} // Ajuste este índice conforme necessário
+}
+
+func (x *StageEventApproved) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *StageEventApproved) GetTimestamp() *timestamp.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+type StageExecutionCreated struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	ExecutionId   string                      `protobuf:"bytes,1,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                      `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StageExecutionCreated) Reset() {
+	*x = StageExecutionCreated{}
+	mi := &file_delivery_proto_msgTypes[38] // Ajuste este índice conforme necessário
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StageExecutionCreated) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StageExecutionCreated) ProtoMessage() {}
+
+func (x *StageExecutionCreated) ProtoReflect() protoreflect.Message {
+	mi := &file_delivery_proto_msgTypes[38] // Ajuste este índice conforme necessário
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (*StageExecutionCreated) Descriptor() ([]byte, []int) {
+	return file_delivery_proto_rawDescGZIP(), []int{38} // Ajuste este índice conforme necessário
+}
+
+func (x *StageExecutionCreated) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
+func (x *StageExecutionCreated) GetStageId() string {
+	if x != nil {
+		return x.StageId
+	}
+	return ""
+}
+
+func (x *StageExecutionCreated) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *StageExecutionCreated) GetTimestamp() *timestamp.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+type StageExecutionStarted struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	ExecutionId   string                      `protobuf:"bytes,1,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                      `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StageExecutionStarted) Reset() {
+	*x = StageExecutionStarted{}
+	mi := &file_delivery_proto_msgTypes[39] // Ajuste este índice conforme necessário
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StageExecutionStarted) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StageExecutionStarted) ProtoMessage() {}
+
+func (x *StageExecutionStarted) ProtoReflect() protoreflect.Message {
+	mi := &file_delivery_proto_msgTypes[39] // Ajuste este índice conforme necessário
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (*StageExecutionStarted) Descriptor() ([]byte, []int) {
+	return file_delivery_proto_rawDescGZIP(), []int{39} // Ajuste este índice conforme necessário
+}
+
+func (x *StageExecutionStarted) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
+func (x *StageExecutionStarted) GetStageId() string {
+	if x != nil {
+		return x.StageId
+	}
+	return ""
+}
+
+func (x *StageExecutionStarted) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *StageExecutionStarted) GetTimestamp() *timestamp.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+type StageExecutionFinished struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	ExecutionId   string                      `protobuf:"bytes,1,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	StageId       string                      `protobuf:"bytes,2,opt,name=stage_id,json=stageId,proto3" json:"stage_id,omitempty"`
+	EventId       string                      `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Timestamp     *timestamp.Timestamp        `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StageExecutionFinished) Reset() {
+	*x = StageExecutionFinished{}
+	mi := &file_delivery_proto_msgTypes[40] // Ajuste este índice conforme necessário
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StageExecutionFinished) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StageExecutionFinished) ProtoMessage() {}
+
+func (x *StageExecutionFinished) ProtoReflect() protoreflect.Message {
+	mi := &file_delivery_proto_msgTypes[40] // Ajuste este índice conforme necessário
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (*StageExecutionFinished) Descriptor() ([]byte, []int) {
+	return file_delivery_proto_rawDescGZIP(), []int{40} // Ajuste este índice conforme necessário
+}
+
+func (x *StageExecutionFinished) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
+func (x *StageExecutionFinished) GetStageId() string {
+	if x != nil {
+		return x.StageId
+	}
+	return ""
+}
+
+func (x *StageExecutionFinished) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *StageExecutionFinished) GetTimestamp() *timestamp.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
 var File_delivery_proto protoreflect.FileDescriptor
 
 const file_delivery_proto_rawDesc = "" +

--- a/ee/delivery-hub/pkg/workers/pending_events_worker.go
+++ b/ee/delivery-hub/pkg/workers/pending_events_worker.go
@@ -158,7 +158,7 @@ func (w *PendingEventsWorker) enqueueEvent(event *models.Event, stages []models.
 				return fmt.Errorf("error creating pending stage event: %v", err)
 			}
 
-			err = messages.NewStageEventCreatedMessage(event).Publish()
+			err = messages.NewStageEventCreatedMessage(stage.CanvasID.String(), event).Publish()
 			if err != nil {
 				logging.ForStage(&stage).Errorf("failed to publish stage event created message: %v", err)
 			}

--- a/ee/delivery-hub/pkg/workers/pending_events_worker.go
+++ b/ee/delivery-hub/pkg/workers/pending_events_worker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/database"
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/grpc/actions/messages"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/logging"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	log "github.com/sirupsen/logrus"
@@ -152,9 +153,14 @@ func (w *PendingEventsWorker) filterStages(logger *log.Entry, event *models.Even
 func (w *PendingEventsWorker) enqueueEvent(event *models.Event, stages []models.Stage) error {
 	return database.Conn().Transaction(func(tx *gorm.DB) error {
 		for _, stage := range stages {
-			_, err := models.CreateStageEventInTransaction(tx, stage.ID, event)
+			event, err := models.CreateStageEventInTransaction(tx, stage.ID, event)
 			if err != nil {
 				return fmt.Errorf("error creating pending stage event: %v", err)
+			}
+
+			err = messages.NewStageEventCreatedMessage(event).Publish()
+			if err != nil {
+				logging.ForStage(&stage).Errorf("failed to publish stage event created message: %v", err)
 			}
 		}
 

--- a/ee/delivery-hub/pkg/workers/pending_events_worker_test.go
+++ b/ee/delivery-hub/pkg/workers/pending_events_worker_test.go
@@ -50,7 +50,7 @@ func Test__PendingEventsWorker(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		amqpUrl, _ := config.RabbitMQURL()
+		amqpURL, _ := config.RabbitMQURL()
 
 		stage1, _ := r.Canvas.FindStageByName("stage-1")
 		stage2, _ := r.Canvas.FindStageByName("stage-2")
@@ -60,7 +60,7 @@ func Test__PendingEventsWorker(t *testing.T) {
 
 		for _, stage := range stages {
 			routingKey := fmt.Sprintf("%s.%s", "created", stage.ID.String())
-			testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.StageEventExchange", routingKey)
+			testconsumer := testconsumer.New(amqpURL, "DeliveryHub.StageEventExchange", routingKey)
 			testconsumer.Start()
 			consumers = append(consumers, testconsumer)
 		}

--- a/ee/delivery-hub/pkg/workers/pending_events_worker_test.go
+++ b/ee/delivery-hub/pkg/workers/pending_events_worker_test.go
@@ -53,9 +53,6 @@ func Test__PendingEventsWorker(t *testing.T) {
 		require.NoError(t, err)
 		amqpURL, _ := config.RabbitMQURL()
 
-		stage1, _ := r.Canvas.FindStageByName("stage-1")
-		stage2, _ := r.Canvas.FindStageByName("stage-2")
-
 		testconsumer := testconsumer.New(amqpURL, EventCreatedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
@@ -78,6 +75,9 @@ func Test__PendingEventsWorker(t *testing.T) {
 		//
 		// Two pending stage events are created: one for each stage.
 		//
+		stage1, _ := r.Canvas.FindStageByName("stage-1")
+		stage2, _ := r.Canvas.FindStageByName("stage-2")
+
 		stage1Events, err := stage1.ListPendingEvents()
 		require.NoError(t, err)
 		require.Len(t, stage1Events, 1)

--- a/ee/delivery-hub/pkg/workers/pending_events_worker_test.go
+++ b/ee/delivery-hub/pkg/workers/pending_events_worker_test.go
@@ -94,7 +94,7 @@ func Test__PendingEventsWorker(t *testing.T) {
 		assert.Equal(t, r.Source.ID, stage2Events[0].SourceID)
 
 		for _, consumer := range consumers {
-			assert.Equal(t, true, consumer.HasReceivedMessage())
+			assert.True(t, consumer.HasReceivedMessage())
 			consumer.Stop()
 		}
 	})

--- a/ee/delivery-hub/pkg/workers/pending_executions_worker.go
+++ b/ee/delivery-hub/pkg/workers/pending_executions_worker.go
@@ -79,7 +79,7 @@ func (w *PendingExecutionsWorker) ProcessExecution(logger *log.Entry, stage *mod
 		return fmt.Errorf("error moving execution to started state: %v", err)
 	}
 
-	err = messages.NewExecutionStartedMessage(&execution).Publish()
+	err = messages.NewExecutionStartedMessage(stage.CanvasID.String(), &execution).Publish()
 	if err != nil {
 		return fmt.Errorf("error publishing execution started message: %v", err)
 	}

--- a/ee/delivery-hub/pkg/workers/pending_executions_worker.go
+++ b/ee/delivery-hub/pkg/workers/pending_executions_worker.go
@@ -74,14 +74,14 @@ func (w *PendingExecutionsWorker) ProcessExecution(logger *log.Entry, stage *mod
 		return fmt.Errorf("error starting execution: %v", err)
 	}
 
-	err = messages.NewExecutionStartedMessage(&execution).Publish()
-	if err != nil {
-		return fmt.Errorf("error publishing execution started message: %v", err)
-	}
-
 	err = execution.Start(executionID)
 	if err != nil {
 		return fmt.Errorf("error moving execution to started state: %v", err)
+	}
+
+	err = messages.NewExecutionStartedMessage(&execution).Publish()
+	if err != nil {
+		return fmt.Errorf("error publishing execution started message: %v", err)
 	}
 
 	logger.Infof("Started execution %s", executionID)

--- a/ee/delivery-hub/pkg/workers/pending_executions_worker.go
+++ b/ee/delivery-hub/pkg/workers/pending_executions_worker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/grpc/actions/messages"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/jwt"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/logging"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
@@ -71,6 +72,11 @@ func (w *PendingExecutionsWorker) ProcessExecution(logger *log.Entry, stage *mod
 	executionID, err := w.StartExecution(logger, stage, execution, *template)
 	if err != nil {
 		return fmt.Errorf("error starting execution: %v", err)
+	}
+
+	err = messages.NewExecutionStartedMessage(&execution).Publish()
+	if err != nil {
+		return fmt.Errorf("error publishing execution started message: %v", err)
 	}
 
 	err = execution.Start(executionID)

--- a/ee/delivery-hub/pkg/workers/pending_executions_worker_test.go
+++ b/ee/delivery-hub/pkg/workers/pending_executions_worker_test.go
@@ -2,7 +2,6 @@ package workers
 
 import (
 	"encoding/json"
-	"fmt"
 	"slices"
 	"testing"
 
@@ -17,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const ExecutionStartedRoutingKey = "execution-started"
 
 func Test__PendingExecutionsWorker(t *testing.T) {
 	r := support.SetupWithOptions(t, support.SetupOptions{Source: true, Stage: true, Grpc: true})
@@ -41,8 +42,7 @@ func Test__PendingExecutionsWorker(t *testing.T) {
 		stage, err := r.Canvas.FindStageByName("stage-wf")
 		require.NoError(t, err)
 
-		routingKey := fmt.Sprintf("%s.%s", "started", stage.ID.String())
-		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, ExecutionStartedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 
@@ -95,8 +95,7 @@ func Test__PendingExecutionsWorker(t *testing.T) {
 		execution, err := models.CreateStageExecution(stage.ID, event.ID)
 		require.NoError(t, err)
 
-		routingKey := fmt.Sprintf("%s.%s", "started", execution.StageID.String())
-		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, ExecutionStartedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 
@@ -170,8 +169,7 @@ func Test__PendingExecutionsWorker(t *testing.T) {
 		execution, err := models.CreateStageExecution(stage.ID, event.ID)
 		require.NoError(t, err)
 
-		routingKey := fmt.Sprintf("%s.%s", "started", execution.StageID.String())
-		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, ExecutionStartedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/pkg/workers/pending_executions_worker_test.go
+++ b/ee/delivery-hub/pkg/workers/pending_executions_worker_test.go
@@ -25,7 +25,7 @@ func Test__PendingExecutionsWorker(t *testing.T) {
 		SchedulerURL: "0.0.0.0:50052",
 		JwtSigner:    jwt.NewSigner("test"),
 	}
-	amqpUrl, _ := config.RabbitMQURL()
+	amqpURL, _ := config.RabbitMQURL()
 
 	t.Run("semaphore workflow is created", func(t *testing.T) {
 		//
@@ -42,7 +42,7 @@ func Test__PendingExecutionsWorker(t *testing.T) {
 		require.NoError(t, err)
 
 		routingKey := fmt.Sprintf("%s.%s", "started", stage.ID.String())
-		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 
@@ -96,7 +96,7 @@ func Test__PendingExecutionsWorker(t *testing.T) {
 		require.NoError(t, err)
 
 		routingKey := fmt.Sprintf("%s.%s", "started", execution.StageID.String())
-		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 
@@ -171,7 +171,7 @@ func Test__PendingExecutionsWorker(t *testing.T) {
 		require.NoError(t, err)
 
 		routingKey := fmt.Sprintf("%s.%s", "started", execution.StageID.String())
-		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/pkg/workers/pending_stage_events_worker.go
+++ b/ee/delivery-hub/pkg/workers/pending_stage_events_worker.go
@@ -125,7 +125,7 @@ func (w *PendingStageEventsWorker) ProcessEvent(stage *models.Stage, event *mode
 		return err
 	}
 
-	err = messages.NewExecutionCreatedMessage(execution).Publish()
+	err = messages.NewExecutionCreatedMessage(stage.CanvasID.String(), execution).Publish()
 	if err != nil {
 		logging.ForStage(stage).Errorf("failed to publish execution created message: %v", err)
 	}

--- a/ee/delivery-hub/pkg/workers/pending_stage_events_worker.go
+++ b/ee/delivery-hub/pkg/workers/pending_stage_events_worker.go
@@ -111,11 +111,6 @@ func (w *PendingStageEventsWorker) ProcessEvent(stage *models.Stage, event *mode
 			return fmt.Errorf("error creating stage execution: %v", err)
 		}
 
-		err = messages.NewExecutionCreatedMessage(execution).Publish()
-		if err != nil {
-			logging.ForStage(stage).Errorf("failed to publish execution created message: %v", err)
-		}
-
 		logger.Infof("Created stage execution %s", execution.ID)
 
 		if err := event.UpdateStateInTransaction(tx, models.StageEventProcessed); err != nil {
@@ -128,6 +123,11 @@ func (w *PendingStageEventsWorker) ProcessEvent(stage *models.Stage, event *mode
 
 	if err != nil {
 		return err
+	}
+
+	err = messages.NewExecutionCreatedMessage(execution).Publish()
+	if err != nil {
+		logging.ForStage(stage).Errorf("failed to publish execution created message: %v", err)
 	}
 
 	logging.ForStage(stage).Infof("Started execution %s", execution.ID)

--- a/ee/delivery-hub/pkg/workers/pending_stage_events_worker_test.go
+++ b/ee/delivery-hub/pkg/workers/pending_stage_events_worker_test.go
@@ -1,11 +1,14 @@
 package workers
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/config"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	"github.com/semaphoreio/semaphore/delivery-hub/test/support"
+	testconsumer "github.com/semaphoreio/semaphore/delivery-hub/test/test_consumer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,6 +16,7 @@ import (
 func Test__PendingStageEventsWorker(t *testing.T) {
 	r := support.SetupWithOptions(t, support.SetupOptions{Source: true})
 	w := PendingStageEventsWorker{}
+	amqpUrl, _ := config.RabbitMQURL()
 
 	t.Run("stage does not require approval -> creates execution", func(t *testing.T) {
 		//
@@ -27,6 +31,11 @@ func Test__PendingStageEventsWorker(t *testing.T) {
 
 		stage, err := r.Canvas.FindStageByName("stage-no-approval-1")
 		require.NoError(t, err)
+
+		routingKey := fmt.Sprintf("%s.%s", "created", stage.ID.String())
+		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer.Start()
+		defer testconsumer.Stop()
 
 		//
 		// Create a pending stage event, and trigger the worker.
@@ -48,6 +57,7 @@ func Test__PendingStageEventsWorker(t *testing.T) {
 		assert.Equal(t, execution.StageID, stage.ID)
 		assert.Equal(t, execution.StageEventID, event.ID)
 		assert.Equal(t, execution.State, models.StageExecutionPending)
+		assert.True(t, testconsumer.HasReceivedMessage())
 	})
 
 	t.Run("stage requires approval and none was given -> waiting-for-approval state", func(t *testing.T) {
@@ -93,6 +103,11 @@ func Test__PendingStageEventsWorker(t *testing.T) {
 		stage, err := r.Canvas.FindStageByName("stage-with-approval-2")
 		require.NoError(t, err)
 
+		routingKey := fmt.Sprintf("%s.%s", "created", stage.ID.String())
+		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer.Start()
+		defer testconsumer.Stop()
+
 		//
 		// Create a pending stage event, approve it, and trigger the worker.
 		//
@@ -114,6 +129,7 @@ func Test__PendingStageEventsWorker(t *testing.T) {
 		assert.Equal(t, execution.StageID, stage.ID)
 		assert.Equal(t, execution.StageEventID, event.ID)
 		assert.Equal(t, execution.State, models.StageExecutionPending)
+		assert.True(t, testconsumer.HasReceivedMessage())
 	})
 
 	t.Run("another execution already in progress -> remains in pending state", func(t *testing.T) {

--- a/ee/delivery-hub/pkg/workers/pending_stage_events_worker_test.go
+++ b/ee/delivery-hub/pkg/workers/pending_stage_events_worker_test.go
@@ -1,7 +1,6 @@
 package workers
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -12,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const ExecutionCreatedRoutingKey = "execution-created"
 
 func Test__PendingStageEventsWorker(t *testing.T) {
 	r := support.SetupWithOptions(t, support.SetupOptions{Source: true})
@@ -32,8 +33,7 @@ func Test__PendingStageEventsWorker(t *testing.T) {
 		stage, err := r.Canvas.FindStageByName("stage-no-approval-1")
 		require.NoError(t, err)
 
-		routingKey := fmt.Sprintf("%s.%s", "created", stage.ID.String())
-		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, ExecutionCreatedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 
@@ -103,8 +103,7 @@ func Test__PendingStageEventsWorker(t *testing.T) {
 		stage, err := r.Canvas.FindStageByName("stage-with-approval-2")
 		require.NoError(t, err)
 
-		routingKey := fmt.Sprintf("%s.%s", "created", stage.ID.String())
-		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, ExecutionCreatedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/pkg/workers/pending_stage_events_worker_test.go
+++ b/ee/delivery-hub/pkg/workers/pending_stage_events_worker_test.go
@@ -16,7 +16,7 @@ import (
 func Test__PendingStageEventsWorker(t *testing.T) {
 	r := support.SetupWithOptions(t, support.SetupOptions{Source: true})
 	w := PendingStageEventsWorker{}
-	amqpUrl, _ := config.RabbitMQURL()
+	amqpURL, _ := config.RabbitMQURL()
 
 	t.Run("stage does not require approval -> creates execution", func(t *testing.T) {
 		//
@@ -33,7 +33,7 @@ func Test__PendingStageEventsWorker(t *testing.T) {
 		require.NoError(t, err)
 
 		routingKey := fmt.Sprintf("%s.%s", "created", stage.ID.String())
-		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 
@@ -104,7 +104,7 @@ func Test__PendingStageEventsWorker(t *testing.T) {
 		require.NoError(t, err)
 
 		routingKey := fmt.Sprintf("%s.%s", "created", stage.ID.String())
-		testconsumer := testconsumer.New(amqpUrl, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/pkg/workers/pipeline_done_consumer.go
+++ b/ee/delivery-hub/pkg/workers/pipeline_done_consumer.go
@@ -128,7 +128,13 @@ func (c *PipelineDoneConsumer) Consume(delivery tackle.Delivery) error {
 	})
 
 	if err == nil {
-		err = messages.NewExecutionFinishedMessage(execution).Publish()
+		stage, err := models.FindStageByID(execution.StageID)
+		if err != nil {
+			logger.Errorf("Error finding stage for execution: %v", err)
+			return err
+		}
+
+		err = messages.NewExecutionFinishedMessage(stage.CanvasID.String(), execution).Publish()
 		if err != nil {
 			logger.Errorf("Error publishing execution finished message: %v", err)
 		}

--- a/ee/delivery-hub/pkg/workers/pipeline_done_consumer.go
+++ b/ee/delivery-hub/pkg/workers/pipeline_done_consumer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/renderedtext/go-tackle"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/database"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/events"
+	"github.com/semaphoreio/semaphore/delivery-hub/pkg/grpc/actions/messages"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/logging"
 	"github.com/semaphoreio/semaphore/delivery-hub/pkg/models"
 	pplproto "github.com/semaphoreio/semaphore/delivery-hub/pkg/protos/plumber.pipeline"
@@ -111,6 +112,11 @@ func (c *PipelineDoneConsumer) Consume(delivery tackle.Delivery) error {
 		if err := execution.FinishInTransaction(tx, result); err != nil {
 			logger.Errorf("Error updating execution state: %v", err)
 			return err
+		}
+
+		err = messages.NewExecutionFinishedMessage(execution).Publish()
+		if err != nil {
+			logger.Errorf("Error publishing execution finished message: %v", err)
 		}
 
 		//

--- a/ee/delivery-hub/pkg/workers/pipeline_done_consumer_test.go
+++ b/ee/delivery-hub/pkg/workers/pipeline_done_consumer_test.go
@@ -2,7 +2,6 @@ package workers
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -17,6 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
+
+const ExecutionFinishedRoutingKey = "execution-finished"
 
 func Test__PipelineDoneConsumer(t *testing.T) {
 	r := support.SetupWithOptions(t, support.SetupOptions{Source: true, Stage: true, Grpc: true})
@@ -42,8 +43,7 @@ func Test__PipelineDoneConsumer(t *testing.T) {
 		execution := support.CreateExecution(t, r.Source, r.Stage)
 		require.NoError(t, execution.Start(workflowID))
 
-		routingKey := fmt.Sprintf("%s.%s", "finished", execution.StageID.String())
-		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, ExecutionFinishedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 
@@ -105,8 +105,7 @@ func Test__PipelineDoneConsumer(t *testing.T) {
 		execution := support.CreateExecution(t, r.Source, r.Stage)
 		require.NoError(t, execution.Start(workflowID))
 
-		routingKey := fmt.Sprintf("%s.%s", "finished", execution.StageID.String())
-		testconsumer := testconsumer.New(amqpURL, "DeliveryHub.ExecutionExchange", routingKey)
+		testconsumer := testconsumer.New(amqpURL, ExecutionFinishedRoutingKey)
 		testconsumer.Start()
 		defer testconsumer.Stop()
 

--- a/ee/delivery-hub/test/test_consumer/test_consumer.go
+++ b/ee/delivery-hub/test/test_consumer/test_consumer.go
@@ -11,16 +11,16 @@ import (
 const TestConsumerService = "TestConsumerService"
 
 type TestConsumer struct {
-	amqpUrl        string
+	amqpURL        string
 	exchangeName   string
 	routingKey     string
 	consumer       *tackle.Consumer
 	messageChannel chan bool
 }
 
-func New(amqpUrl string, exchangeName string, routingKey string) TestConsumer {
+func New(amqpURL string, exchangeName string, routingKey string) TestConsumer {
 	return TestConsumer{
-		amqpUrl:        amqpUrl,
+		amqpURL:        amqpURL,
 		exchangeName:   exchangeName,
 		routingKey:     routingKey,
 		messageChannel: make(chan bool),
@@ -32,7 +32,7 @@ func (c *TestConsumer) Start() {
 	randomServiceName := fmt.Sprintf("%s.%s", TestConsumerService, uuid.NewString())
 
 	go c.consumer.Start(&tackle.Options{
-		URL:            c.amqpUrl,
+		URL:            c.amqpURL,
 		RemoteExchange: c.exchangeName,
 		Service:        randomServiceName,
 		RoutingKey:     c.routingKey,

--- a/ee/delivery-hub/test/test_consumer/test_consumer.go
+++ b/ee/delivery-hub/test/test_consumer/test_consumer.go
@@ -9,7 +9,7 @@ import (
 )
 
 const TestConsumerService = "TestConsumerService"
-const TestExchangeName = "DeliveryHub.CanvasExchange"
+const TestExchangeName = "delivery-hub.canvas-exchange"
 
 type TestConsumer struct {
 	amqpURL        string

--- a/ee/delivery-hub/test/test_consumer/test_consumer.go
+++ b/ee/delivery-hub/test/test_consumer/test_consumer.go
@@ -58,7 +58,7 @@ func (c *TestConsumer) HasReceivedMessage() bool {
 	select {
 	case <-c.messageChannel:
 		return true
-	case <-time.After(3000 * time.Millisecond):
+	case <-time.After(1000 * time.Millisecond):
 		return false
 	}
 }

--- a/ee/delivery-hub/test/test_consumer/test_consumer.go
+++ b/ee/delivery-hub/test/test_consumer/test_consumer.go
@@ -1,0 +1,64 @@
+package testconsumer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/renderedtext/go-tackle"
+)
+
+const TestConsumerService = "TestConsumerService"
+
+type TestConsumer struct {
+	amqpUrl        string
+	exchangeName   string
+	routingKey     string
+	consumer       *tackle.Consumer
+	messageChannel chan bool
+}
+
+func New(amqpUrl string, exchangeName string, routingKey string) TestConsumer {
+	return TestConsumer{
+		amqpUrl:        amqpUrl,
+		exchangeName:   exchangeName,
+		routingKey:     routingKey,
+		messageChannel: make(chan bool),
+		consumer:       tackle.NewConsumer(),
+	}
+}
+
+func (c *TestConsumer) Start() {
+	randomServiceName := fmt.Sprintf("%s.%s", TestConsumerService, uuid.NewString())
+
+	go c.consumer.Start(&tackle.Options{
+		URL:            c.amqpUrl,
+		RemoteExchange: c.exchangeName,
+		Service:        randomServiceName,
+		RoutingKey:     c.routingKey,
+	}, func(d tackle.Delivery) error {
+		c.messageChannel <- true
+		return nil
+	})
+
+	c.waitForInitialization()
+}
+
+func (c *TestConsumer) waitForInitialization() {
+	for c.consumer.State != tackle.StateListening {
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func (c *TestConsumer) Stop() {
+	c.consumer.Stop()
+}
+
+func (c *TestConsumer) HasReceivedMessage() bool {
+	select {
+	case <-c.messageChannel:
+		return true
+	case <-time.After(3000 * time.Millisecond):
+		return false
+	}
+}

--- a/ee/delivery-hub/test/test_consumer/test_consumer.go
+++ b/ee/delivery-hub/test/test_consumer/test_consumer.go
@@ -9,6 +9,7 @@ import (
 )
 
 const TestConsumerService = "TestConsumerService"
+const TestExchangeName = "DeliveryHub.CanvasExchange"
 
 type TestConsumer struct {
 	amqpURL        string
@@ -18,10 +19,10 @@ type TestConsumer struct {
 	messageChannel chan bool
 }
 
-func New(amqpURL string, exchangeName string, routingKey string) TestConsumer {
+func New(amqpURL string, routingKey string) TestConsumer {
 	return TestConsumer{
 		amqpURL:        amqpURL,
-		exchangeName:   exchangeName,
+		exchangeName:   TestExchangeName,
 		routingKey:     routingKey,
 		messageChannel: make(chan bool),
 		consumer:       tackle.NewConsumer(),


### PR DESCRIPTION
## 📝 Description

### Changes:
- Created RabbitMQ events for:
  - stage created
  - event source created
  - stage event created (event enqueued on stage)
  - stage event approved
  - execution created
  - execution started
  - execution finished

Note: The routing key depends on pointing directly to each parent resource Id to make the available filtering in the UI

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
