### PR TITLE
fix(front): remove groups reference from deployment target screen

### DIFF
--- a/front/lib/front_web/templates/deployments/forms/_subject_rules.html.eex
+++ b/front/lib/front_web/templates/deployments/forms/_subject_rules.html.eex
@@ -33,7 +33,7 @@
 
             <div class="ml1 mv2">
                 <%= label @form, :people, class: "db b" %>
-                <p class="measure f6 gray">Allow individual people or groups to deploy regardless of their role</p>
+                <p class="measure f6 gray">Allow individual people to deploy regardless of their role</p>
                 <%= multiple_select @form, :members, options(@resources, :members),
                     'data-component': "people-select", class: "form-control w-100 w-50-m" %>
             </div>


### PR DESCRIPTION
## 📝 Description

We don't support groups in deployment targets, so we shouldn't mention them there.
Ref: https://github.com/renderedtext/tasks/issues/7930

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
