### PR TITLE
feat(front): enable writable root FS and live reload for front

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -45,20 +45,18 @@ RUN mix sentry_recompile && mix compile --warnings-as-errors
 # -- elixir stage
 
 # -- node stage
-FROM base AS node
-WORKDIR /node
-COPY front/assets/package.json front/assets/package-lock.json ./
-RUN npm install
+FROM node:16-alpine as node
 WORKDIR /assets
-COPY front/assets /assets
-RUN mv /node/node_modules /assets/node_modules
+COPY front/assets/package.json front/assets/package-lock.json ./
+RUN npm set progress=false && npm install
+COPY front/assets ./
 # -- node stage
 
 # -- dev stage - for local development
 FROM elixir AS dev
 WORKDIR /app
 RUN apk update \
-    && apk add --no-cache chromium-chromedriver inotify-tools bash gnupg
+    && apk add --no-cache chromium-chromedriver inotify-tools bash gnupg entr
 
 COPY --from=elixir /elixir ./
 COPY --from=node /assets ./assets
@@ -66,7 +64,7 @@ WORKDIR /app/assets
 RUN node build.js
 WORKDIR /app
 
-CMD [ "/bin/ash",  "-c \"while sleep 1000; do :; done\"" ]
+CMD ["sh", "-c", "find lib config | entr -n -r mix phx.server"]
 # -- dev stage
 
 # -- builder stage - build artifacts are created here

--- a/front/helm/templates/job-page.yaml
+++ b/front/helm/templates/job-page.yaml
@@ -66,7 +66,7 @@ spec:
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: {{ not .Values.global.development.writableRootFilesystem | default true }}
             capabilities:
               drop:
                 - ALL

--- a/front/helm/templates/project-page.yaml
+++ b/front/helm/templates/project-page.yaml
@@ -92,7 +92,7 @@ spec:
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: {{ not .Values.global.development.writableRootFilesystem | default true }}
             capabilities:
               drop:
                 - ALL
@@ -200,6 +200,7 @@ spec:
               port: http-port
             initialDelaySeconds: 30
             periodSeconds: 10
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /is_alive

--- a/front/helm/templates/ui-cache-reactor.yaml
+++ b/front/helm/templates/ui-cache-reactor.yaml
@@ -46,7 +46,7 @@ spec:
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: {{ not .Values.global.development.writableRootFilesystem | default true }}
             capabilities:
               drop:
                 - ALL
@@ -154,13 +154,6 @@ spec:
               path: /is_alive
               port: http-port
             periodSeconds: 2
-          securityContext:
-            privileged: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
 
 {{- if .Values.cacheReactor.resources }}
           resources:

--- a/helm-chart/values.yaml.in
+++ b/helm-chart/values.yaml.in
@@ -2,6 +2,13 @@ global:
   # Edition of Semaphore to install (ce or ee)
   edition: "ce"
 
+  development:
+    #
+    # When true, mounts a writable root filesystem in containers
+    # to support local development tools.
+    #
+    writableRootFilesystem: false
+
   domain:
     ip: ""
     name: ""


### PR DESCRIPTION
## 📝 Description
These changes improve the local development experience when running the cluster locally by enabling file syncing and automatic server restarts. They address local compatibility issues and allow runtime file writes inside pods still running under MIX_ENV=prod.

- Replaced custom Node Dockerfile stage with node:16-alpine to fix local build issues.
- Added `entr` for watching file changes during development.
- Changed CMD to restart Phoenix server using `entr` on source file updates.
- Made `readOnlyRootFilesystem` configurable based on the new flag.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
