### PR TITLE
chore(guard): reduce guard logging volume and make logs more useful

### DIFF
--- a/guard/.tool-versions
+++ b/guard/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.14.3-otp-24
+erlang 24.3.4.9

--- a/guard/lib/guard/grpc_servers/user_server.ex
+++ b/guard/lib/guard/grpc_servers/user_server.ex
@@ -850,7 +850,7 @@ defmodule Guard.GrpcServers.UserServer do
 
   defp grpc_timestamp(_), do: nil
 
-  defp observe_and_log(name, request \\ nil, f) do
+  defp observe_and_log(name, request, f) do
     Watchman.benchmark(name, fn ->
       try do
         Logger.debug(fn -> "Service #{name} - request: #{inspect(request)} - Started" end)


### PR DESCRIPTION
## 📝 Description
We do not need log based metrics so the log level of "started" and "finished" logs in the api is reduced to debug.
Also adds context metadata for grpc error logs

## ✅ Checklist
- [x] I have tested this change
- [ ] ~This change requires documentation update~