### PR TITLE
feat(secrethub): add project and org. name to OIDC token claims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,10 @@ console.bash:
 	docker compose $(DOCKER_COMPOSE_OPTS) build --build-arg BUILDKIT_INLINE_CACHE=$(BUILDKIT_INLINE_CACHE) --build-arg MIX_ENV=$(MIX_ENV) app
 	docker compose $(DOCKER_COMPOSE_OPTS) run $(DOCKER_COMPOSE_RUN_OPTS) --rm app /bin/bash
 
+console.sh:
+	docker compose $(DOCKER_COMPOSE_OPTS) build --build-arg BUILDKIT_INLINE_CACHE=$(BUILDKIT_INLINE_CACHE) --build-arg MIX_ENV=$(MIX_ENV) app
+	docker compose $(DOCKER_COMPOSE_OPTS) run $(DOCKER_COMPOSE_RUN_OPTS) --rm app /bin/sh
+
 #
 # The default test.ex.setup target does nothing.
 # Each application's Makefile should override it as it sees fit.

--- a/docs/docs/reference/openid.md
+++ b/docs/docs/reference/openid.md
@@ -2,7 +2,7 @@
 description: OpenID Connect (OIDC) token reference
 ---
 
-# OIDC Tokens 
+# OIDC Tokens
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -23,9 +23,9 @@ Sure, here is the reordered list presented in a table with three columns: Claim,
 
 | Claim       | Description                                               | Example                              |
 |-------------|-----------------------------------------------------------|--------------------------------------|
-| iss         | The issuer of the token. The full URL of the organization | `https://<org-url>.semaphoreci.com` |
-| aud         | The intended audience of the token. The full URL of the organization | `https://<org-url>.semaphoreci.com` |
-| sub         | The subject of the token. A combination of org, project, repository, and git reference for which this token was issued<br/>Template:<br/> `org:<org-url>:`<br/>`project:{project-id}:`<br/>`repo:{repo-name}:`<br/>`ref_type:{branch or pr or tag}:`<br/>`ref:{git_reference}` | `org:{org-name}:`<br/>`project:936a5312-a3b8-4921-8b3f-2cec8baac574:`<br/>`repo:web:`<br/>`ref_type:branch:`<br/>`ref:refs/heads/main` |
+| iss         | The issuer of the token. The full URL of the organization | `https://<org-name>.semaphoreci.com` |
+| aud         | The intended audience of the token. The full URL of the organization | `https://<org-name>.semaphoreci.com` |
+| sub         | The subject of the token. A combination of org, project, repository, and git reference for which this token was issued<br/>Template:<br/> `org:<org-name>:`<br/>`project:{project-id}:`<br/>`repo:{repo-name}:`<br/>`ref_type:{branch or pr or tag}:`<br/>`ref:{git_reference}` | `org:{org-name}:`<br/>`project:936a5312-a3b8-4921-8b3f-2cec8baac574:`<br/>`repo:web:`<br/>`ref_type:branch:`<br/>`ref:refs/heads/main` |
 | exp         | The UNIX timestamp when the token expires  | `1660317851` |
 | iat         | The UNIX timestamp when the token was issued | `1660317851` |
 | nbf         | The UNIX timestamp before which the token is not valid | `1660317851` |
@@ -38,7 +38,9 @@ Sure, here is the reordered list presented in a table with three columns: Claim,
 | tag         | The name of the git tag for which the token was issued    | `v1.0.0`   |
 | repo        | The name of the repository for which the token was issued | `web` |
 | repo_slug   | Specifies the repository's name in the format `owner_name/repository_name` for the current Semaphore project. It is associated with the environment variable `SEMAPHORE_GIT_REPO_SLUG` | `semaphoreci/docs`  |
-| org_id      | The organization ID of the owner of the project for which the token was issued | `d7dd33ad-9317-498c-9cc6-51c250749be7` |
+| org         | The organization name for which the token was issued | `semaphore` |
+| org_id      | The organization ID for which the token was issued | `d7dd33ad-9317-498c-9cc6-51c250749be7` |
+| prj         | The project name for which the token was issued | `docs` |
 | prj_id      | The project ID for which the token was issued | `1e1fcfb5-09c0-487e-b051-2d0b5514c42a` |
 | wf_id       | The ID of the workflow for which the token was issued | `1be81412-6ab8-4fc0-9d0d-7af33335a6ec` |
 | ppl_id      | The pipeline ID for which the token was issued | `1e1fcfb5-09c0-487e-b051-2d0b5514c42a` |

--- a/secrethub/Makefile
+++ b/secrethub/Makefile
@@ -4,7 +4,7 @@ include ../Makefile
 
 DOCKER_BUILD_PATH=..
 APP_NAME=secrethub
-TMP_REPO_DIR=/tmp/internal_api
+TMP_REPO_DIR?=/tmp/internal_api
 INTERNAL_API_BRANCH ?= master
 PUBLIC_API_BRANCH ?= master
 PROTOC_TAG=1.12.1-3.17.3-0.7.1
@@ -43,13 +43,13 @@ CONTAINER_ENV_VARS= \
   -e INTERNAL_API_URL_PROJECT=$(INTERNAL_API_URL_PROJECT)
 
 pb.gen.internal:
-	rm -rf $(TMP_REPO_DIR)
-	git clone git@github.com:renderedtext/internal_api.git $(TMP_REPO_DIR) && (cd $(TMP_REPO_DIR) && git checkout $(INTERNAL_API_BRANCH) && cd -)
+#	rm -rf $(TMP_REPO_DIR)
+#	git clone git@github.com:renderedtext/internal_api.git $(TMP_REPO_DIR) && (cd $(TMP_REPO_DIR) && git checkout $(INTERNAL_API_BRANCH) && cd -)
 	scripts/vagrant_sudo rm -rf lib/internal_api && mkdir -p lib/internal_api
 	docker run --rm -v $(PWD):/home/protoc/code -v $(TMP_REPO_DIR):/home/protoc/source -t renderedtext/protoc:$(PROTOC_TAG) sh -c /home/protoc/code/scripts/internal_protos.sh
-	scripts/vagrant_sudo chown -R $$(id -u $${USER}):$$(id -g $${USER}) lib/internal_api
-	rm -rf $(TMP_REPO_DIR)
-	$(MAKE) pb.gen.format
+#	scripts/vagrant_sudo chown -R $$(id -u $${USER}):$$(id -g $${USER}) lib/internal_api
+#	rm -rf $(TMP_REPO_DIR)
+#	$(MAKE) pb.gen.format
 
 pb.gen.public:
 	rm -rf $(TMP_REPO_DIR)

--- a/secrethub/Makefile
+++ b/secrethub/Makefile
@@ -43,13 +43,13 @@ CONTAINER_ENV_VARS= \
   -e INTERNAL_API_URL_PROJECT=$(INTERNAL_API_URL_PROJECT)
 
 pb.gen.internal:
-#	rm -rf $(TMP_REPO_DIR)
-#	git clone git@github.com:renderedtext/internal_api.git $(TMP_REPO_DIR) && (cd $(TMP_REPO_DIR) && git checkout $(INTERNAL_API_BRANCH) && cd -)
+	rm -rf $(TMP_REPO_DIR)
+	git clone git@github.com:renderedtext/internal_api.git $(TMP_REPO_DIR) && (cd $(TMP_REPO_DIR) && git checkout $(INTERNAL_API_BRANCH) && cd -)
 	scripts/vagrant_sudo rm -rf lib/internal_api && mkdir -p lib/internal_api
 	docker run --rm -v $(PWD):/home/protoc/code -v $(TMP_REPO_DIR):/home/protoc/source -t renderedtext/protoc:$(PROTOC_TAG) sh -c /home/protoc/code/scripts/internal_protos.sh
-#	scripts/vagrant_sudo chown -R $$(id -u $${USER}):$$(id -g $${USER}) lib/internal_api
-#	rm -rf $(TMP_REPO_DIR)
-#	$(MAKE) pb.gen.format
+	scripts/vagrant_sudo chown -R $$(id -u $${USER}):$$(id -g $${USER}) lib/internal_api
+	rm -rf $(TMP_REPO_DIR)
+	$(MAKE) pb.gen.format
 
 pb.gen.public:
 	rm -rf $(TMP_REPO_DIR)

--- a/secrethub/lib/internal_api/secrethub.pb.ex
+++ b/secrethub/lib/internal_api/secrethub.pb.ex
@@ -719,7 +719,8 @@ defmodule InternalApi.Secrethub.GenerateOpenIDConnectTokenRequest do
           job_type: String.t(),
           git_pull_request_branch: String.t(),
           repo_slug: String.t(),
-          triggerer: String.t()
+          triggerer: String.t(),
+          project_name: String.t()
         }
 
   defstruct [
@@ -741,7 +742,8 @@ defmodule InternalApi.Secrethub.GenerateOpenIDConnectTokenRequest do
     :job_type,
     :git_pull_request_branch,
     :repo_slug,
-    :triggerer
+    :triggerer,
+    :project_name
   ]
 
   field :org_id, 1, type: :string
@@ -763,6 +765,7 @@ defmodule InternalApi.Secrethub.GenerateOpenIDConnectTokenRequest do
   field :git_pull_request_branch, 17, type: :string
   field :repo_slug, 18, type: :string
   field :triggerer, 19, type: :string
+  field :project_name, 20, type: :string
 end
 
 defmodule InternalApi.Secrethub.GenerateOpenIDConnectTokenResponse do

--- a/secrethub/lib/secrethub/open_id_connect/jwt.ex
+++ b/secrethub/lib/secrethub/open_id_connect/jwt.ex
@@ -117,7 +117,9 @@ defmodule Secrethub.OpenIDConnect.JWT do
       "job_type" => req.job_type,
       "pr_branch" => req.git_pull_request_branch,
       "repo_slug" => req.repo_slug,
-      "trg" => req.triggerer
+      "trg" => req.triggerer,
+      "proj" => req.project_name,
+      "org" => req.org_username
     }
 
     claims =

--- a/secrethub/lib/secrethub/open_id_connect/jwt.ex
+++ b/secrethub/lib/secrethub/open_id_connect/jwt.ex
@@ -99,7 +99,9 @@ defmodule Secrethub.OpenIDConnect.JWT do
     domain = Application.fetch_env!(:secrethub, :domain)
 
     common_claims = %{
+      "org" => req.org_username,
       "org_id" => req.org_id,
+      "prj" => req.project_name,
       "prj_id" => req.project_id,
       "wf_id" => req.workflow_id,
       "ppl_id" => req.pipeline_id,
@@ -117,9 +119,7 @@ defmodule Secrethub.OpenIDConnect.JWT do
       "job_type" => req.job_type,
       "pr_branch" => req.git_pull_request_branch,
       "repo_slug" => req.repo_slug,
-      "trg" => req.triggerer,
-      "proj" => req.project_name,
-      "org" => req.org_username
+      "trg" => req.triggerer
     }
 
     claims =

--- a/secrethub/lib/secrethub/open_id_connect/jwt_claim.ex
+++ b/secrethub/lib/secrethub/open_id_connect/jwt_claim.ex
@@ -250,9 +250,9 @@ defmodule Secrethub.OpenIDConnect.JWTClaim do
         is_mandatory: false,
         is_active: false
       },
-      "proj" => %__MODULE__{
-        name: "proj",
-        description: "Project name",
+      "prj" => %__MODULE__{
+        name: "prj",
+        description: "Project name associated with the workflow",
         is_system_claim: true,
         is_aws_tag: false,
         is_mandatory: false,

--- a/secrethub/lib/secrethub/open_id_connect/jwt_claim.ex
+++ b/secrethub/lib/secrethub/open_id_connect/jwt_claim.ex
@@ -242,6 +242,22 @@ defmodule Secrethub.OpenIDConnect.JWTClaim do
         is_mandatory: false,
         is_active: true
       },
+      "org" => %__MODULE__{
+        name: "org",
+        description: "Organization name",
+        is_system_claim: true,
+        is_aws_tag: false,
+        is_mandatory: false,
+        is_active: false
+      },
+      "proj" => %__MODULE__{
+        name: "proj",
+        description: "Project name",
+        is_system_claim: true,
+        is_aws_tag: false,
+        is_mandatory: false,
+        is_active: false
+      },
       "https://aws.amazon.com/tags" => %__MODULE__{
         name: "https://aws.amazon.com/tags",
         description:

--- a/secrethub/test/secrethub/internal_grpc_api_test.exs
+++ b/secrethub/test/secrethub/internal_grpc_api_test.exs
@@ -809,7 +809,8 @@ defmodule Secrethub.InternalGrpcApi.Test do
           workflow_id: Ecto.UUID.generate(),
           pipeline_id: Ecto.UUID.generate(),
           job_id: Ecto.UUID.generate(),
-          job_type: "pipeline_job"
+          job_type: "pipeline_job",
+          project_name: "my-project"
         )
 
       {:ok, channel} = GRPC.Stub.connect("localhost:50051")
@@ -833,6 +834,8 @@ defmodule Secrethub.InternalGrpcApi.Test do
       assert Map.get(jwt.fields, "aud") == "https://testera.localhost"
       assert Map.get(jwt.fields, "iss") == "https://testera.localhost"
       assert Map.get(jwt.fields, "sub") == "project:front:pipeline:semaphore.yml"
+      assert Map.get(jwt.fields, "proj") == req.project_name
+      assert Map.get(jwt.fields, "org") == req.org_username
       refute Map.has_key?(jwt.fields, "https://aws.amazon.com/tags")
     end
 
@@ -925,7 +928,8 @@ defmodule Secrethub.InternalGrpcApi.Test do
           git_ref_type: "branch",
           job_type: "debug_job",
           repo_slug: "renderedtext/front",
-          triggerer: "h:f-i:f"
+          triggerer: "h:f-i:f",
+          project_name: "front"
         )
 
       with_mock Secrethub, on_prem?: fn -> true end do
@@ -946,6 +950,8 @@ defmodule Secrethub.InternalGrpcApi.Test do
         # Project related claims should be present
         assert Map.get(jwt.fields, "prj_id") == req.project_id
         assert Map.get(jwt.fields, "job_type") == req.job_type
+        refute Map.has_key?(jwt.fields, "proj")
+        refute Map.has_key?(jwt.fields, "org")
 
         # AWS tags should be filtered
         aws_tags = Map.get(jwt.fields, "https://aws.amazon.com/tags")

--- a/secrethub/test/secrethub/internal_grpc_api_test.exs
+++ b/secrethub/test/secrethub/internal_grpc_api_test.exs
@@ -827,6 +827,7 @@ defmodule Secrethub.InternalGrpcApi.Test do
       assert_in_delta Map.get(jwt.fields, "exp") + req.expires_in, now, 5
 
       assert Map.get(jwt.fields, "prj_id") == req.project_id
+      assert Map.get(jwt.fields, "org_id") == org_id
       assert Map.get(jwt.fields, "wf_id") == req.workflow_id
       assert Map.get(jwt.fields, "ppl_id") == req.pipeline_id
       assert Map.get(jwt.fields, "job_id") == req.job_id
@@ -834,7 +835,7 @@ defmodule Secrethub.InternalGrpcApi.Test do
       assert Map.get(jwt.fields, "aud") == "https://testera.localhost"
       assert Map.get(jwt.fields, "iss") == "https://testera.localhost"
       assert Map.get(jwt.fields, "sub") == "project:front:pipeline:semaphore.yml"
-      assert Map.get(jwt.fields, "proj") == req.project_name
+      assert Map.get(jwt.fields, "prj") == req.project_name
       assert Map.get(jwt.fields, "org") == req.org_username
       refute Map.has_key?(jwt.fields, "https://aws.amazon.com/tags")
     end
@@ -950,7 +951,8 @@ defmodule Secrethub.InternalGrpcApi.Test do
         # Project related claims should be present
         assert Map.get(jwt.fields, "prj_id") == req.project_id
         assert Map.get(jwt.fields, "job_type") == req.job_type
-        refute Map.has_key?(jwt.fields, "proj")
+        assert Map.get(jwt.fields, "org_id") == org_id
+        refute Map.has_key?(jwt.fields, "prj")
         refute Map.has_key?(jwt.fields, "org")
 
         # AWS tags should be filtered

--- a/secrethub/test/secrethub/open_id_connect/jwt_configuration_test.exs
+++ b/secrethub/test/secrethub/open_id_connect/jwt_configuration_test.exs
@@ -199,7 +199,7 @@ defmodule Secrethub.OpenIDConnect.JWTConfigurationTest do
                    claim_config["is_mandatory"] == claim.is_mandatory &&
                    claim_config["is_aws_tag"] == claim.is_aws_tag &&
                    claim_config["is_system_claim"] == claim.is_system_claim &&
-                   claim_config["is_active"] == true
+                   claim_config["is_active"] == claim.is_active
                end)
       end)
     end

--- a/zebra/Makefile
+++ b/zebra/Makefile
@@ -57,11 +57,11 @@ CONTAINER_ENV_VARS= \
 	-e ZEBRA_CALLBACK_TOKEN_KEYS=$(ZEBRA_CALLBACK_TOKEN_KEYS)
 
 internal.pb.gen:
-#	rm -rf $(TMP_REPO_DIR)
-#	git clone git@github.com:renderedtext/internal_api.git $(TMP_REPO_DIR) && (cd $(TMP_REPO_DIR) && git checkout $(INTERNAL_API_BRANCH) && cd -)
+	rm -rf $(TMP_REPO_DIR)
+	git clone git@github.com:renderedtext/internal_api.git $(TMP_REPO_DIR) && (cd $(TMP_REPO_DIR) && git checkout $(INTERNAL_API_BRANCH) && cd -)
 	scripts/vagrant_sudo rm -rf lib/protos/internal_api && mkdir -p lib/protos/internal_api
 	docker run --rm -v $(PWD):/home/protoc/code -v $(TMP_REPO_DIR):/home/protoc/source -t renderedtext/protoc:$(RT_PROTOC_IMG_VSN) sh -c /home/protoc/code/scripts/internal_protos.sh
-#	rm -rf $(TMP_REPO_DIR)
+	rm -rf $(TMP_REPO_DIR)
 
 public.pb.gen:
 	rm -rf $(TMP_REPO_DIR)

--- a/zebra/Makefile
+++ b/zebra/Makefile
@@ -4,7 +4,7 @@ include ../Makefile
 
 DOCKER_BUILD_PATH=..
 APP_NAME=zebra
-TMP_REPO_DIR=/tmp/internal_api
+TMP_REPO_DIR?=/tmp/internal_api
 PUBLIC_API_BRANCH ?= master
 INTERNAL_API_BRANCH ?= master
 RT_PROTOC_IMG_VSN=1.6.6-3.3.0-0.5.4
@@ -57,11 +57,11 @@ CONTAINER_ENV_VARS= \
 	-e ZEBRA_CALLBACK_TOKEN_KEYS=$(ZEBRA_CALLBACK_TOKEN_KEYS)
 
 internal.pb.gen:
-	rm -rf $(TMP_REPO_DIR)
-	git clone git@github.com:renderedtext/internal_api.git $(TMP_REPO_DIR) && (cd $(TMP_REPO_DIR) && git checkout $(INTERNAL_API_BRANCH) && cd -)
+#	rm -rf $(TMP_REPO_DIR)
+#	git clone git@github.com:renderedtext/internal_api.git $(TMP_REPO_DIR) && (cd $(TMP_REPO_DIR) && git checkout $(INTERNAL_API_BRANCH) && cd -)
 	scripts/vagrant_sudo rm -rf lib/protos/internal_api && mkdir -p lib/protos/internal_api
 	docker run --rm -v $(PWD):/home/protoc/code -v $(TMP_REPO_DIR):/home/protoc/source -t renderedtext/protoc:$(RT_PROTOC_IMG_VSN) sh -c /home/protoc/code/scripts/internal_protos.sh
-	rm -rf $(TMP_REPO_DIR)
+#	rm -rf $(TMP_REPO_DIR)
 
 public.pb.gen:
 	rm -rf $(TMP_REPO_DIR)

--- a/zebra/lib/protos/internal_api/secrethub.pb.ex
+++ b/zebra/lib/protos/internal_api/secrethub.pb.ex
@@ -673,7 +673,8 @@ defmodule InternalApi.Secrethub.GenerateOpenIDConnectTokenRequest do
           job_type: String.t(),
           git_pull_request_branch: String.t(),
           repo_slug: String.t(),
-          triggerer: String.t()
+          triggerer: String.t(),
+          project_name: String.t()
         }
   defstruct [
     :org_id,
@@ -694,7 +695,8 @@ defmodule InternalApi.Secrethub.GenerateOpenIDConnectTokenRequest do
     :job_type,
     :git_pull_request_branch,
     :repo_slug,
-    :triggerer
+    :triggerer,
+    :project_name
   ]
 
   field(:org_id, 1, type: :string)
@@ -716,6 +718,7 @@ defmodule InternalApi.Secrethub.GenerateOpenIDConnectTokenRequest do
   field(:git_pull_request_branch, 17, type: :string)
   field(:repo_slug, 18, type: :string)
   field(:triggerer, 19, type: :string)
+  field(:project_name, 20, type: :string)
 end
 
 defmodule InternalApi.Secrethub.GenerateOpenIDConnectTokenResponse do

--- a/zebra/lib/zebra/workers/job_request_factory.ex
+++ b/zebra/lib/zebra/workers/job_request_factory.ex
@@ -91,7 +91,7 @@ defmodule Zebra.Workers.JobRequestFactory do
          {:ok, artifact_env_var} <- Task.await(find_artifact_token),
          {:ok, loghub2_token} <- Task.await(generate_token),
          {:ok, open_id_token_env_vars} <-
-           OpenIDConnect.load(job, repo_env_vars, organization, job_type, spec_env_vars),
+           OpenIDConnect.load(job, repo_env_vars, organization, project, job_type, spec_env_vars),
          {:ok, callback_token} <- CallbackToken.generate(job) do
       org_url = "https://#{organization.org_username}.#{Application.get_env(:zebra, :domain)}"
 

--- a/zebra/lib/zebra/workers/job_request_factory/open_id_connect.ex
+++ b/zebra/lib/zebra/workers/job_request_factory/open_id_connect.ex
@@ -12,7 +12,7 @@ defmodule Zebra.Workers.JobRequestFactory.OpenIDConnect do
       FeatureProvider.feature_enabled?(:open_id_connect, param: org_id)
   end
 
-  def load(job, repo_env_vars, org, job_type \\ :pipeline_job, spec_env_vars \\ []) do
+  def load(job, repo_env_vars, org, proj, job_type \\ :pipeline_job, spec_env_vars \\ []) do
     if enabled?(job.organization_id) do
       Watchman.benchmark("zebra.external.secrethub.generate_open_id_token", fn ->
         {wf_id, ppl_id} = find_wf_and_ppl_ids(job)
@@ -28,6 +28,7 @@ defmodule Zebra.Workers.JobRequestFactory.OpenIDConnect do
             subject:
               "org:#{org.org_username}:project:#{job.project_id}:repo:#{repo}:ref_type:#{ref_type}:ref:#{ref}",
             project_id: job.project_id,
+            project_name: proj.name,
             workflow_id: wf_id,
             pipeline_id: ppl_id,
             job_id: job.id,


### PR DESCRIPTION
## 📝 Description

Adds `prj` (project name) and `org` (organization name) claims to the OIDC token. More in the [public discussion](https://github.com/semaphoreio/semaphore/issues/204).

See also [this task](https://github.com/renderedtext/tasks/issues/7975). 

## ✅ Checklist
- [x] I have tested this change
- [x] This change requires documentation update
