### PR TITLE
toil(github_hooks): update outdated alpine image

### DIFF
--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.13)
+    rack (2.2.14)
     rack-session (1.0.2)
       rack (< 3)
     rack-test (2.1.0)
@@ -506,4 +506,4 @@ DEPENDENCIES
   xmlrpc
 
 BUNDLED WITH
-   2.5.22
+   2.5.23


### PR DESCRIPTION
## 📝 Description
Alpine 3.18 has reached [EOL](https://endoflife.date/alpine-linux)

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
