### PR TITLE
fix(api v1alpha): Use pipeline_file as param name in Run wf API

### DIFF
--- a/public-api/v1alpha/lib/pipelines_api/workflow_client/wf_request_formatter.ex
+++ b/public-api/v1alpha/lib/pipelines_api/workflow_client/wf_request_formatter.ex
@@ -21,7 +21,7 @@ defmodule PipelinesAPI.WorkflowClient.WFRequestFormatter do
       request_token: UUID.uuid4(),
       project_id: params["project_id"],
       requester_id: Map.get(params, "requester_id", ""),
-      definition_file: Map.get(params, "definition_file", ".semaphore/semaphore.yml"),
+      definition_file: Map.get(params, "pipeline_file", ".semaphore/semaphore.yml"),
       organization_id: Map.get(params, "organization_id", ""),
       git_reference: params |> Map.get("reference", "") |> ref(),
       start_in_conceived_state: true,

--- a/public-api/v1alpha/test/workflow_client_test.exs
+++ b/public-api/v1alpha/test/workflow_client_test.exs
@@ -46,15 +46,37 @@ defmodule PipelinesAPI.WorkflowClient.Test do
     assert message == "Project was deleted."
   end
 
+  test "workflow client request formatter schedule - creates valid gRPC request when given valid params" do
+    alias InternalApi.PlumberWF.TriggeredBy
+    alias PipelinesAPI.WorkflowClient.WFRequestFormatter
+    alias InternalApi.PlumberWF.ScheduleRequest.{ServiceType, EnvVar}
+
+    params = schedule_params()
+
+    assert {:ok, request} = WFRequestFormatter.form_schedule_request(params)
+    assert request.service == ServiceType.value(:GIT_HUB)
+    assert request.repo.branch_name == "main"
+    assert request.repo.commit_sha == "773d5c953bd68cc97efa81d2e014449336265fb4"
+    assert {:ok, _} = UUID.info(request.request_token)
+    assert request.requester_id == params["requester_id"]
+    assert request.definition_file == "semaphore.yml"
+    assert request.organization_id == params["organization_id"]
+    assert request.git_reference == "refs/heads/main"
+    assert request.start_in_conceived_state == true
+    assert request.triggered_by == TriggeredBy.value(:API)
+    assert request.env_vars == [%EnvVar{name: "MY_PARAM", value: "my_value"}]
+  end
+
   defp schedule_params() do
     %{
       "reference" => "refs/heads/main",
       "commit_sha" => "773d5c953bd68cc97efa81d2e014449336265fb4",
-      "definition_file" => "semaphore.yml",
+      "pipeline_file" => "semaphore.yml",
       "project_id" => UUID.uuid4(),
       "organization_id" => UUID.uuid4(),
       "requester_id" => UUID.uuid4(),
-      "repository" => %{integration_type: :GITHUB_APP}
+      "repository" => %{integration_type: :GITHUB_APP},
+      "parameters" => %{"MY_PARAM" => "my_value"}
     }
   end
 end


### PR DESCRIPTION
## 📝 Description

In the recent changes to how the Run workflow API works in the backend, we changed by mistake the expected name for the parameter that holds the name of the pipeline file. This PR fixes that issue and adds a test to verify that the request is properly formed based on the input parameters. 

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires a documentation update~
