### PR TITLE
fix: If there are multiple branches having current tag, use the first one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TAG_NAME=$(shell git describe --exact-match --tags HEAD 2>/dev/null)
 # If we are building on a tag, we use the branch name which contains the tag.
 #
 ifneq ($(TAG_NAME),)
-	export BRANCH?=$(shell git branch --contains tags/$(TAG_NAME) | sed '/HEAD/d' | sed 's/[^a-z]//g' | cut -c 1-40)
+	export BRANCH?=$(shell git branch --contains tags/$(TAG_NAME) | head -n 1 | sed '/HEAD/d' | sed 's/[^a-z]//g' | cut -c 1-40)
 else
 	export BRANCH?=$(shell git rev-parse --abbrev-ref HEAD | sed 's/[^a-z]//g' | cut -c 1-40)
 endif


### PR DESCRIPTION
## 📝 Description

When there are multiple branches having the same tag, every make command will fail because the Docker image will have an unsupported format

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
