### PR TITLE
docs: Specify parser in docs for PHPUnit

### DIFF
--- a/docs/docs/using-semaphore/languages/php.md
+++ b/docs/docs/using-semaphore/languages/php.md
@@ -73,7 +73,7 @@ This section explains how to set up [test reports](../../using-semaphore/tests/t
 2. Create an [after_pipeline job](../../using-semaphore/pipelines#after-pipeline-job) with the following command:
 
     ```shell
-    test-results publish junit.xml
+    test-results publish --parser phpunit junit.xml
     ```
 
 </Steps>


### PR DESCRIPTION
## 📝 Description
I've added information about specifying the parser in this case. If the user does not specify it, the test result tab will show that no tests have been executed.

## ✅ Checklist
- [X] have tested this change
- [X] This change requires documentation update
