### PR TITLE
fix(hooks_processor): explicitly add jason as production dependency

### DIFF
--- a/hooks_processor/lib/hooks_processor/hooks/processing/workers_supervisor.ex
+++ b/hooks_processor/lib/hooks_processor/hooks/processing/workers_supervisor.ex
@@ -44,12 +44,12 @@ defmodule HooksProcessor.Hooks.Processing.WorkersSupervisor do
   end
 
   defp process_response(resp = {:ok, pid}, id, provider) do
-    LT.info(pid, "Hook #{id} - #{provider} worker started")
+    LT.debug(pid, "Hook #{id} - #{provider} worker started")
     resp
   end
 
   defp process_response({:error, {:already_started, pid}}, id, provider) do
-    LT.info(pid, "Hook #{id} - #{provider} worker already started")
+    LT.debug(pid, "Hook #{id} - #{provider} worker already started")
     {:ok, pid}
   end
 

--- a/hooks_processor/mix.exs
+++ b/hooks_processor/mix.exs
@@ -39,6 +39,7 @@ defmodule HooksProcessor.MixProject do
       {:postgrex, ">= 0.0.0"},
       {:uuid, "~> 1.1"},
       {:logger_json, "~> 7.0"},
+      {:jason, "~> 1.4"},
       {:junit_formatter, "~> 3.1", only: [:test]},
       # head because support for JSON is not yet released
       {:sentry, github: "getsentry/sentry-elixir", ref: "f375551f32f35674f9baab470d0e571466b07055"},


### PR DESCRIPTION
## 📝 Description
`jason` was not packaged into the release so json logger is crashing in prod env and printing just a log message

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
