### PR TITLE
toil(helm): remove imagePullPolicy override

### DIFF
--- a/artifacthub/helm/templates/dpl-bucketcleaner-scheduler.yml
+++ b/artifacthub/helm/templates/dpl-bucketcleaner-scheduler.yml
@@ -26,7 +26,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-bucketcleaner-scheduler
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/artifacthub/helm/templates/dpl-bucketcleaner-worker.yml
+++ b/artifacthub/helm/templates/dpl-bucketcleaner-worker.yml
@@ -26,7 +26,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-bucketcleaner-worker
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/artifacthub/helm/templates/dpl-internal-api.yaml
+++ b/artifacthub/helm/templates/dpl-internal-api.yaml
@@ -41,7 +41,6 @@ spec:
       containers:
         - name: "{{ .Chart.Name }}-internal-grpc-api"
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/artifacthub/helm/templates/dpl-public-api.yaml
+++ b/artifacthub/helm/templates/dpl-public-api.yaml
@@ -41,7 +41,6 @@ spec:
       containers:
         - name: "{{ .Chart.Name }}-public-grpc-api"
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/branch_hub/helm/templates/deployment.yaml
+++ b/branch_hub/helm/templates/deployment.yaml
@@ -42,7 +42,6 @@ spec:
       containers:
         - name: {{ $baseName }}
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           ports:
             - name: grpc-port
               containerPort: 50051

--- a/ee/audit/helm/templates/deployment.yaml
+++ b/ee/audit/helm/templates/deployment.yaml
@@ -42,7 +42,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args: ["bin/audit eval \"Audit.Release.create_and_migrate()\" && bin/audit start"]
           ports:

--- a/ee/gofer/helm/templates/dpl.yaml
+++ b/ee/gofer/helm/templates/dpl.yaml
@@ -46,7 +46,6 @@ spec:
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
           command: ["/bin/sh", "-c"]
           args: ["bin/gofer eval \"Gofer.ReleaseTasks.migrate()\" && bin/gofer start"]
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/ee/velocity/helm/templates/api.yaml
+++ b/ee/velocity/helm/templates/api.yaml
@@ -34,7 +34,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-api
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/ee/velocity/helm/templates/emitter.yaml
+++ b/ee/velocity/helm/templates/emitter.yaml
@@ -19,7 +19,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-metric-emitter
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/ee/velocity/helm/templates/metric-aggregator.yaml
+++ b/ee/velocity/helm/templates/metric-aggregator.yaml
@@ -19,7 +19,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-metric-aggregator
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/ee/velocity/helm/templates/summary-worker.yaml
+++ b/ee/velocity/helm/templates/summary-worker.yaml
@@ -19,7 +19,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-summary-worker
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/ee/velocity/helm/templates/worker.yaml
+++ b/ee/velocity/helm/templates/worker.yaml
@@ -19,7 +19,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-worker
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/front/helm/templates/job-page.yaml
+++ b/front/helm/templates/job-page.yaml
@@ -62,7 +62,6 @@ spec:
       containers:
         - name: "job-page"
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/front/helm/templates/project-page.yaml
+++ b/front/helm/templates/project-page.yaml
@@ -88,7 +88,6 @@ spec:
       containers:
         - name: "project-page"
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/front/helm/templates/ui-cache-reactor.yaml
+++ b/front/helm/templates/ui-cache-reactor.yaml
@@ -42,7 +42,6 @@ spec:
       containers:
         - name: "ui-cache-reactor"
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/github_hooks/helm/templates/hooks-dpl.yaml
+++ b/github_hooks/helm/templates/hooks-dpl.yaml
@@ -31,7 +31,6 @@ spec:
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
           command: ["bash", "-c"]
           args: ["bundle exec rails db:create db:migrate && bundle exec puma"]
-          imagePullPolicy: Always
           ports:
             - name: web-port
               containerPort: 3000

--- a/github_hooks/helm/templates/sidekiq-web-dpl.yaml
+++ b/github_hooks/helm/templates/sidekiq-web-dpl.yaml
@@ -29,7 +29,6 @@ spec:
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
           command: ["bash", "-c"]
           args: ["bundle exec puma sidekiq.ru -C config/puma_sidekiq.rb"]
-          imagePullPolicy: Always
           ports:
             - name: web-port
               containerPort: 3000

--- a/github_notifier/helm/templates/api.yaml
+++ b/github_notifier/helm/templates/api.yaml
@@ -36,7 +36,6 @@ spec:
       containers:
         - name: "{{ .Chart.Name }}-api"
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/github_notifier/helm/templates/consumer.yaml
+++ b/github_notifier/helm/templates/consumer.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
         - name: "{{ .Chart.Name }}-consumer"
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/keycloak/setup/helm/templates/setup-job.yaml
+++ b/keycloak/setup/helm/templates/setup-job.yaml
@@ -21,7 +21,6 @@ spec:
       containers:
       - name: {{ .Chart.Name }}-job
         image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-        imagePullPolicy: Always
         env:
           - name: BASE_DOMAIN
             valueFrom: { configMapKeyRef: { name: {{ .Values.global.domain.configMapName }}, key: BASE_DOMAIN } }

--- a/projecthub-rest-api/helm/templates/dpl.yaml
+++ b/projecthub-rest-api/helm/templates/dpl.yaml
@@ -43,7 +43,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           ports:
             - name: http-port
               containerPort: 4000

--- a/projecthub/helm/templates/dpl.yaml
+++ b/projecthub/helm/templates/dpl.yaml
@@ -53,7 +53,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-grpc
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/repository_hub/helm/templates/deployment.yaml
+++ b/repository_hub/helm/templates/deployment.yaml
@@ -47,7 +47,6 @@ spec:
       containers:
         - name: {{ $chartName }}
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/scouter/helm/templates/scouter-api.yaml
+++ b/scouter/helm/templates/scouter-api.yaml
@@ -47,7 +47,6 @@ spec:
       containers:
         - name: "{{ .Chart.Name }}-api"
           image: "{{ .Values.global.image.registry }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## 📝 Description

`imagePullPolicy: Always` forces Kubernetes to pull the image on every pod start, even if it's already present locally. This is unnecessary for Semaphore, where the default `IfNotPresent` is more appropriate and compatible with local workflows like Skaffold.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
