### PR TITLE
fix(ppl): Add label to schedule wf via api request

### DIFF
--- a/public-api/v1alpha/lib/pipelines_api/workflow_client/wf_request_formatter.ex
+++ b/public-api/v1alpha/lib/pipelines_api/workflow_client/wf_request_formatter.ex
@@ -14,7 +14,7 @@ defmodule PipelinesAPI.WorkflowClient.WFRequestFormatter do
   def form_schedule_request(params) when is_map(params) do
     %{
       service: service_type(params["repository"].integration_type),
-      label: params |> Map.get("reference", "") |> branch_name(),
+      label: params |> Map.get("reference", "") |> label(),
       repo: %{
         branch_name: params |> Map.get("reference", "") |> branch_name(),
         commit_sha: params |> Map.get("commit_sha", "")
@@ -59,6 +59,12 @@ defmodule PipelinesAPI.WorkflowClient.WFRequestFormatter do
   defp branch_name("refs/pull/" <> number), do: "pull-request-" <> number
   defp branch_name("refs/heads/" <> branch_name), do: branch_name
   defp branch_name(name), do: name
+
+  defp label(""), do: ""
+  defp label("refs/tags/" <> tag), do: tag
+  defp label("refs/pull/" <> number), do: number
+  defp label("refs/heads/" <> branch_name), do: branch_name
+  defp label(name), do: name
 
   # Terminate
 

--- a/public-api/v1alpha/test/workflow_client_test.exs
+++ b/public-api/v1alpha/test/workflow_client_test.exs
@@ -55,6 +55,7 @@ defmodule PipelinesAPI.WorkflowClient.Test do
 
     assert {:ok, request} = WFRequestFormatter.form_schedule_request(params)
     assert request.service == ServiceType.value(:GIT_HUB)
+    assert request.label == "main"
     assert request.repo.branch_name == "main"
     assert request.repo.commit_sha == "773d5c953bd68cc97efa81d2e014449336265fb4"
     assert {:ok, _} = UUID.info(request.request_token)


### PR DESCRIPTION
## 📝 Description

branch "run" conditions rely of pipeline label to determine what is the current branhc, and we were not setting up labels at all when triggering wfs via API.

https://github.com/renderedtext/tasks/issues/8281

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
