### PR TITLE
fix(repositoryhub): bitbucket status checks for blocks

### DIFF
--- a/repository_hub/lib/repository_hub/clients/bitbucket_client.ex
+++ b/repository_hub/lib/repository_hub/clients/bitbucket_client.ex
@@ -7,8 +7,6 @@ defmodule RepositoryHub.BitbucketClient do
   alias RepositoryHub.Toolkit
   import Toolkit
 
-  @status_title "SemaphoreCI Pipeline"
-
   @type request_options :: [token: String.t()]
   @type http_response :: {:ok, HTTPoison.Response.t() | HTTPoison.AsyncResponse.t()} | {:error, HTTPoison.Error.t()}
 
@@ -25,7 +23,7 @@ defmodule RepositoryHub.BitbucketClient do
       "state" => params.status,
       "url" => params.url,
       "description" => params.description,
-      "name" => @status_title
+      "name" => params.context
     })
     |> process_response
   end


### PR DESCRIPTION
## 📝 Description
This PR fixes how we're sending status checks to Bitbucket. 
When a project uses [block-level](https://docs.semaphoreci.com/using-semaphore/projects#edit-status-checks) status checks, the repository hub assumes it's always a pipeline status. 

We fixed this using the same data we have for GitHub status checks.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
