### PR TITLE
Added isRendered to false state when switch yml tabs

### DIFF
--- a/front/assets/js/workflow_editor/components/monaco_code_editor.js
+++ b/front/assets/js/workflow_editor/components/monaco_code_editor.js
@@ -49,6 +49,7 @@ export class MonacoCodeEditor {
     this.activePipeline = pipeline;
 
     this.state.value = pipeline.toYaml();
+    this.isRendered = false;
     this.renderEditor();
   }
 


### PR DESCRIPTION
## 📝 Description
Added isRendered to false for the YamlEditor be able to rerendered.

Tests are all green:

![image](https://github.com/user-attachments/assets/11568fb7-9dbf-492a-a976-ba748d724827)


## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
