### PR TITLE
feat: add flag for scanners

### DIFF
--- a/security-toolbox/docker
+++ b/security-toolbox/docker
@@ -24,6 +24,10 @@ OptionParser.new do |parser|
     args[:severity] = severity
   end
 
+  parser.on("-c", "--scanners SCANNERS", "Comma-separated list of scanners to use (vuln,secret,license,misconfig)") do |scanners|
+    args[:scanners] = scanners
+  end
+
   parser.on("-p", "--ignore-policy IGNORE_POLICY_PATH", "Ignore policy to use when scanning docker image") do |ignore_policy|
     args[:ignore_policy] = ignore_policy
   end

--- a/security-toolbox/policies/docker/trivy_image.rb
+++ b/security-toolbox/policies/docker/trivy_image.rb
@@ -11,6 +11,7 @@ class Policy::TrivyImage < Policy
     @image = args[:image]
     @severity = args[:severity] || "HIGH,CRITICAL"
     @ignore_policy = args[:ignore_policy] || nil
+    @scanners = args[:scanners] || "vuln,secret,license,misconfig"
 
     @skip_files = args[:skip_files].to_s.split(",") || []
     @skip_dirs = args[:skip_dirs].to_s.split(",") || []
@@ -24,7 +25,7 @@ class Policy::TrivyImage < Policy
       "--severity #{@severity}",
       "--exit-on-eol 1",
       "--ignore-unfixed",
-      "--scanners vuln,secret,license,misconfig",
+      "--scanners #{@scanners}",
       "--format json",
       "--output out/docker-scan-trivy.json"
     ]


### PR DESCRIPTION
## 📝 Description
Sometimes we do not want to scan licenses so this enables us to set what scanners trivy is using

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
