### PR TITLE
fix(projecthub-rest-api): drop page size

### DIFF
--- a/projecthub-rest-api/config/config.exs
+++ b/projecthub-rest-api/config/config.exs
@@ -10,7 +10,8 @@ config :projecthub, http_port: 4000
 config :projecthub,
   projecthub_grpc_endpoint: "0.0.0.0:50051",
   organization_grpc_endpoint: "0.0.0.0:50051",
-  rbac_grpc_endpoint: "0.0.0.0:50051"
+  rbac_grpc_endpoint: "0.0.0.0:50051",
+  projects_page_size: 500
 
 config :projecthub, :enviroment, config_env()
 

--- a/projecthub-rest-api/config/runtime.exs
+++ b/projecthub-rest-api/config/runtime.exs
@@ -17,5 +17,6 @@ if config_env() == :prod do
   config :projecthub,
     projecthub_grpc_endpoint: System.fetch_env!("INTERNAL_API_URL_PROJECT"),
     organization_grpc_endpoint: System.fetch_env!("INTERNAL_API_URL_ORGANIZATION"),
-    rbac_grpc_endpoint: System.fetch_env!("INTERNAL_API_URL_RBAC")
+    rbac_grpc_endpoint: System.fetch_env!("INTERNAL_API_URL_RBAC"),
+    projects_page_size: System.get_env("PROJECTS_PAGE_SIZE", "500") |> String.to_integer()
 end

--- a/projecthub-rest-api/config/test.exs
+++ b/projecthub-rest-api/config/test.exs
@@ -7,3 +7,5 @@ config :junit_formatter,
   print_report_file: true,
   include_filename?: true,
   include_file_line?: true
+
+config :projecthub, :projects_page_size, 2


### PR DESCRIPTION
## 📝 Description

Removed the `page_size` query parameter due to inconsistent behavior. Pagination now relies on the default `page_size` and the `page` parameter only.

Retained only the `x-page` and `x-has-more` response headers, which are sufficient for paginated iteration.

Related [task](https://github.com/renderedtext/tasks/issues/7953).

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ - N/A
