### PR TITLE
feat(plumber): inject SEMAPHORE_BLOCK_NAME env to jobs

### DIFF
--- a/docs/docs/reference/env-vars.md
+++ b/docs/docs/reference/env-vars.md
@@ -88,7 +88,7 @@ A string with a user-supplied name for the job.
 - **Environment variable**: `SEMAPHORE_JOB_COUNT`
 - **Example**: 4
 
-Only available when [job parallelism](../using-semaphore/jobs#job-parallelism) is enabled. This variable holds the total number of jobs configured in job parallelism. 
+Only available when [job parallelism](../using-semaphore/jobs#job-parallelism) is enabled. This variable holds the total number of jobs configured in job parallelism.
 
 It can be used to configure a test partitioning strategy using a 3rd party test runner.
 
@@ -129,6 +129,13 @@ Describes why the current job was created. The possible values are:
 - `pipeline_job`: a regular job created by Semaphore as part of the workflow
 - `project_debug_job`: job created with [`sem debug project`](./semaphore-cli#sem-debug-project)
 - `debug_job`: job created with [`sem debug job`](./semaphore-cli#sem-debug)
+
+### Block name {#block-name}
+
+- **Environment variable**: `SEMAPHORE_BLOCK_NAME`
+- **Example**: `Security checks`
+
+A string with a user-supplied block name.
 
 ### Organization URL {#organization-url}
 
@@ -504,7 +511,7 @@ The time that the pipeline spent in the queue is expressed in seconds.
 - **Environment variable**: `SEMAPHORE_PIPELINE_RESULT`
 - **Example**: `failed`, `passed`, `canceled`, `stopped`
 
-Contains the result of the pipeline. Possible values are: `failed`, `passed`, `canceled`, `stopped` 
+Contains the result of the pipeline. Possible values are: `failed`, `passed`, `canceled`, `stopped`
 
 ### Pipeline result reason {#pipeline-result-reason}
 

--- a/plumber/ppl/lib/ppl/definition_reviser/blocks_reviser.ex
+++ b/plumber/ppl/lib/ppl/definition_reviser/blocks_reviser.ex
@@ -1,4 +1,5 @@
 defmodule Ppl.DefinitionReviser.BlocksReviser do
+  require Logger
   @moduledoc """
   Module performs necessary transformations on raw block definition.
   """
@@ -11,6 +12,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
   @ppl_artefact_id_env_var_name "SEMAPHORE_PIPELINE_ARTEFACT_ID"
   @ppl_id_env_var_name "SEMAPHORE_PIPELINE_ID"
   @pipeline_rerun "SEMAPHORE_PIPELINE_RERUN"
+  @block_name "SEMAPHORE_BLOCK_NAME"
   @pipeline_promotion "SEMAPHORE_PIPELINE_PROMOTION"
   @pipeline_promoted_by "SEMAPHORE_PIPELINE_PROMOTED_BY"
   @workflow_id_env_var_name "SEMAPHORE_WORKFLOW_ID"
@@ -234,7 +236,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
   defp set_ppl_env_vars_(block_def, ppl_req, ppl, promoter, triggerer) do
     ppl_env_vars =
       ppl_req
-      |> basic_env_vars(ppl, promoter, triggerer)
+      |> basic_env_vars(ppl, promoter, triggerer, block_def)
       |> env_vars_from_prev_ppl_artefact_ids(ppl_req.prev_ppl_artefact_ids ++ [ppl_req.ppl_artefact_id])
       |> Enum.concat(Map.get(ppl_req.request_args, "env_vars", []))
 
@@ -253,8 +255,9 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
     list ++ prev_ids_env_vars
   end
 
-  defp basic_env_vars(ppl_req, ppl, promoter, triggerer) do
+  defp basic_env_vars(ppl_req, ppl, promoter, triggerer, block_def) do
     snapshot_id = get_snapshot_id(ppl_req.request_args)
+    block_name = get_block_name(block_def)
 
     [
      %{"name" => @workflow_id_env_var_name, "value" => "#{ppl_req.wf_id}"},
@@ -267,6 +270,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
      %{"name" => @workflow_triggered_by_manual_run, "value" => manual_run?(ppl_req.request_args)},
      %{"name" => @ppl_artefact_id_env_var_name, "value" => "#{ppl_req.ppl_artefact_id}"},
      %{"name" => @ppl_id_env_var_name, "value" => "#{ppl_req.id}"},
+     %{"name" => @block_name, "value" => block_name},
      %{"name" => @pipeline_rerun, "value" => ppl_rerun?(ppl.partial_rebuild_of)},
      %{"name" => @pipeline_promotion, "value" => promotion?(ppl.extension_of)},
      %{"name" => @pipeline_promoted_by, "value" => promoter},
@@ -312,4 +316,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
   defp committer(source_args) when is_map(source_args),
     do: Map.get(source_args, "repo_host_username", "")
   defp committer(_source_args), do: ""
+
+  defp get_block_name(%{"name" => name}), do: name
+  defp get_block_name(_block_def), do: ""
 end

--- a/plumber/ppl/test/definition_reviser/blocks_reviser_test.exs
+++ b/plumber/ppl/test/definition_reviser/blocks_reviser_test.exs
@@ -26,7 +26,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
     assert {:ok, real_ppl_req} = PplRequestsQueries.get_by_id(ppl_id)
 
     agent = %{"machine" => %{"type" => "e1-standard-2", "os_image" => "ubuntu1804"}}
-    blocks = [%{"build" => %{}}, %{"build" => %{}}]
+    blocks = [%{"build" => %{}, "name" => "blk 0"}, %{"build" => %{}, "name" => "blk 1"}]
     ppl_def = %{"agent" => agent, "blocks" => blocks}
     args = %{"service" => "local", "repo_name" => "4_cmd_file", "branch_name" => "master",
             "commit_sha" => "sha_1", "working_dir" => ".semaphore", "file_name" => "semaphore.yml"}
@@ -38,6 +38,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
 
   @ppl_id_env_var_name "SEMAPHORE_PIPELINE_ID"
   @artefact_id_env_var_name "SEMAPHORE_PIPELINE_ARTEFACT_ID"
+  @block_name "SEMAPHORE_BLOCK_NAME"
   @pipeline_rerun "SEMAPHORE_PIPELINE_RERUN"
   @pipeline_promotion "SEMAPHORE_PIPELINE_PROMOTION"
   @pipeline_promoted_by "SEMAPHORE_PIPELINE_PROMOTED_BY"
@@ -76,24 +77,26 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
     assert %{"blocks" => blocks} = revised_def
     assert is_list(blocks)
 
-    expected_env_vars = [%{"name" => @workflow_id_env_var_name, "value" => ctx.ppl_req.wf_id},
-                         %{"name" => @workflow_number_env_var_name, "value" => "1"},
-                         %{"name" => @workflow_rerun, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_hook, "value" => "true"},
-                         %{"name" => @workflow_hook_source, "value" => "github"},
-                         %{"name" => @workflow_triggered_by_schedule, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_api, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
-                         %{"name" => @artefact_id_env_var_name, "value" => "A1"},
-                         %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
-                         %{"name" => @pipeline_rerun, "value" => "false"},
-                         %{"name" => @pipeline_promotion, "value" => "false"},
-                         %{"name" => @pipeline_promoted_by, "value" => ""},
-                         %{"name" => @workflow_triggered_by, "value" => "gh_username_1"},
-                         %{"name" => @git_commit_author, "value" => "gh_username_2"},
-                         %{"name" => @git_committer, "value" => "gh_username_1"},
-                         %{"name" => "SEMAPHORE_PIPELINE_0_ARTEFACT_ID", "value" => "A1"}]
     blocks |> Enum.map(fn block ->
+      expected_env_vars = [%{"name" => @workflow_id_env_var_name, "value" => ctx.ppl_req.wf_id},
+        %{"name" => @workflow_number_env_var_name, "value" => "1"},
+        %{"name" => @workflow_rerun, "value" => "false"},
+        %{"name" => @workflow_triggered_by_hook, "value" => "true"},
+        %{"name" => @workflow_hook_source, "value" => "github"},
+        %{"name" => @workflow_triggered_by_schedule, "value" => "false"},
+        %{"name" => @workflow_triggered_by_api, "value" => "false"},
+        %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
+        %{"name" => @artefact_id_env_var_name, "value" => "A1"},
+        %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
+        %{"name" => @block_name, "value" => block["name"]},
+        %{"name" => @pipeline_rerun, "value" => "false"},
+        %{"name" => @pipeline_promotion, "value" => "false"},
+        %{"name" => @pipeline_promoted_by, "value" => ""},
+        %{"name" => @workflow_triggered_by, "value" => "gh_username_1"},
+        %{"name" => @git_commit_author, "value" => "gh_username_2"},
+        %{"name" => @git_committer, "value" => "gh_username_1"},
+        %{"name" => "SEMAPHORE_PIPELINE_0_ARTEFACT_ID", "value" => "A1"}]
+
       assert is_map(block)
       assert get_in(block, ["build", "ppl_env_variables"]) == expected_env_vars
     end)
@@ -107,26 +110,27 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
     assert %{"blocks" => blocks} = revised_def
     assert is_list(blocks)
 
-    expected_env_vars = [%{"name" => @workflow_id_env_var_name, "value" => ctx.ppl_req.wf_id},
-                         %{"name" => @workflow_number_env_var_name, "value" => "1"},
-                         %{"name" => @workflow_rerun, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_hook, "value" => "true"},
-                         %{"name" => @workflow_hook_source, "value" => "github"},
-                         %{"name" => @workflow_triggered_by_schedule, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_api, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
-                         %{"name" => @artefact_id_env_var_name, "value" => "A1"},
-                         %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
-                         %{"name" => @pipeline_rerun, "value" => "false"},
-                         %{"name" => @pipeline_promotion, "value" => "false"},
-                         %{"name" => @pipeline_promoted_by, "value" => ""},
-                         %{"name" => @workflow_triggered_by, "value" => "gh_username_1"},
-                         %{"name" => @git_commit_author, "value" => "gh_username_2"},
-                         %{"name" => @git_committer, "value" => "gh_username_1"},
-                         %{"name" => "SEMAPHORE_PIPELINE_0_ARTEFACT_ID", "value" => "A1"},
-                         %{"name" => "TEST", "value" => "VALUE"}]
-
     blocks |> Enum.map(fn block ->
+      expected_env_vars = [%{"name" => @workflow_id_env_var_name, "value" => ctx.ppl_req.wf_id},
+        %{"name" => @workflow_number_env_var_name, "value" => "1"},
+        %{"name" => @workflow_rerun, "value" => "false"},
+        %{"name" => @workflow_triggered_by_hook, "value" => "true"},
+        %{"name" => @workflow_hook_source, "value" => "github"},
+        %{"name" => @workflow_triggered_by_schedule, "value" => "false"},
+        %{"name" => @workflow_triggered_by_api, "value" => "false"},
+        %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
+        %{"name" => @artefact_id_env_var_name, "value" => "A1"},
+        %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
+        %{"name" => @block_name, "value" => block["name"]},
+        %{"name" => @pipeline_rerun, "value" => "false"},
+        %{"name" => @pipeline_promotion, "value" => "false"},
+        %{"name" => @pipeline_promoted_by, "value" => ""},
+        %{"name" => @workflow_triggered_by, "value" => "gh_username_1"},
+        %{"name" => @git_commit_author, "value" => "gh_username_2"},
+        %{"name" => @git_committer, "value" => "gh_username_1"},
+        %{"name" => "SEMAPHORE_PIPELINE_0_ARTEFACT_ID", "value" => "A1"},
+        %{"name" => "TEST", "value" => "VALUE"}]
+
       assert is_map(block)
       assert get_in(block, ["build", "ppl_env_variables"]) == expected_env_vars
     end)
@@ -137,26 +141,27 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
     assert {:ok, revised_def} = BlocksReviser.revise_blocks_definition(ctx.ppl_def, ppl_req)
     assert %{"blocks" => blocks} = revised_def
     assert is_list(blocks)
-
-    expected_env_vars = [%{"name" => @workflow_id_env_var_name, "value" => ctx.ppl_req.wf_id},
-                         %{"name" => @workflow_number_env_var_name, "value" => "1"},
-                         %{"name" => @workflow_rerun, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_hook, "value" => "true"},
-                         %{"name" => @workflow_hook_source, "value" => "github"},
-                         %{"name" => @workflow_triggered_by_schedule, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_api, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
-                         %{"name" => @artefact_id_env_var_name, "value" => "A1"},
-                         %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
-                         %{"name" => @pipeline_rerun, "value" => "false"},
-                         %{"name" => @pipeline_promotion, "value" => "false"},
-                         %{"name" => @pipeline_promoted_by, "value" => ""},
-                         %{"name" => @workflow_triggered_by, "value" => "gh_username_1"},
-                         %{"name" => @git_commit_author, "value" => "gh_username_2"},
-                         %{"name" => @git_committer, "value" => "gh_username_1"},
-                         %{"name" => "SEMAPHORE_PIPELINE_0_ARTEFACT_ID", "value" => "Previous id value"},
-                         %{"name" => "SEMAPHORE_PIPELINE_1_ARTEFACT_ID", "value" => "A1"}]
     blocks |> Enum.map(fn block ->
+      expected_env_vars = [%{"name" => @workflow_id_env_var_name, "value" => ctx.ppl_req.wf_id},
+        %{"name" => @workflow_number_env_var_name, "value" => "1"},
+        %{"name" => @workflow_rerun, "value" => "false"},
+        %{"name" => @workflow_triggered_by_hook, "value" => "true"},
+        %{"name" => @workflow_hook_source, "value" => "github"},
+        %{"name" => @workflow_triggered_by_schedule, "value" => "false"},
+        %{"name" => @workflow_triggered_by_api, "value" => "false"},
+        %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
+        %{"name" => @artefact_id_env_var_name, "value" => "A1"},
+        %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
+        %{"name" => @block_name, "value" => block["name"]},
+        %{"name" => @pipeline_rerun, "value" => "false"},
+        %{"name" => @pipeline_promotion, "value" => "false"},
+        %{"name" => @pipeline_promoted_by, "value" => ""},
+        %{"name" => @workflow_triggered_by, "value" => "gh_username_1"},
+        %{"name" => @git_commit_author, "value" => "gh_username_2"},
+        %{"name" => @git_committer, "value" => "gh_username_1"},
+        %{"name" => "SEMAPHORE_PIPELINE_0_ARTEFACT_ID", "value" => "Previous id value"},
+        %{"name" => "SEMAPHORE_PIPELINE_1_ARTEFACT_ID", "value" => "A1"}]
+
       assert is_map(block)
       assert get_in(block, ["build", "ppl_env_variables"]) == expected_env_vars
     end)
@@ -199,25 +204,25 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
     assert %{"blocks" => blocks} = revised_def
     assert is_list(blocks)
 
-    expected_env_vars = [%{"name" => @workflow_id_env_var_name, "value" => ctx.ppl_req.wf_id},
-                         %{"name" => @workflow_number_env_var_name, "value" => "1"},
-                         %{"name" => @workflow_rerun, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_hook, "value" => "true"},
-                         %{"name" => @workflow_hook_source, "value" => "github"},
-                         %{"name" => @workflow_triggered_by_schedule, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_api, "value" => "false"},
-                         %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
-                         %{"name" => @artefact_id_env_var_name, "value" => "A1"},
-                         %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
-                         %{"name" => @pipeline_rerun, "value" => "false"},
-                         %{"name" => @pipeline_promotion, "value" => "false"},
-                         %{"name" => @pipeline_promoted_by, "value" => "github_username_1"},
-                         %{"name" => @workflow_triggered_by, "value" => "github_username_2"},
-                         %{"name" => @git_commit_author, "value" => "gh_username_2"},
-                         %{"name" => @git_committer, "value" => "gh_username_1"},
-                         %{"name" => "SEMAPHORE_PIPELINE_0_ARTEFACT_ID", "value" => "A1"}]
-
     blocks |> Enum.map(fn block ->
+      expected_env_vars = [%{"name" => @workflow_id_env_var_name, "value" => ctx.ppl_req.wf_id},
+        %{"name" => @workflow_number_env_var_name, "value" => "1"},
+        %{"name" => @workflow_rerun, "value" => "false"},
+        %{"name" => @workflow_triggered_by_hook, "value" => "true"},
+        %{"name" => @workflow_hook_source, "value" => "github"},
+        %{"name" => @workflow_triggered_by_schedule, "value" => "false"},
+        %{"name" => @workflow_triggered_by_api, "value" => "false"},
+        %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
+        %{"name" => @artefact_id_env_var_name, "value" => "A1"},
+        %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
+        %{"name" => @block_name, "value" => block["name"]},
+        %{"name" => @pipeline_rerun, "value" => "false"},
+        %{"name" => @pipeline_promotion, "value" => "false"},
+        %{"name" => @pipeline_promoted_by, "value" => "github_username_1"},
+        %{"name" => @workflow_triggered_by, "value" => "github_username_2"},
+        %{"name" => @git_commit_author, "value" => "gh_username_2"},
+        %{"name" => @git_committer, "value" => "gh_username_1"},
+        %{"name" => "SEMAPHORE_PIPELINE_0_ARTEFACT_ID", "value" => "A1"}]
       assert is_map(block)
       assert get_in(block, ["build", "ppl_env_variables"]) == expected_env_vars
     end)

--- a/plumber/ppl/test/ppl_blocks/stm_handler/run_test.exs
+++ b/plumber/ppl/test/ppl_blocks/stm_handler/run_test.exs
@@ -44,7 +44,7 @@ defmodule Ppl.PplBlocks.STMHandler.WaitingState.Test do
     assert {:ok, ppl_blk} = insert_ppl_blk(ppl_id, 0)
     assert ppl_blk.state == "waiting"
 
-    with_mock Block, [schedule: &(mocked_schedule({&1, ppl_id, workflow_id, ctx.ppl_req.request_args})),
+    with_mock Block, [schedule: &(mocked_schedule({&1, ppl_id, workflow_id, ctx.ppl_req.request_args, ppl_blk.name})),
                       status: &mocked_status(&1)] do
       assert {:ok, result_func} = WaitingState.scheduling_handler(ppl_blk)
 
@@ -65,7 +65,7 @@ defmodule Ppl.PplBlocks.STMHandler.WaitingState.Test do
 
     insert_connections(ctx.ppl_req)
 
-    with_mock Block, [schedule: &(mocked_schedule({&1, ppl_id, workflow_id, ctx.ppl_req.request_args})),
+    with_mock Block, [schedule: &(mocked_schedule({&1, ppl_id, workflow_id, ctx.ppl_req.request_args, ppl_blk.name})),
                       status: &mocked_status(&1)] do
       assert {:ok, result_func} = WaitingState.scheduling_handler(ppl_blk)
 
@@ -86,7 +86,7 @@ defmodule Ppl.PplBlocks.STMHandler.WaitingState.Test do
 
     insert_connections(ctx.ppl_req)
 
-    with_mock Block, [schedule: &(mocked_schedule({&1, ppl_id, workflow_id, ctx.ppl_req.request_args})),
+    with_mock Block, [schedule: &(mocked_schedule({&1, ppl_id, workflow_id, ctx.ppl_req.request_args, ppl_blk.name})),
                       status: &mocked_status(&1)] do
       assert {:ok, result_func} = WaitingState.scheduling_handler(ppl_blk)
 
@@ -122,7 +122,7 @@ defmodule Ppl.PplBlocks.STMHandler.WaitingState.Test do
     {:ok, ppl_blk}
   end
 
-  defp mocked_schedule({schedule_request, id, workflow_id, req_args}) do
+  defp mocked_schedule({schedule_request, id, workflow_id, req_args, blk_name}) do
     assert schedule_request.ppl_id == id
     assert get_in(schedule_request.definition, ["build", "agent", "machine"]) == %{"os_image" => "bar", "type" => "foo"}
     ppl_env_vars = [%{"name" => "SEMAPHORE_WORKFLOW_ID", "value" => "#{workflow_id}"},
@@ -135,6 +135,7 @@ defmodule Ppl.PplBlocks.STMHandler.WaitingState.Test do
                     %{"name" => "SEMAPHORE_WORKFLOW_TRIGGERED_BY_MANUAL_RUN", "value" => "false"},
                     %{"name" => "SEMAPHORE_PIPELINE_ARTEFACT_ID", "value" => "#{id}"},
                     %{"name" => "SEMAPHORE_PIPELINE_ID", "value" => "#{id}"},
+                    %{"name" => "SEMAPHORE_BLOCK_NAME", "value" => blk_name},
                     %{"name" => "SEMAPHORE_PIPELINE_RERUN", "value" => "false"},
                     %{"name" => "SEMAPHORE_PIPELINE_PROMOTION", "value" => "false"},
                     %{"name" => "SEMAPHORE_PIPELINE_PROMOTED_BY", "value" => ""},

--- a/plumber/ppl/test/ppl_sub_inits/stm_handler/compilation/definition_test.exs
+++ b/plumber/ppl/test/ppl_sub_inits/stm_handler/compilation/definition_test.exs
@@ -526,7 +526,7 @@ defmodule Ppl.PplSubInits.STMHandler.Compilation.Definition.Test do
     assert {:ok, definition} = Definition.form_definition(ppl_req, :undefined, settings, :prod)
     assert list = Map.get(definition, "jobs") |> Enum.at(0) |> Map.get("env_vars")
     assert is_list(list)
-    assert Enum.count(list) == 18
+    assert Enum.count(list) == 19
 
     yml_path_ev = Enum.find(list, fn map -> map["name"] == "SEMAPHORE_YAML_FILE_PATH" end)
     assert yml_path_ev["value"] == ".semaphore/semaphore.yml"


### PR DESCRIPTION
## 📝 Description
Adding SEMAPHORE_BLOCK_NAME env variable to jobs. This will allow showing better metrics about jobs on a workflow.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
