### PR TITLE
fix(public-api-gateway): add missing rabbitmq init container

### DIFF
--- a/public-api-gateway/helm/templates/dpl.yaml
+++ b/public-api-gateway/helm/templates/dpl.yaml
@@ -40,6 +40,8 @@ spec:
         - name: {{ . }}
 {{- end }}
 {{- end }}
+      initContainers:
+{{ include "initContainers.waitForRabbitMQ" . | indent 8 }}
       automountServiceAccountToken: false
       containers:
         - name: "{{ .Chart.Name }}"


### PR DESCRIPTION
Service is using rabbitmq but is missing init container that waits for rabbitmq pod bootup

## 📝 Description
<!-- Describe your changes in detail -->

## ✅ Checklist
- [x] I have tested this change
- [ ] ~This change requires documentation update~
