### PR TITLE
fix(front): display promoter information for scheduled workflows

### DIFF
--- a/front/test/front/models/pipeline/triggerer_test.exs
+++ b/front/test/front/models/pipeline/triggerer_test.exs
@@ -35,6 +35,15 @@ defmodule Front.Models.Pipeline.TriggererTest do
       assert {:task, _} = triggerer.triggered_by
       assert :none == triggerer.owner
     end
+
+    test "constructs proper triggerer for promotions" do
+      pipeline = Factories.pipeline_with_trigger(:SCHEDULED_RUN_WITH_PROMOTION)
+      triggerer = Triggerer.construct(pipeline)
+
+      assert :MANUAL_PROMOTION == triggerer.trigger_type
+      assert :none = triggerer.triggered_by
+      assert {:user, _} = triggerer.owner
+    end
   end
 
   describe "#construct for scheduled manual run" do

--- a/front/test/support/factories.ex
+++ b/front/test/support/factories.ex
@@ -3130,6 +3130,14 @@ defmodule Support.Factories do
           ]
         )
 
+      :SCHEDULED_RUN_WITH_PROMOTION ->
+        pipeline(
+          triggerer: [
+            wf_triggered_by: WfTriggeredBy.value(:SCHEDULE),
+            ppl_triggered_by: PplTriggeredBy.value(:PROMOTION)
+          ]
+        )
+
       :SCHEDULED_MANUAL_RUN ->
         pipeline(
           triggerer: [


### PR DESCRIPTION
## 📝 Description
Currently, scheduled tasks do not correctly show who ran their promotions.
This PR ensures that the correct promoter information is displayed when a promotion is manually triggered.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
