### PR TITLE
feat(zebra): Configure max job time limit based on a feature flag

### DIFF
--- a/zebra/lib/zebra/apis/internal_task_api/schedule.ex
+++ b/zebra/lib/zebra/apis/internal_task_api/schedule.ex
@@ -72,7 +72,8 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
         repository_id: req.repository_id,
         machine_type: job_req.agent.machine.type,
         machine_os_image: job_req.agent.machine.os_image,
-        execution_time_limit: valid_time_limit(job_req.execution_time_limit),
+        execution_time_limit:
+          configure_execution_time_limit(req.org_id, job_req.execution_time_limit),
         priority: valid_priority(job_req.priority),
         spec:
           Spec.new(
@@ -126,11 +127,32 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
   defp valid_priority(_), do: @default_job_priority
 
   # value of execution_time_limit is received in minutes and it is stored in seconds
-  defp valid_time_limit(value)
-       when value > 0 and value <= @max_job_execution_time_limit,
-       do: value * 60
+  def configure_execution_time_limit(org_id, req_value) do
+    {max_job_time_limit, deafult_job_time_limit} = find_max_and_default_job_time_limits(org_id)
 
-  defp valid_time_limit(_), do: @default_job_execution_time_limit
+    if req_value > 0 and req_value <= max_job_time_limit do
+      req_value * 60
+    else
+      deafult_job_time_limit
+    end
+  end
+
+  defp find_max_and_default_job_time_limits(org_id) do
+    if FeatureProvider.feature_enabled?(:max_job_execution_time_limit, param: org_id) do
+      max_limit = FeatureProvider.feature_quota(:max_job_execution_time_limit, param: org_id)
+
+      deafult_limit =
+        if max_limit * 60 < @default_job_execution_time_limit do
+          max_limit * 60
+        else
+          @default_job_execution_time_limit
+        end
+
+      {max_limit, deafult_limit}
+    else
+      {@max_job_execution_time_limit, @default_job_execution_time_limit}
+    end
+  end
 
   def encode_fail_fast_strategy(strategy) do
     alias InternalApi.Task.ScheduleRequest.FailFast, as: FF

--- a/zebra/lib/zebra/apis/internal_task_api/schedule.ex
+++ b/zebra/lib/zebra/apis/internal_task_api/schedule.ex
@@ -141,14 +141,14 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
     if FeatureProvider.feature_enabled?(:max_job_execution_time_limit, param: org_id) do
       max_limit = FeatureProvider.feature_quota(:max_job_execution_time_limit, param: org_id)
 
-      deafult_limit =
+      default_limit =
         if max_limit * 60 < @default_job_execution_time_limit do
           max_limit * 60
         else
           @default_job_execution_time_limit
         end
 
-      {max_limit, deafult_limit}
+      {max_limit, default_limit}
     else
       {@max_job_execution_time_limit, @default_job_execution_time_limit}
     end

--- a/zebra/test/support/stubbed_provider.ex
+++ b/zebra/test/support/stubbed_provider.ex
@@ -2,13 +2,26 @@ defmodule Support.StubbedProvider do
   use FeatureProvider.Provider
 
   @impl FeatureProvider.Provider
-  def provide_features(_org_id \\ nil, _opts \\ []) do
+  def provide_features(org_id \\ nil, _opts \\ []) do
     {:ok,
      [
        feature("max_paralellism_in_org", [:enabled, {:quantity, 500}]),
        feature("cache_cli_parallel_archive_method", [:hidden]),
-       feature("some_custom_feature", [:hidden])
+       feature("some_custom_feature", [:hidden]),
+       max_job_time_limit_feature(org_id)
      ]}
+  end
+
+  defp max_job_time_limit_feature("enabled_30") do
+    feature("max_job_execution_time_limit", [:enabled, {:quantity, 30}])
+  end
+
+  defp max_job_time_limit_feature("enabled_48h") do
+    feature("max_job_execution_time_limit", [:enabled, {:quantity, 48 * 60}])
+  end
+
+  defp max_job_time_limit_feature(_org_id) do
+    feature("max_job_execution_time_limit", [:hidden])
   end
 
   @impl FeatureProvider.Provider

--- a/zebra/test/zebra/apis/internal_task_api/schedule_test.exs
+++ b/zebra/test/zebra/apis/internal_task_api/schedule_test.exs
@@ -154,14 +154,14 @@ defmodule Zebra.Apis.InternalTaskApi.ScheduleTest do
     test "when feature is disabled and limit from request is invalid => returns default limit in seconds" do
       org_id = UUID.uuid4()
 
-      # if requested limit <= 0 -> configure it to deafult one
+      # if requested limit <= 0 -> configure it to default one
       assert @default_job_execution_time_limit ==
                Schedule.configure_execution_time_limit(org_id, 0)
 
       assert @default_job_execution_time_limit ==
                Schedule.configure_execution_time_limit(org_id, -5)
 
-      # if requested limit >= max time limit -> configure it to deafult one
+      # if requested limit >= max time limit -> configure it to default one
       assert @default_job_execution_time_limit ==
                Schedule.configure_execution_time_limit(org_id, 48 * 60)
     end
@@ -173,22 +173,22 @@ defmodule Zebra.Apis.InternalTaskApi.ScheduleTest do
       assert 15 * 60 == Schedule.configure_execution_time_limit(org_id, 15)
     end
 
-    test "when feature is enabled, limit from request is invalid, and feature limit >= deafult limit  => returns deafult limit" do
+    test "when feature is enabled, limit from request is invalid, and feature limit >= default limit  => returns default limit" do
       org_id = "enabled_48h"
 
-      # if requested limit <= 0 and feature limit >= max limit -> configure it to deafult one
+      # if requested limit <= 0 and feature limit >= max limit -> configure it to default one
       assert @default_job_execution_time_limit ==
                Schedule.configure_execution_time_limit(org_id, 0)
 
       assert @default_job_execution_time_limit ==
                Schedule.configure_execution_time_limit(org_id, -5)
 
-      # if requested limit > feature limit and feature limit >= max limit -> configure it to deafult one
+      # if requested limit > feature limit and feature limit >= max limit -> configure it to default one
       assert @default_job_execution_time_limit ==
                Schedule.configure_execution_time_limit(org_id, 72 * 60)
     end
 
-    test "when feature is enabled, limit from request is invalid, and feature limit < deafult limit  => returns feature limit" do
+    test "when feature is enabled, limit from request is invalid, and feature limit < default limit  => returns feature limit" do
       org_id = "enabled_30"
 
       # if requested limit <= 0 and feature limit < max limit -> configure it to feature limit

--- a/zebra/test/zebra/workers/feature_provider_invalidator_worker_test.exs
+++ b/zebra/test/zebra/workers/feature_provider_invalidator_worker_test.exs
@@ -99,7 +99,7 @@ defmodule Zebra.Workers.FeatureProviderInvalidatorWorkerTest do
       Worker.features_changed(callback_message)
 
       {:ok, features} = FeatureProvider.list_features()
-      assert length(features) == 3
+      assert length(features) == 4
     end
 
     test "when the organization feature state changes, organization feature caches are invalidated" do


### PR DESCRIPTION
## 📝 Description

Makes max job execution time limit configurable via feature flag.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires a documentation update~
