### PR TITLE
fix(plumber): handle skipped blocks in partial pipeline rebuilds

### DIFF
--- a/plumber/block/priv/repos/22_skip_block/.semaphore/skip_block_with_failed_job.yml
+++ b/plumber/block/priv/repos/22_skip_block/.semaphore/skip_block_with_failed_job.yml
@@ -1,0 +1,27 @@
+version: "v1.0"
+name: Pipeline
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Failing
+    dependencies: []
+    task:
+      jobs:
+        - commands:
+            - exit 127
+  - name: B
+    dependencies: []
+    task:
+      jobs:
+        - commands:
+            - echo ok
+  - name: Deployment - skip on dev branches
+    dependencies: [B]
+    skip:
+      when: "(branch =~ '^dev' and branch != 'dev-execute-dpl') or tag =~ '^v0\.' or pull_request =~ '1.*'"
+    task:
+      jobs:
+        - commands:
+            - exit 127

--- a/plumber/ppl/lib/ppl/ppl_blocks/stm_handler/initializing_state.ex
+++ b/plumber/ppl/lib/ppl/ppl_blocks/stm_handler/initializing_state.ex
@@ -60,6 +60,10 @@ defmodule Ppl.PplBlocks.STMHandler.InitializingState do
     end
   end
 
+  defp rebuild_or_duplicate_block(orig_ppl_blk = %{block_id: nil, state: "done", result: "passed", result_reason: "skipped"}, new_ppl_id) do
+    {:ok, fn _, _ -> {:ok, %{state: "done", result: "passed", result_reason: "skipped"}} end}
+  end
+
   defp rebuild_or_duplicate_block(orig_ppl_blk = %{state: "done", result: "passed"}, new_ppl_id) do
     case  Block.duplicate(orig_ppl_blk.block_id, new_ppl_id) do
       {:ok, new_block_id} ->

--- a/plumber/ppl/test/grpc/server_test.exs
+++ b/plumber/ppl/test/grpc/server_test.exs
@@ -2268,6 +2268,40 @@ defmodule Ppl.Grpc.Server.Test do
     end
   end
 
+  @tag :integration
+  test "gRPC partial_rebuild() - handles skipped blocks correctly" do
+    # 1. Schedule pipeline with skip condition that will skip block
+    {:ok, %{ppl_id: ppl_id}} = 
+      %{"repo_name" => "22_skip_block", "file_name" => "skip_block.yml", "label" => "dev-test"}
+      |> Test.Helpers.schedule_request_factory(:local)
+      |> Actions.schedule()
+
+    # 2. Run original pipeline to completion
+    loopers = Test.Helpers.start_all_loopers()
+    {:ok, _ppl} = Test.Helpers.wait_for_ppl_state(ppl_id, "done", 15_000)
+    
+    # 3. Verify original pipeline has skipped block
+    {:ok, orig_blk} = PplBlocksQueries.get_by_id_and_index(ppl_id, 1)
+    assert orig_blk.result == "passed"
+    assert orig_blk.result_reason == "skipped"
+    assert orig_blk.block_id == nil
+    
+    # 4. Perform partial rebuild
+    request_token = UUID.uuid4()
+    new_ppl_id = assert_partial_rebuild(ppl_id, request_token, :ok)
+    
+    # 5. Wait for rebuild completion
+    {:ok, _new_ppl} = Test.Helpers.wait_for_ppl_state(new_ppl_id, "done", 15_000)
+    Test.Helpers.stop_all_loopers(loopers)
+    
+    # 6. Verify rebuilt pipeline preserves skipped state
+    {:ok, new_blk} = PplBlocksQueries.get_by_id_and_index(new_ppl_id, 1)
+    assert new_blk.result == "passed"
+    assert new_blk.result_reason == "skipped"
+    assert new_blk.block_id == nil
+    assert new_blk.duplicate == true
+  end
+
   defp create_pipeline_with_deployment_target(deployment_target_id) do
     source_args = Test.Support.RequestFactory.source_args(%{})
 


### PR DESCRIPTION
## 📝 Description
When performing a partial rebuild, skipped blocks from the original pipeline caused the system to get stuck because:

1. **Skipped blocks have `block_id: nil`**  
   They never get scheduled in the Block service.
2. **Pattern matching issue**  
   The existing code only matched `%{state: "done", result: "passed"}` without considering `result_reason: "skipped"`.
3. **`Block.duplicate` failure**  
   The code called `Block.duplicate(nil, new_ppl_id)` which failed because:
   - `BlockRequestsQueries.get(nil)` returns `nil`
   - No `BlockRequest` exists to duplicate
   - Block gets stuck in `initializing` state instead of `done/passed/skipped`

---

## Fix

1. **Specific Pattern Match**  
   Matches exactly the skipped block signature:
   - `block_id: nil` (never scheduled)
   - `state: "done"` (completed)
   - `result: "passed"` (successful)
   - `result_reason: "skipped"` (was skipped)

2. **Bypasses `Block.duplicate`**  
   Returns a function that directly sets the final state without attempting to duplicate non-existent Block service data.

3. **Preserves Semantic Meaning**  
   The rebuilt block maintains the exact same state as the original skipped block.

4. **Pattern Matching Order**  
   This pattern is checked *before* the generic `%{state: "done", result: "passed"}` pattern, ensuring skipped blocks are handled correctly.

---

## Result

- ✅ Skipped blocks in partial rebuilds now transition directly to `done/passed/skipped`
- ✅ No more failed `Block.duplicate` calls with `nil` `block_id`
- ✅ Rebuilt pipelines preserve the skipped state semantically
- ✅ System no longer gets stuck in `initializing` state for skipped blocks


## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
