### PR TITLE
fix(guard): add correct owner filter for list projects by owner

### DIFF
--- a/guard/lib/guard/api/project.ex
+++ b/guard/lib/guard/api/project.ex
@@ -93,7 +93,8 @@ defmodule Guard.Api.Project do
         InternalApi.Projecthub.PaginationRequest.new(
           page: opts[:page] || 1,
           page_size: @project_page_size
-        )
+        ),
+      owner_id: opts[:owner_id] || ""
     )
   end
 end


### PR DESCRIPTION
## 📝 Description
- Add correct owner filter for list projects by owner besides user_id
- Instead of getting project owner projects, it was getting all projects related to the user, blocking the deletion of the user by the API, independent of how many projects he has
- Since our tests are mocking this response, it was not able to test its correctness

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
