### PR TITLE
fix(front): remove redundant checks from add people button visibility check

### DIFF
--- a/front/Makefile
+++ b/front/Makefile
@@ -52,7 +52,7 @@ CONTAINER_ENV_VARS = \
 
 
 CONTAINER_CE_ENV_VARS =\
-	 -e CE_ROLES=true \
+     -e EDITION=ce \
 	 -e SEED_CLOUD_MACHINES=false \
 	 -e SEED_SELF_HOSTED_AGENTS=true \
 	 -e SEED_CE_FEATURES=true \

--- a/front/config/runtime.exs
+++ b/front/config/runtime.exs
@@ -57,8 +57,6 @@ config :front,
   cookie_name: System.get_env("COOKIE_NAME"),
   use_rbac_api: if(System.get_env("USE_RBAC_API") == "true", do: true, else: false)
 
-on_prem? = if(System.get_env("ON_PREM") == "true", do: true, else: false)
-
 # Internal API endpoints - always read from environment variables for all environments
 # Test environment will need these env vars set, or use stubs in test setup
 config :front,
@@ -131,11 +129,8 @@ config :front,
   zendesk_snippet_id: System.get_env("ZENDESK_SNIPPET_ID"),
   google_gtag: System.get_env("GOOGLE_GTAG")
 
-config :front, :on_prem?, on_prem?
-
-
 edition = System.get_env("EDITION", "") |> String.trim() |> String.downcase()
-is_saas? = !(on_prem? or edition in ["ce", "ee"])
+is_saas? = !(edition in ["ce", "ee"])
 
 if is_saas? do
   config :front,
@@ -169,8 +164,6 @@ if System.get_env("AMQP_URL") != nil do
 end
 
 config :front, :audit_logging, System.get_env("AUDIT_LOGGING") == "true"
-
-config :front, :ce_roles, System.get_env("CE_ROLES") == "true"
 
 config :front,
        :hide_promotions,

--- a/front/config/runtime.exs
+++ b/front/config/runtime.exs
@@ -178,14 +178,6 @@ config :front,
        System.fetch_env!("WORKFLOW_TEMPLATES_YAMLS_PATH") <> "_new"
 
 config :front,
-       :hide_bitbucket_me_page,
-       System.get_env("HIDE_BITBUCKET_ME_PAGE") == "true"
-
-config :front,
-       :hide_gitlab_me_page,
-       System.get_env("HIDE_GITLAB_ME_PAGE") == "true"
-
-config :front,
        :single_tenant,
        System.get_env("SINGLE_TENANT") == "true"
 

--- a/front/helm/templates/job-page.yaml
+++ b/front/helm/templates/job-page.yaml
@@ -113,8 +113,6 @@ spec:
 {{- end }}
             - name: METRICS_SERVICE
               value: "front"
-            - name: ON_PREM
-              value: "true"
             - name: FEATURE_YAML_PATH
               value: {{ .Values.featureFlags.mountPath | quote }}
             - name: GETTING_STARTED_YAML_PATH

--- a/front/helm/templates/job-page.yaml
+++ b/front/helm/templates/job-page.yaml
@@ -122,8 +122,6 @@ spec:
 {{- if eq .Values.global.edition "ce" }}
             - name: "SKIP_VELOCITY"
               value: "true"
-            - name: "CE_ROLES"
-              value: "true"
             - name: "HIDE_PROMOTIONS"
               value: "true"
 {{- end }}

--- a/front/helm/templates/project-page.yaml
+++ b/front/helm/templates/project-page.yaml
@@ -152,8 +152,6 @@ spec:
 {{- if eq .Values.global.edition "ce" }}
             - name: "SKIP_VELOCITY"
               value: "true"
-            - name: "CE_ROLES"
-              value: "true"
             - name: "HIDE_PROMOTIONS"
               value: "true"
 {{- end }}

--- a/front/helm/templates/project-page.yaml
+++ b/front/helm/templates/project-page.yaml
@@ -139,8 +139,6 @@ spec:
 {{- end }}
             - name: METRICS_SERVICE
               value: "front"
-            - name: ON_PREM
-              value: "true"
             - name: START_TELEMETRY
               value: {{ .Values.global.telemetry.enabled | quote }}
             - name: TELEMETRY_CRON

--- a/front/helm/templates/ui-cache-reactor.yaml
+++ b/front/helm/templates/ui-cache-reactor.yaml
@@ -104,8 +104,6 @@ spec:
 {{- if eq .Values.global.edition "ce" }}
             - name: "SKIP_VELOCITY"
               value: "true"
-            - name: "CE_ROLES"
-              value: "true"
             - name: "HIDE_PROMOTIONS"
               value: "true"
 {{- end }}

--- a/front/helm/templates/ui-cache-reactor.yaml
+++ b/front/helm/templates/ui-cache-reactor.yaml
@@ -95,8 +95,6 @@ spec:
             - name: METRICS_NAMESPACE
               value: {{ .Values.global.statsd.metricsNamespace }}
 {{- end }}
-            - name: ON_PREM
-              value: "true"
             - name: FEATURE_YAML_PATH
               value: {{ .Values.featureFlags.mountPath | quote }}
             - name: GETTING_STARTED_YAML_PATH

--- a/front/lib/front.ex
+++ b/front/lib/front.ex
@@ -35,4 +35,12 @@ defmodule Front do
   def os? do
     ee?() || ce?()
   end
+
+  @doc """
+  Check if we're running on saas or not
+  """
+  @spec saas?() :: boolean()
+  def saas? do
+    !(on_prem?() or os?())
+  end
 end

--- a/front/lib/front.ex
+++ b/front/lib/front.ex
@@ -1,18 +1,5 @@
 defmodule Front do
   @doc """
-  Checks if application is running on-prem environment
-  """
-  @spec on_prem?() :: boolean()
-  def on_prem? do
-    Application.get_env(:front, :on_prem?)
-  end
-
-  @spec ce_roles?() :: boolean()
-  def ce_roles? do
-    Application.get_env(:front, :ce_roles)
-  end
-
-  @doc """
   Check if it's CE edition
   """
   @spec ce?() :: boolean()
@@ -41,6 +28,6 @@ defmodule Front do
   """
   @spec saas?() :: boolean()
   def saas? do
-    !(on_prem?() or os?())
+    !os?()
   end
 end

--- a/front/lib/front/clients/billing.ex
+++ b/front/lib/front/clients/billing.ex
@@ -314,26 +314,26 @@ defmodule Front.Clients.Billing do
 
   defp call_grpc(error = {:error, err}, _, _, _, _, _) do
     Logger.error("""
-    Unexpected error when connecting to Velocity: #{inspect(err)}
+    Unexpected error when connecting to Billing: #{inspect(err)}
     """)
 
     error
   end
 
   defp call_grpc({:ok, channel}, module, function_name, request, metadata, timeout) do
-    if Front.on_prem?() do
-      {:error, "Billing service is not running on on-prem instance"}
-    else
+    if Front.saas?() do
       apply(module, function_name, [channel, request, [metadata: metadata, timeout: timeout]])
+    else
+      {:error, "Billing service is running only on saas instance"}
     end
   end
 
   defp channel do
-    if Front.on_prem?() do
-      {:error, "Billing service is not running on on-prem instance"}
-    else
+    if Front.saas?() do
       Application.fetch_env!(:front, :billing_api_grpc_endpoint)
       |> GRPC.Stub.connect()
+    else
+      {:error, "Billing service is running only on saas instance"}
     end
   end
 

--- a/front/lib/front/feature_hub_provider.ex
+++ b/front/lib/front/feature_hub_provider.ex
@@ -12,6 +12,19 @@ defmodule Front.FeatureHubProvider do
   import Front.Utils
 
   @impl FeatureProvider.Provider
+  def provide_features(nil, _opts \\ []) do
+    %InternalApi.Feature.ListFeaturesRequest{}
+    |> FeatureClient.list_features()
+    |> unwrap(fn response ->
+      features =
+        response.features
+        |> Enum.map(&feature_from_grpc/1)
+        |> Enum.filter(&FeatureProvider.Feature.visible?/1)
+
+      ok(features)
+    end)
+  end
+
   def provide_features(org_id, _opts \\ []) do
     FeatureClient.list_organization_features(%{org_id: org_id})
     |> unwrap(fn response ->

--- a/front/lib/front/feature_hub_provider.ex
+++ b/front/lib/front/feature_hub_provider.ex
@@ -12,7 +12,8 @@ defmodule Front.FeatureHubProvider do
   import Front.Utils
 
   @impl FeatureProvider.Provider
-  def provide_features(nil, _opts \\ []) do
+  def provide_features(org_id, opts \\ [])
+  def provide_features(nil, _opts) do
     %InternalApi.Feature.ListFeaturesRequest{}
     |> FeatureClient.list_features()
     |> unwrap(fn response ->
@@ -25,7 +26,7 @@ defmodule Front.FeatureHubProvider do
     end)
   end
 
-  def provide_features(org_id, _opts \\ []) do
+  def provide_features(org_id, _opts) do
     FeatureClient.list_organization_features(%{org_id: org_id})
     |> unwrap(fn response ->
       features =

--- a/front/lib/front/feature_hub_provider.ex
+++ b/front/lib/front/feature_hub_provider.ex
@@ -13,6 +13,7 @@ defmodule Front.FeatureHubProvider do
 
   @impl FeatureProvider.Provider
   def provide_features(org_id, opts \\ [])
+
   def provide_features(nil, _opts) do
     %InternalApi.Feature.ListFeaturesRequest{}
     |> FeatureClient.list_features()

--- a/front/lib/front/feature_hub_provider.ex
+++ b/front/lib/front/feature_hub_provider.ex
@@ -6,6 +6,7 @@ defmodule Front.FeatureHubProvider do
     Availability,
     Machine,
     OrganizationFeature,
+    Feature,
     OrganizationMachine
   }
 
@@ -51,6 +52,21 @@ defmodule Front.FeatureHubProvider do
 
       ok(machines)
     end)
+  end
+
+  defp feature_from_grpc(%Feature{
+         availability: availability,
+         name: name,
+         type: type,
+         description: description
+       }) do
+    %FeatureProvider.Feature{
+      name: name,
+      type: type,
+      description: description,
+      quantity: quantity_from_availability(availability),
+      state: state_from_availability(availability)
+    }
   end
 
   defp feature_from_grpc(%OrganizationFeature{feature: feature, availability: availability}) do

--- a/front/lib/front/layout/cache_invalidator.ex
+++ b/front/lib/front/layout/cache_invalidator.ex
@@ -314,7 +314,7 @@ defmodule Front.Layout.CacheInvalidator do
   end
 
   def invalidate_billing(org_id) do
-    if not Front.on_prem?() do
+    if Front.saas?() do
       Front.Clients.Billing.invalidate_cache(:list_spendings, %{org_id: org_id})
       Front.Clients.Billing.invalidate_cache(:current_spending, %{org_id: org_id})
       Front.Clients.Billing.invalidate_cache(:credits_usage, %{org_id: org_id})

--- a/front/lib/front/models/organization_onboarding.ex
+++ b/front/lib/front/models/organization_onboarding.ex
@@ -125,9 +125,7 @@ defmodule Front.Models.OrganizationOnboarding do
 
   @spec validate_billing(model :: t()) :: :ok | {:error, String.t()}
   defp validate_billing(model) do
-    if Front.on_prem?() do
-      :ok
-    else
+    if Front.saas?() do
       BillingClient.can_setup_organization(%{
         owner_id: model.user_id
       })
@@ -136,6 +134,8 @@ defmodule Front.Models.OrganizationOnboarding do
         {:ok, %{allowed: false, errors: messages}} -> {:error, Enum.join(messages, ", ")}
         {:error, _} -> {:error, "Account check failed"}
       end
+    else
+      :ok
     end
   end
 

--- a/front/lib/front_web/controllers/organization_okta_controller.ex
+++ b/front/lib/front_web/controllers/organization_okta_controller.ex
@@ -84,7 +84,7 @@ defmodule FrontWeb.OrganizationOktaController do
           with {:ok, model} <- create_integration(org_id, user_id, integration),
                {:ok, token} <- gen_token(model) do
             Watchman.increment(watchman_name(:create, :success))
-            if Front.on_prem?(), do: log_create(conn, user_id, model)
+            if Front.os?(), do: log_create(conn, user_id, model)
 
             conn
             |> put_flash(:notice, "Success: Your organization is connected with Okta")

--- a/front/lib/front_web/controllers/page_controller.ex
+++ b/front/lib/front_web/controllers/page_controller.ex
@@ -18,7 +18,7 @@ defmodule FrontWeb.PageController do
   def status404(conn, _params) do
     # On onprem, if user isn't logged in, we want to redirect user to okta login
     # right away, without showing the 404 page
-    if anonymous?(conn) == true and Front.on_prem?() do
+    if anonymous?(conn) == true and Front.os?() do
       conn
       |> put_resp_header("location", login_url(conn))
       |> send_resp(302, "")

--- a/front/lib/front_web/controllers/people_controller.ex
+++ b/front/lib/front_web/controllers/people_controller.ex
@@ -284,7 +284,7 @@ defmodule FrontWeb.PeopleController do
     user_type = params["type"] || ""
 
     member_role_id =
-      if Front.ce_roles?() do
+      if Front.ce?() do
         {:ok, roles} = RoleManagement.list_possible_roles(org_id, "org_scope")
 
         member_role = Enum.find(roles, fn role -> role.name == "Member" end)
@@ -501,7 +501,7 @@ defmodule FrontWeb.PeopleController do
 
   defp create_email_member(conn, params) do
     Watchman.benchmark("people.create_member", fn ->
-      if email_members_supported?(conn.assigns.organization_id) || Front.ce_roles?() do
+      if email_members_supported?(conn.assigns.organization_id) || Front.ce?() do
         user_id = conn.assigns.user_id
         org_id = conn.assigns.organization_id
 
@@ -800,7 +800,7 @@ defmodule FrontWeb.PeopleController do
 
   defp change_user_email(conn, user_id, email) do
     Watchman.benchmark("people.change_email", fn ->
-      if email_members_supported?(conn.assigns.organization_id) || Front.ce_roles?() do
+      if email_members_supported?(conn.assigns.organization_id) || Front.ce?() do
         conn
         |> Audit.new(:User, :Modified)
         |> Audit.add(description: "Change Email")
@@ -867,7 +867,7 @@ defmodule FrontWeb.PeopleController do
 
   defp reset_user_password(conn, user_id) do
     Watchman.benchmark("people.reset_password", fn ->
-      if email_members_supported?(conn.assigns.organization_id) || Front.ce_roles?() do
+      if email_members_supported?(conn.assigns.organization_id) || Front.ce?() do
         conn
         |> Audit.new(:User, :Modified)
         |> Audit.add(description: "Reset Password")

--- a/front/lib/front_web/controllers/project_onboarding_controller.ex
+++ b/front/lib/front_web/controllers/project_onboarding_controller.ex
@@ -630,15 +630,14 @@ defmodule FrontWeb.ProjectOnboardingController do
          ) do
         project_onboarding_path(conn, :onboarding_index, project.name, [""])
       else
-        # TODO: check with Amir
-        if Front.on_prem?() do
+        if Front.saas?() do
+          project_onboarding_path(conn, :invite_collaborators, project.name)
+        else
           if Models.Project.file_exists?(project.id, project.initial_pipeline_file) do
             project_onboarding_path(conn, :existing_configuration, project.name)
           else
             project_onboarding_path(conn, :template, project.name)
           end
-        else
-          project_onboarding_path(conn, :invite_collaborators, project.name)
         end
       end
 

--- a/front/lib/front_web/controllers/project_onboarding_controller.ex
+++ b/front/lib/front_web/controllers/project_onboarding_controller.ex
@@ -630,6 +630,7 @@ defmodule FrontWeb.ProjectOnboardingController do
          ) do
         project_onboarding_path(conn, :onboarding_index, project.name, [""])
       else
+        # TODO: check with Amir
         if Front.on_prem?() do
           if Models.Project.file_exists?(project.id, project.initial_pipeline_file) do
             project_onboarding_path(conn, :existing_configuration, project.name)

--- a/front/lib/front_web/controllers/project_settings_controller.ex
+++ b/front/lib/front_web/controllers/project_settings_controller.ex
@@ -344,7 +344,7 @@ defmodule FrontWeb.ProjectSettingsController do
 
       changeset = DeletionValidator.run(project, params)
 
-      if Front.on_prem?() or changeset.valid? do
+      if Front.os?() or changeset.valid? do
         case Project.destroy(project.id, user_id, org_id) do
           {:ok, _} ->
             conn

--- a/front/lib/front_web/controllers/roles_controller.ex
+++ b/front/lib/front_web/controllers/roles_controller.ex
@@ -56,7 +56,7 @@ defmodule FrontWeb.RolesController do
       case Async.await(async_role) do
         {:ok, role} ->
           async_roles = fetch_roles_async(conn.assigns.organization_id)
-          scope = if Front.ce_roles?(), do: "", else: role.scope
+          scope = if Front.ce?(), do: "", else: role.scope
           async_permissions = fetch_permissions_async(scope)
 
           {:ok, roles} = Async.await(async_roles)

--- a/front/lib/front_web/plugs/onprem_blocker.ex
+++ b/front/lib/front_web/plugs/onprem_blocker.ex
@@ -9,7 +9,7 @@ defmodule FrontWeb.Plugs.OnPremBlocker do
   def init(default), do: default
 
   def call(conn, _opts) do
-    if Front.on_prem?() do
+    if Front.os?() do
       Logger.info("Blocking access to #{conn.request_path} because of on-premises")
 
       conn

--- a/front/lib/front_web/templates/account/show.html.eex
+++ b/front/lib/front_web/templates/account/show.html.eex
@@ -18,7 +18,7 @@
       <div class="mt4 pv3 bt b--lighter-gray">
         <div class="f4 b mb3">Repository access</div>
         <div class="dib ba b--lighter-gray br2 w-100">
-          <%= if not FeatureProvider.feature_enabled?(:bitbucket) do %>
+          <%= if FeatureProvider.feature_enabled?(:bitbucket) do %>
           <div class="pa2 bb b--lighter-gray">
           <% else %>
           <div class="pa2">
@@ -76,7 +76,7 @@
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
             <% end %>
           </div>
-          <%= if not FeatureProvider.feature_enabled?(:bitbucket) do %>
+          <%= if FeatureProvider.feature_enabled?(:bitbucket) do %>
           <div class="pa2 bt b--lighter-gray">
             <span class="b">Bitbucket</span> ·
             <%= case {@user.bitbucket_scope, @user.bitbucket_login} do %>
@@ -98,7 +98,7 @@
                 <span><a href="https://bitbucket.org/<%= @user.bitbucket_login %>" target="_blank">@<%= @user.bitbucket_login %></a></span>
             <% end %>
           </div>
-          <%= if not FeatureProvider.feature_enabled?(:gitlab) do %>
+          <%= if FeatureProvider.feature_enabled?(:gitlab) do %>
           <div class="pa2 bt b--lighter-gray">
             <span class="b">GitLab</span> ·
             <%= case {@user.gitlab_scope, @user.gitlab_login} do %>

--- a/front/lib/front_web/templates/account/show.html.eex
+++ b/front/lib/front_web/templates/account/show.html.eex
@@ -27,25 +27,25 @@
             <%= case {@user.github_scope, @user.github_login} do %>
               <% {:NONE, nil} -> %>
                 <span class="red">Not Connected</span>
-                <%= unless Front.on_prem?() do %>
-                <div>
-                <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
-                <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
-                </div>
+                <%= if Front.saas?() do %>
+                  <div>
+                    <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
+                    <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
+                  </div>
                 <% else %>
-                <div>
-                  <%= link "Connect…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :email]), method: :post %>
-                </div>
+                  <div>
+                    <%= link "Connect…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :email]), method: :post %>
+                  </div>
                 <% end %>
               <% {:NONE, _} -> %>
                 <span class="red">Not Connected</span>
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
-                <%= unless Front.on_prem?() do %>
-                <div>
-                <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
-                <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
-                </div>
+                <%= if Front.saas?() do %>
+                  <div>
+                    <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
+                    <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
+                  </div>
                 <% end %>
               <% {:EMAIL, _} -> %>
                 <span class="green">Connected</span>
@@ -53,11 +53,11 @@
                 <span class="gray">email only</span>
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
-                <%= unless Front.on_prem?() do %>
-                <div>
-                <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
-                <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
-                </div>
+                <%= if Front.saas?() do %>
+                  <div>
+                    <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
+                    <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
+                  </div>
                   <% end %>
               <% {:PUBLIC, _} -> %>
                 <span class="green">Connected</span>
@@ -65,10 +65,10 @@
                 <span class="gray">public repositories</span>
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
-                <%= unless Front.on_prem?() do %>
-                <div>
-                <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
-                </div>
+                <%= if Front.saas?() do %>
+                  <div>
+                    <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
+                  </div>
                 <% end %>
               <% {:PRIVATE, _} -> %>
                 <span class="green">Connected</span>

--- a/front/lib/front_web/templates/account/show.html.eex
+++ b/front/lib/front_web/templates/account/show.html.eex
@@ -27,7 +27,7 @@
             <%= case {@user.github_scope, @user.github_login} do %>
               <% {:NONE, nil} -> %>
                 <span class="red">Not Connected</span>
-                <%= if Front.saas?() do %>
+                <%= if FeatureProvider.feature_enabled?(:user_repos_access) do %>
                   <div>
                     <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
                     <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
@@ -41,7 +41,7 @@
                 <span class="red">Not Connected</span>
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
-                <%= if Front.saas?() do %>
+                <%= if FeatureProvider.feature_enabled?(:user_repos_access) do %>
                   <div>
                     <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
                     <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
@@ -53,7 +53,7 @@
                 <span class="gray">email only</span>
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
-                <%= if Front.saas?() do %>
+                <%= if FeatureProvider.feature_enabled?(:user_repos_access) do %>
                   <div>
                     <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
                     <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
@@ -65,7 +65,7 @@
                 <span class="gray">public repositories</span>
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
-                <%= if Front.saas?() do %>
+                <%= if FeatureProvider.feature_enabled?(:user_repos_access) do %>
                   <div>
                     <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
                   </div>
@@ -76,7 +76,7 @@
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
             <% end %>
           </div>
-          <%= if not Application.get_env(:front, :hide_bitbucket_me_page) do %>
+          <%= if not FeatureProvider.feature_enabled?(:bitbucket) do %>
           <div class="pa2 bt b--lighter-gray">
             <span class="b">Bitbucket</span> ·
             <%= case {@user.bitbucket_scope, @user.bitbucket_login} do %>
@@ -98,7 +98,7 @@
                 <span><a href="https://bitbucket.org/<%= @user.bitbucket_login %>" target="_blank">@<%= @user.bitbucket_login %></a></span>
             <% end %>
           </div>
-          <%= if not Application.get_env(:front, :hide_gitlab_me_page) do %>
+          <%= if not FeatureProvider.feature_enabled?(:gitlab) do %>
           <div class="pa2 bt b--lighter-gray">
             <span class="b">GitLab</span> ·
             <%= case {@user.gitlab_scope, @user.gitlab_login} do %>

--- a/front/lib/front_web/templates/account/show.html.eex
+++ b/front/lib/front_web/templates/account/show.html.eex
@@ -27,7 +27,7 @@
             <%= case {@user.github_scope, @user.github_login} do %>
               <% {:NONE, nil} -> %>
                 <span class="red">Not Connected</span>
-                <%= if FeatureProvider.feature_enabled?(:user_repos_access) do %>
+                <%= unless FeatureProvider.feature_enabled?(:restrict_user_repos_access) do %>
                   <div>
                     <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
                     <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
@@ -41,7 +41,7 @@
                 <span class="red">Not Connected</span>
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
-                <%= if FeatureProvider.feature_enabled?(:user_repos_access) do %>
+                <%= unless FeatureProvider.feature_enabled?(:restrict_user_repos_access) do %>
                   <div>
                     <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
                     <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
@@ -53,7 +53,7 @@
                 <span class="gray">email only</span>
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
-                <%= if FeatureProvider.feature_enabled?(:user_repos_access) do %>
+                <%= unless FeatureProvider.feature_enabled?(:restrict_user_repos_access) do %>
                   <div>
                     <%= link "Grant public access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :public]), method: :post %>
                     <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
@@ -65,7 +65,7 @@
                 <span class="gray">public repositories</span>
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
-                <%= if FeatureProvider.feature_enabled?(:user_repos_access) do %>
+                <%= unless FeatureProvider.feature_enabled?(:restrict_user_repos_access) do %>
                   <div>
                     <%= link "Grant private access…", to: account_path(@conn, :update_repo_scope, "github", [access_level: :private]), method: :post %>
                   </div>

--- a/front/lib/front_web/templates/account/show.html.eex
+++ b/front/lib/front_web/templates/account/show.html.eex
@@ -18,7 +18,7 @@
       <div class="mt4 pv3 bt b--lighter-gray">
         <div class="f4 b mb3">Repository access</div>
         <div class="dib ba b--lighter-gray br2 w-100">
-          <%= if not Application.get_env(:front, :hide_bitbucket_me_page) do %>
+          <%= if not FeatureProvider.feature_enabled?(:bitbucket) do %>
           <div class="pa2 bb b--lighter-gray">
           <% else %>
           <div class="pa2">

--- a/front/lib/front_web/templates/account/welcome/okta.html.eex
+++ b/front/lib/front_web/templates/account/welcome/okta.html.eex
@@ -11,7 +11,7 @@
 
       <div class="">
         <div class="dib ba b--lighter-gray br2 w-100">
-          <%= if not FeatureProvider.feature_enabled?(:bitbucket) do %>
+          <%= if FeatureProvider.feature_enabled?(:bitbucket) do %>
           <div class="pa2 bb b--lighter-gray">
           <% else %>
           <div class="pa2">
@@ -55,7 +55,7 @@
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
             <% end %>
           </div>
-          <%= if not FeatureProvider.feature_enabled?(:bitbucket) do %>
+          <%= if FeatureProvider.feature_enabled?(:bitbucket) do %>
           <div class="pa2">
             <span class="b">Bitbucket</span> ·
             <%= case {@user.bitbucket_scope, @user.bitbucket_login} do %>
@@ -78,7 +78,7 @@
             <% end %>
           </div>
           <% end %>
-          <%= if not FeatureProvider.feature_enabled?(:gitlab) do %>
+          <%= if FeatureProvider.feature_enabled?(:gitlab) do %>
           <div class="pa2">
             <span class="b">GitLab</span> ·
             <%= case {@user.gitlab_scope, @user.gitlab_login} do %>

--- a/front/lib/front_web/templates/account/welcome/okta.html.eex
+++ b/front/lib/front_web/templates/account/welcome/okta.html.eex
@@ -11,7 +11,7 @@
 
       <div class="">
         <div class="dib ba b--lighter-gray br2 w-100">
-          <%= if not Application.get_env(:front, :hide_bitbucket_me_page) do %>
+          <%= if not FeatureProvider.feature_enabled?(:bitbucket) do %>
           <div class="pa2 bb b--lighter-gray">
           <% else %>
           <div class="pa2">
@@ -55,7 +55,7 @@
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
             <% end %>
           </div>
-          <%= if not Application.get_env(:front, :hide_bitbucket_me_page) do %>
+          <%= if not FeatureProvider.feature_enabled?(:bitbucket) do %>
           <div class="pa2">
             <span class="b">Bitbucket</span> ·
             <%= case {@user.bitbucket_scope, @user.bitbucket_login} do %>
@@ -78,7 +78,7 @@
             <% end %>
           </div>
           <% end %>
-          <%= if not Application.get_env(:front, :hide_gitlab_me_page) do %>
+          <%= if not FeatureProvider.feature_enabled?(:gitlab) do %>
           <div class="pa2">
             <span class="b">GitLab</span> ·
             <%= case {@user.gitlab_scope, @user.gitlab_login} do %>

--- a/front/lib/front_web/templates/audit/streaming/_form.html.eex
+++ b/front/lib/front_web/templates/audit/streaming/_form.html.eex
@@ -50,7 +50,7 @@
 
                 <label class="db b mb0">Access Credentials</label>
                 <p class="mb3">Semaphore needs credentials with write acess to upload the logs</p>
-                <%= if Front.on_prem?() do %>
+                <%= if Front.os?() do %>
                  <div class="ml1 mv2">
                     <div class="flex items-center mt2">
                         <%= checkbox(f, :instance_role) %>

--- a/front/lib/front_web/templates/error/404.html.eex
+++ b/front/lib/front_web/templates/error/404.html.eex
@@ -44,7 +44,7 @@
         <a href="https://me.<%= Application.fetch_env!(:front, :domain) %>/" class="db">
           <img src="<%= assets_path() %>/images/semaphore-logo-full-white.svg" alt="Semaphore Logo">
         </a>
-        <%= if not Front.on_prem?() do %>
+        <%= if Front.saas?() do %>
           <div class="flex-ns items-center">
             <div class="f5 fw5 pr2 mv3 mv0-m flex justify-center">
               <a href="https://<%= Application.fetch_env!(:front, :domain) %>/product" class="link white-90 hover-white ph2">Product</a>
@@ -72,7 +72,7 @@
         <%= if anonymous?(@conn) do %>
           <p class="f4 black-80 mb3=0">Perhaps you need to <a href="<%= login_url(@conn) %>" class="link black-50 hover-black-80">log in →</a></p>
         <% else %>
-        <%= if not Front.on_prem?() do %>
+        <%= if Front.saas?() do %>
           <%= if Enum.all?([:user, :project], fn m -> Enum.member?(Map.keys(@conn.assigns), m) end) do %>
             <%= if @conn.assigns.user.gitlab_scope == :NONE &&
               @conn.assigns.project.integration_type == :GITLAB do %>

--- a/front/lib/front_web/templates/job/_state.html.eex
+++ b/front/lib/front_web/templates/job/_state.html.eex
@@ -38,7 +38,7 @@
               <span class="gray mh1">·</span>
 
               <%= cond do %>
-                  <% @self_hosted and Front.on_prem?() -> %>
+                  <% @self_hosted and Front.os?() -> %>
                       <span class="gray hover-dark-gray pointer js-job-dropdown-menu-trigger" data-value="<%= debug_or_attach_self_hosted_txt(@debug_action) %>" data-template="sshSelfHostedMenu">
                           SSH <%= @debug_action |> String.capitalize() %>
                       </span>

--- a/front/lib/front_web/templates/layout/_anonymous_page_header.html.eex
+++ b/front/lib/front_web/templates/layout/_anonymous_page_header.html.eex
@@ -8,7 +8,7 @@
     <div class="flex items-center flex-shrink-0">
       <p class="f6 mb0">Blazing-fast build and deploy!</p>
       <a href="<%= login_url(@conn) %>" class="btn btn-secondary btn-small ml3">Log in</a>
-    <%= if not Front.on_prem?() do %>
+    <%= if Front.saas?() do %>
       <a href="<%= signup_url(@conn) %>" class="btn btn-secondary btn-small ml3">Sign up</a>
     <% end %>
     </div>

--- a/front/lib/front_web/templates/layout/organization_settings.html.eex
+++ b/front/lib/front_web/templates/layout/organization_settings.html.eex
@@ -50,7 +50,7 @@
               <%= link "Okta Integration", to: organization_okta_path(@conn, :show), class: "link db pv1 ph3 br3 dark-gray hover-bg-lightest-gray" %>
             <% end %>
           <% end %>
-        <%= if not Front.on_prem?() do %>
+        <%= if Front.saas?() do %>
           <%= if @conn.request_path =~ organization_contacts_path(@conn, :show) do %>
             <%= link "Contacts", to: organization_contacts_path(@conn, :show), class: "link db pv1 ph3 br3 bg-green white" %>
           <% else %>

--- a/front/lib/front_web/templates/people/add_to_project/_popup_window.html.eex
+++ b/front/lib/front_web/templates/people/add_to_project/_popup_window.html.eex
@@ -102,7 +102,7 @@
           <input type="hidden">
           <input
             type="text"
-            placeholder="<%= if Front.ce_roles?(), do: "Search users to add to project", else: "Search users and groups to add to project" %>"
+            placeholder="<%= if Front.ce?(), do: "Search users to add to project", else: "Search users and groups to add to project" %>"
             class="form-control w-100 mr2" >
           <div class="jumpto-results"></div>
         </div>
@@ -112,7 +112,7 @@
       <%# This div is managed by the add_to_project.js %>
     </div>
 
-    <%= if !Front.ce_roles?() do %>
+    <%= if !Front.ce?() do %>
       <%= render "add_to_project/__select_role.html", conn: @conn, roles: @roles%>
     <% end %>
 

--- a/front/lib/front_web/templates/people/collaborators.html.eex
+++ b/front/lib/front_web/templates/people/collaborators.html.eex
@@ -7,7 +7,7 @@
 
 
   <div class="bg-washed-gray mt4 pa3 pa4-l br3 ba b--black-075">
-    <%= if FeatureProvider.feature_enabled?(:email_members, param: @conn.assigns[:organization_id]) || Front.ce_roles?() do %>
+    <%= if FeatureProvider.feature_enabled?(:email_members, param: @conn.assigns[:organization_id]) || Front.ce?() do %>
       <div class="mb2 bb b--lighter-gray">
         <div class="mb3 mb0-m">
           <p class="measure mb2">Add member to Organization</p>
@@ -29,7 +29,7 @@
       </div>
     <% end %>
 
-    <%= if !Front.ce_roles?() do %>
+    <%= if !Front.ce?() do %>
       <%= if FeatureProvider.feature_enabled?(:gitlab, param: @conn.assigns[:organization_id]) do %>
       <div class="flex-m justify-between mb0 bb b--lighter-gray">
         <div class="mb3 mb0-m">

--- a/front/lib/front_web/templates/people/members/_add_people_button.html.eex
+++ b/front/lib/front_web/templates/people/members/_add_people_button.html.eex
@@ -1,6 +1,6 @@
 <%= if show_people_management_buttons?(@conn, @org_scope?, @permissions) do %>
   <div>
-    <%= if @org_scope? do %>
+    <%= if @org_scope? and !Front.on_prem?() do %>
       <div id="add-people" data-config="<%= Poison.encode!(add_people_config(@conn)) %>"></div>
     <% else %>
       <div class="flex-m">

--- a/front/lib/front_web/templates/people/members/_add_people_button.html.eex
+++ b/front/lib/front_web/templates/people/members/_add_people_button.html.eex
@@ -1,9 +1,7 @@
 <%= if show_people_management_buttons?(@conn, @org_scope?, @permissions) do %>
   <div>
     <%= if @org_scope? do %>
-      <%= if !Front.on_prem?() do %>
-        <div id="add-people" data-config="<%= Poison.encode!(add_people_config(@conn)) %>"></div>
-      <% end %>
+      <div id="add-people" data-config="<%= Poison.encode!(add_people_config(@conn)) %>"></div>
     <% else %>
       <div class="flex-m">
         <div>

--- a/front/lib/front_web/templates/people/members/_add_people_button.html.eex
+++ b/front/lib/front_web/templates/people/members/_add_people_button.html.eex
@@ -1,7 +1,9 @@
 <%= if show_people_management_buttons?(@conn, @org_scope?, @permissions) do %>
   <div>
-    <%= if @org_scope? and !Front.on_prem?() do %>
-      <div id="add-people" data-config="<%= Poison.encode!(add_people_config(@conn)) %>"></div>
+    <%= if @org_scope? do %>
+      <%= if !Front.on_prem?() do %>
+        <div id="add-people" data-config="<%= Poison.encode!(add_people_config(@conn)) %>"></div>
+      <% end %>
     <% else %>
       <div class="flex-m">
         <div>

--- a/front/lib/front_web/templates/people/members/_member.html.eex
+++ b/front/lib/front_web/templates/people/members/_member.html.eex
@@ -30,8 +30,8 @@
       && "Owner" not in member_role_names do %>
       <div class="flex-shrink-0 pl2">
         <div class="button-group">
-          <%= unless !@org_scope? && Front.ce_roles?() do %>
-            <%= if Front.ce_roles?() do %>
+          <%= unless !@org_scope? && Front.ce?() do %>
+            <%= if Front.ce?() do %>
               <div class="app-edit-person" data-config="<%= Poison.encode!(edit_person_config(@conn, @member, @member_type, @roles, @permissions)) %>"></div>
             <% else %>
               <%= render "members/__change_role_btn.html", member: @member, member_type: @member_type, roles: @roles, permissions: @permissions %>
@@ -42,11 +42,11 @@
               <%= render "members/__modify_group_button.html", group: @member, permissions: @permissions %>
               <%= render "members/__delete_group_button.html", group: @member, conn: @conn, permissions: @permissions %>
             <% @member_type == :service_account -> %>
-              <%= if @org_scope? || !Front.ce_roles?() || "Member" in member_role_names do %>
+              <%= if @org_scope? || !Front.ce?() || "Member" in member_role_names do %>
                 <%= render "members/__remove_member_btn.html", member: @member %>
               <% end %>
             <% true -> %>
-              <%= if @org_scope? || !Front.ce_roles?() || "Member" in member_role_names do %>
+              <%= if @org_scope? || !Front.ce?() || "Member" in member_role_names do %>
                 <%= render "members/__remove_member_btn.html", member: @member %>
               <% end %>
           <% end %>

--- a/front/lib/front_web/templates/people/members/members_list.html.eex
+++ b/front/lib/front_web/templates/people/members/members_list.html.eex
@@ -32,9 +32,7 @@
           <div class="b">People</div>
         </div>
       </div>
-      <%= if !@org_scope? || !Front.on_prem?() || Front.ce_roles?() do %>
-        <%= render "members/_add_people_button.html", conn: @conn, org_scope?: @org_scope?, permissions: @permissions %>
-      <% end %>
+      <%= render "members/_add_people_button.html", conn: @conn, org_scope?: @org_scope?, permissions: @permissions %>
     </div>
 
     <div id="members">

--- a/front/lib/front_web/templates/people/organization.html.eex
+++ b/front/lib/front_web/templates/people/organization.html.eex
@@ -28,7 +28,7 @@
     <%= render "members/members_list.html", org_id: @org_id, groups: @groups, members: @members, roles: @roles, org_scope?: @org_scope?, conn: @conn, permissions: @permissions %>
     <%= render "_pagination.html", pagination: @pagination%>
 
-    <%= if not Front.on_prem?() do %>
+    <%= if Front.saas?() do %>
     <div id="invitees">
       <%= @invitations |> Enum.map(fn (invitee) -> %>
         <%= render "members/_invitee.html", invitee: invitee, conn: @conn %>

--- a/front/lib/front_web/templates/people/project.html.eex
+++ b/front/lib/front_web/templates/people/project.html.eex
@@ -26,7 +26,7 @@
 
     <div class="w-100 flex">
       <%= render "_search_bar.html", conn: @conn, org_id: @org_id, search_endpoint: people_path(@conn, :render_members) %>
-      <%= if !Front.ce_roles?() do %>
+      <%= if !Front.ce?() do %>
         <%= render "_role_filter.html", conn: @conn, roles: @roles%>
       <% end %>
     </div>

--- a/front/lib/front_web/templates/people/show.html.eex
+++ b/front/lib/front_web/templates/people/show.html.eex
@@ -41,7 +41,7 @@
       <div class="mt3 pv3 bt b--lighter-gray">
         <div class="f4 b mb3">Repository access</div>
         <div class="dib ba b--lighter-gray br2 w-100">
-          <%= if not Front.on_prem?() do %>
+          <%= if Front.saas?() do %>
           <div class="pa2 bb b--lighter-gray">
           <% else %>
           <div class="pa2">
@@ -51,28 +51,28 @@
               <% {:NONE, nil} -> %>
                 <span class="red">Not Connected</span>
                 <%= if @owned do %>
-                <%= unless Front.on_prem?() do %>
-                <div>
-                <%= link "Grant public access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :public]), method: :post %>
-                <%= link "Grant private access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :private]), method: :post %>
-                </div>
-                <% else %>
-                <div>
-                  <%= link "Connect…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :email]), method: :post %>
-                </div>
-                <% end %>
+                  <%= if Front.saas?() do %>
+                    <div>
+                    <%= link "Grant public access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :public]), method: :post %>
+                    <%= link "Grant private access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :private]), method: :post %>
+                    </div>
+                  <% else %>
+                    <div>
+                      <%= link "Connect…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :email]), method: :post %>
+                    </div>
+                  <% end %>
                 <% end %>
               <% {:NONE, _} -> %>
                 <span class="red">Not Connected</span>
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
                 <%= if @owned do %>
-                <%= unless Front.on_prem?() do %>
-                <div>
-                <%= link "Grant public access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :public]), method: :post %>
-                <%= link "Grant private access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :private]), method: :post %>
-                </div>
-                <% end %>
+                  <%= if Front.saas?() do %>
+                    <div>
+                    <%= link "Grant public access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :public]), method: :post %>
+                    <%= link "Grant private access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :private]), method: :post %>
+                    </div>
+                  <% end %>
                 <% end %>
               <% {:EMAIL, _} -> %>
                 <span class="green">Connected</span>
@@ -81,12 +81,12 @@
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
                 <%= if @owned do %>
-                <%= unless Front.on_prem?() do %>
-                <div>
-                <%= link "Grant public access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :public]), method: :post %>
-                <%= link "Grant private access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :private]), method: :post %>
-                </div>
-                <% end %>
+                  <%= if Front.saas?() do %>
+                    <div>
+                    <%= link "Grant public access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :public]), method: :post %>
+                    <%= link "Grant private access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :private]), method: :post %>
+                    </div>
+                  <% end %>
                 <% end %>
               <% {:PUBLIC, _} -> %>
                 <span class="green">Connected</span>
@@ -95,11 +95,11 @@
                   ·
                 <span><a href="https://github.com/<%= @user.github_login %>" target="_blank">@<%= @user.github_login %></a></span>
                 <%= if @owned do %>
-                <%= unless Front.on_prem?() do %>
-                <div>
-                <%= link "Grant private access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :private]), method: :post %>
-                </div>
-                <% end %>
+                  <%= if Front.saas?() do %>
+                    <div>
+                    <%= link "Grant private access…", to: people_path(@conn, :update_repo_scope, @user.id, "github", [access_level: :private]), method: :post %>
+                    </div>
+                  <% end %>
                 <% end %>
               <% {:PRIVATE, _} -> %>
                 <span class="green">Connected</span>
@@ -135,31 +135,31 @@
           </div>
           <% end %>
           <%= if FeatureProvider.feature_enabled?(:gitlab, param: @conn.assigns[:organization_id]) do %>
-          <div class="pa2 bt b--lighter-gray">
-            <span class="b">GitLab</span> ·
-            <%= case {@user.gitlab_scope, @user.gitlab_login} do %>
-              <% {:NONE, nil} -> %>
-                <span class="red">Not Connected</span>
-                <%= if @owned do %>
-                <div>
-                  <%= link "Grant access…", to: people_path(@conn, :update_repo_scope, @user.id, "gitlab"), method: :post %>
-                </div>
-                <% end %>
-              <% {:NONE, _} -> %>
-                <span class="red">Not Connected</span>
-                ·
-                <span><a href="https://gitlab.com/<%= @user.gitlab_login %>" target="_blank">@<%= @user.gitlab_login %></a></span>
-                <%= if @owned do %>
-                <div>
-                  <%= link "Grant access…", to: people_path(@conn, :update_repo_scope, @user.id, "gitlab"), method: :post %>
-                </div>
-                <% end %>
-              <% {:PRIVATE, _} -> %>
-                <span class="green">Connected</span>
-                ·
-                <span><a href="https://gitlab.com/<%= @user.gitlab_login %>" target="_blank">@<%= @user.gitlab_login %></a></span>
-            <% end %>
-          </div>
+            <div class="pa2 bt b--lighter-gray">
+              <span class="b">GitLab</span> ·
+              <%= case {@user.gitlab_scope, @user.gitlab_login} do %>
+                <% {:NONE, nil} -> %>
+                  <span class="red">Not Connected</span>
+                  <%= if @owned do %>
+                  <div>
+                    <%= link "Grant access…", to: people_path(@conn, :update_repo_scope, @user.id, "gitlab"), method: :post %>
+                  </div>
+                  <% end %>
+                <% {:NONE, _} -> %>
+                  <span class="red">Not Connected</span>
+                  ·
+                  <span><a href="https://gitlab.com/<%= @user.gitlab_login %>" target="_blank">@<%= @user.gitlab_login %></a></span>
+                  <%= if @owned do %>
+                  <div>
+                    <%= link "Grant access…", to: people_path(@conn, :update_repo_scope, @user.id, "gitlab"), method: :post %>
+                  </div>
+                  <% end %>
+                <% {:PRIVATE, _} -> %>
+                  <span class="green">Connected</span>
+                  ·
+                  <span><a href="https://gitlab.com/<%= @user.gitlab_login %>" target="_blank">@<%= @user.gitlab_login %></a></span>
+              <% end %>
+            </div>
           <% end %>
         </div>
       </div>

--- a/front/lib/front_web/templates/project_settings/confirm_delete.html.eex
+++ b/front/lib/front_web/templates/project_settings/confirm_delete.html.eex
@@ -13,7 +13,7 @@
 <div class="mw6">
   <div class="mt3">
     <%= form_for @conn, project_settings_path(@conn, :submit_delete, @project.id), [method: :post], fn f -> %>
-      <%= unless Front.on_prem?() do %>
+      <%= if Front.saas?() do %>
       <div class="mv3">
         <%= label f, :reason, "Reason for deleting", class: "db b mb1" %>
         <%= select f, :reason,

--- a/front/lib/front_web/templates/roles/_role_form.html.eex
+++ b/front/lib/front_web/templates/roles/_role_form.html.eex
@@ -50,7 +50,7 @@
   <% end %>
 </div>
 
-<%= if to_string(@form.data.scope) == "organization" && !Front.ce_roles?() do %>
+<%= if to_string(@form.data.scope) == "organization" && !Front.ce?() do %>
     <div class="ml2 mv4">
         <%= label @form, :role_mapping, class: "db b" do %>
             Project access

--- a/front/lib/front_web/views/people_view.ex
+++ b/front/lib/front_web/views/people_view.ex
@@ -81,9 +81,14 @@ defmodule FrontWeb.PeopleView do
   defp available_user_providers(org_id) do
     [
       {"email", FeatureProvider.feature_enabled?(:email_members, param: org_id)},
-      {"github", Front.saas?() || FeatureProvider.feature_enabled?(:github_user_provider, param: org_id)},
-      {"gitlab", (FeatureProvider.feature_enabled?(:gitlab, param: org_id) && Front.saas?()) || FeatureProvider.feature_enabled?(:gitlab_user_provider, param: org_id)},
-      {"bitbucket", (FeatureProvider.feature_enabled?(:bitbucket, param: org_id) && Front.saas?) || FeatureProvider.feature_enabled?(:bitbucket_user_provider, param: org_id)}
+      {"github",
+       Front.saas?() || FeatureProvider.feature_enabled?(:github_user_provider, param: org_id)},
+      {"gitlab",
+       (FeatureProvider.feature_enabled?(:gitlab, param: org_id) && Front.saas?()) ||
+         FeatureProvider.feature_enabled?(:gitlab_user_provider, param: org_id)},
+      {"bitbucket",
+       (FeatureProvider.feature_enabled?(:bitbucket, param: org_id) && Front.saas?()) ||
+         FeatureProvider.feature_enabled?(:bitbucket_user_provider, param: org_id)}
     ]
     |> Enum.map(fn
       {name, true} ->

--- a/front/lib/front_web/views/people_view.ex
+++ b/front/lib/front_web/views/people_view.ex
@@ -80,10 +80,10 @@ defmodule FrontWeb.PeopleView do
   @spec available_user_providers(org_id :: String.t()) :: [String.t()]
   defp available_user_providers(org_id) do
     [
-      {"email", FeatureProvider.feature_enabled?(:email_members, param: org_id) || Front.ce?()},
-      {"github", !Front.ce?()},
-      {"gitlab", FeatureProvider.feature_enabled?(:gitlab, param: org_id) && !Front.ce?()},
-      {"bitbucket", FeatureProvider.feature_enabled?(:bitbucket, param: org_id) && !Front.ce?()}
+      {"email", FeatureProvider.feature_enabled?(:email_members, param: org_id)},
+      {"github", Front.saas?() || FeatureProvider.feature_enabled?(:github_user_provider, param: org_id)},
+      {"gitlab", (FeatureProvider.feature_enabled?(:gitlab, param: org_id) && Front.saas?()) || FeatureProvider.feature_enabled?(:gitlab_user_provider, param: org_id)},
+      {"bitbucket", (FeatureProvider.feature_enabled?(:bitbucket, param: org_id) && Front.saas?) || FeatureProvider.feature_enabled?(:bitbucket_user_provider, param: org_id)}
     ]
     |> Enum.map(fn
       {name, true} ->

--- a/front/lib/front_web/views/people_view.ex
+++ b/front/lib/front_web/views/people_view.ex
@@ -80,12 +80,10 @@ defmodule FrontWeb.PeopleView do
   @spec available_user_providers(org_id :: String.t()) :: [String.t()]
   defp available_user_providers(org_id) do
     [
-      {"email",
-       FeatureProvider.feature_enabled?(:email_members, param: org_id) || Front.ce_roles?()},
-      {"github", !Front.ce_roles?()},
-      {"gitlab", FeatureProvider.feature_enabled?(:gitlab, param: org_id) && !Front.ce_roles?()},
-      {"bitbucket",
-       FeatureProvider.feature_enabled?(:bitbucket, param: org_id) && !Front.ce_roles?()}
+      {"email", FeatureProvider.feature_enabled?(:email_members, param: org_id) || Front.ce?()},
+      {"github", !Front.ce?()},
+      {"gitlab", FeatureProvider.feature_enabled?(:gitlab, param: org_id) && !Front.ce?()},
+      {"bitbucket", FeatureProvider.feature_enabled?(:bitbucket, param: org_id) && !Front.ce?()}
     ]
     |> Enum.map(fn
       {name, true} ->
@@ -168,13 +166,13 @@ defmodule FrontWeb.PeopleView do
 
     feature_enabled? =
       org_scope? || FeatureProvider.feature_enabled?(:rbac__project_roles, param: org_id) ||
-        Front.ce_roles?()
+        Front.ce?()
 
     user_has_permissions? and feature_enabled?
   end
 
   def roles_action_message do
-    if Front.ce_roles?(), do: "View", else: "Manage"
+    if Front.ce?(), do: "View", else: "Manage"
   end
 
   def construct_role_label(role_binding) do

--- a/front/lib/front_web/views/roles_view.ex
+++ b/front/lib/front_web/views/roles_view.ex
@@ -4,9 +4,9 @@ defmodule FrontWeb.RolesView do
 
   @default_permissions ~w(organization.view project.view)
 
-  def allow_role_creation?, do: !Front.ce_roles?()
+  def allow_role_creation?, do: !Front.ce?()
 
-  def allow_project_roles?, do: !Front.ce_roles?()
+  def allow_project_roles?, do: !Front.ce?()
 
   def page_description do
     if allow_role_creation?() do

--- a/front/test/browser/people_test.exs
+++ b/front/test/browser/people_test.exs
@@ -9,10 +9,10 @@ defmodule Front.Browser.PeopleTest do
   @change_role_btn Query.css(".change_role_btn", count: :any, at: 0)
 
   setup do
-    ce_roles = Application.get_env(:front, :ce_roles)
-    Application.put_env(:front, :ce_roles, false)
+    edition = Application.get_env(:front, :edition)
+    Application.put_env(:front, :edition, "")
 
-    on_exit(fn -> Application.put_env(:front, :ce_roles, ce_roles) end)
+    on_exit(fn -> Application.put_env(:front, :edition, edition) end)
     :ok
   end
 

--- a/front/test/front_web/controllers/account_controller_test.exs
+++ b/front/test/front_web/controllers/account_controller_test.exs
@@ -33,8 +33,8 @@ defmodule FrontWeb.AccountControllerTest do
       refute html_response(conn, 200) =~ "/account/update_repo_scope/github"
     end
 
-    test "when bitbucket feature is disabled => do not show bitbucket scope", %{conn: conn} do
-      Application.put_env(:front, :hide_bitbucket_me_page, true)
+    test "when bitbucket feature is disabled => do not show bitbucket scope", %{conn: conn, org_id: org_id} do
+      Support.Stubs.Feature.disable_feature(org_id, "bitbucket")
 
       conn =
         conn
@@ -42,8 +42,6 @@ defmodule FrontWeb.AccountControllerTest do
 
       refute html_response(conn, 200) =~ "Bitbucket"
       assert html_response(conn, 200) =~ "GitHub"
-
-      Application.put_env(:front, :hide_bitbucket_me_page, false)
     end
   end
 

--- a/front/test/front_web/controllers/account_controller_test.exs
+++ b/front/test/front_web/controllers/account_controller_test.exs
@@ -34,10 +34,9 @@ defmodule FrontWeb.AccountControllerTest do
     end
 
     test "when bitbucket feature is disabled => do not show bitbucket scope", %{
-      conn: conn,
-      org_id: org_id
+      conn: conn
     } do
-      Support.Stubs.Feature.disable_feature(org_id, "bitbucket")
+      Support.Stubs.Feature.setup_feature("bitbucket", state: :HIDDEN, quantity: 0)
 
       conn =
         conn
@@ -45,6 +44,8 @@ defmodule FrontWeb.AccountControllerTest do
 
       refute html_response(conn, 200) =~ "Bitbucket"
       assert html_response(conn, 200) =~ "GitHub"
+
+      Support.Stubs.Feature.setup_feature("bitbucket", state: :ENABLED, quantity: 1)
     end
   end
 

--- a/front/test/front_web/controllers/account_controller_test.exs
+++ b/front/test/front_web/controllers/account_controller_test.exs
@@ -33,7 +33,10 @@ defmodule FrontWeb.AccountControllerTest do
       refute html_response(conn, 200) =~ "/account/update_repo_scope/github"
     end
 
-    test "when bitbucket feature is disabled => do not show bitbucket scope", %{conn: conn, org_id: org_id} do
+    test "when bitbucket feature is disabled => do not show bitbucket scope", %{
+      conn: conn,
+      org_id: org_id
+    } do
       Support.Stubs.Feature.disable_feature(org_id, "bitbucket")
 
       conn =

--- a/helm-chart/templates/configmaps/features.yaml
+++ b/helm-chart/templates/configmaps/features.yaml
@@ -36,8 +36,6 @@ data:
       enabled: false
     bitbucket_user_provider:
       enabled: false
-    user_repos_access:
-      enabled: true
     deployment_targets:
       enabled: false
     expose_cloud_agent_types:
@@ -154,8 +152,6 @@ data:
       enabled: false
     bitbucket_user_provider:
       enabled: false
-    user_repos_access:
-      enabled: true
     deployment_targets:
       enabled: true
     expose_cloud_agent_types:

--- a/helm-chart/templates/configmaps/features.yaml
+++ b/helm-chart/templates/configmaps/features.yaml
@@ -44,7 +44,7 @@ data:
       enabled: true
     max_paralellism_in_org:
       quantity: 500
-    max_people_in_organization:
+    max_people_in_org:
       quantity: 600
     max_projects_in_org:
       quantity: 10000

--- a/helm-chart/templates/configmaps/features.yaml
+++ b/helm-chart/templates/configmaps/features.yaml
@@ -28,6 +28,14 @@ data:
       enabled: true
     github_oauth_token:
       enabled: false
+    email_members:
+      enabled: true
+    github_user_provider:
+      enabled: false
+    gitlab_user_provider:
+      enabled: false
+    bitbucket_user_provider:
+      enabled: false
     deployment_targets:
       enabled: false
     expose_cloud_agent_types:
@@ -136,6 +144,14 @@ data:
       enabled: true
     github_oauth_token:
       enabled: false
+    email_members:
+      enabled: true
+    github_user_provider:
+      enabled: false
+    gitlab_user_provider:
+      enabled: false
+    bitbucket_user_provider:
+      enabled: false
     deployment_targets:
       enabled: true
     expose_cloud_agent_types:
@@ -150,7 +166,7 @@ data:
       enabled: true
     max_paralellism_in_org:
       quantity: 500
-    max_people_in_organization:
+    max_people_in_org:
       quantity: 600
     max_projects_in_org:
       quantity: 10000

--- a/helm-chart/templates/configmaps/features.yaml
+++ b/helm-chart/templates/configmaps/features.yaml
@@ -36,6 +36,8 @@ data:
       enabled: false
     bitbucket_user_provider:
       enabled: false
+    user_repos_access:
+      enabled: true
     deployment_targets:
       enabled: false
     expose_cloud_agent_types:
@@ -152,6 +154,8 @@ data:
       enabled: false
     bitbucket_user_provider:
       enabled: false
+    user_repos_access:
+      enabled: true
     deployment_targets:
       enabled: true
     expose_cloud_agent_types:


### PR DESCRIPTION
## 📝 Description
[_add_people_button](https://github.com/semaphoreio/semaphore/blob/d9a95d1890e5551a67c8071340b065c8bc61d213/front/lib/front_web/templates/people/members/_add_people_button.html.eex#L3) partial already performs required checks. We only need to check if we're on the `on_prem` environment.
Introduces `github_user_provider`, `gitlab_user_provider` and `bitbucket_user_provider` feature flags so OS installations can enable user authentication integration with git providers. 
Introduces `user_repos_access` feature flag for specific setups that need to restrict users from connecting their git provider account to semaphore account.
## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
