### PR TITLE
fix(front): follow pagination when preloading workflow pipelines

### DIFF
--- a/front/lib/front/models/workflow.ex
+++ b/front/lib/front/models/workflow.ex
@@ -431,7 +431,8 @@ defmodule Front.Models.Workflow do
 
   def preload_pipelines(workflows) when is_list(workflows) do
     Front.Utils.parallel_map(workflows, fn workflow ->
-      pipelines = Front.Models.Pipeline.list(wf_id: workflow.id)
+      options = [pagination: :auto]
+      pipelines = Front.Models.Pipeline.list([wf_id: workflow.id], options)
 
       %{workflow | pipelines: pipelines}
     end)


### PR DESCRIPTION
## 📝 Description

When preloading the pipelines for the workflow, we are not following the pagination, so for workflows with more pipelines than 300, which is rare, we don't get all of them, which can lead to 500s in the branch and workflow pages, due to FrontWeb.PipelineView.TreeLike.find_top_pipeline/1 returning nil.

Task: https://github.com/renderedtext/tasks/issues/8107

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
