### PR TITLE
feat(security-toolbox/docker): configure vuln-severity-source

### DIFF
--- a/security-toolbox/docker
+++ b/security-toolbox/docker
@@ -38,6 +38,10 @@ OptionParser.new do |parser|
     args[:install_dependencies] = true
   end
 
+  parser.on("-v", "--vuln-severity-source SOURCES", "Vulnerability severity source (e.g., nvd,auto)") do |vuln_severity_source|
+    args[:vuln_severity_source] = vuln_severity_source
+  end
+
   parser.on("", "--scanners SCANNERS", "Which scanners to use") do |scanners|
     args[:scanners] = scanners
   end

--- a/security-toolbox/policies/docker/trivy_image.rb
+++ b/security-toolbox/policies/docker/trivy_image.rb
@@ -12,6 +12,7 @@ class Policy::TrivyImage < Policy
     @severity = args[:severity] || "HIGH,CRITICAL"
     @ignore_policy = args[:ignore_policy] || nil
     @scanners = args[:scanners] || "vuln,secret,license,misconfig"
+    @vuln_severity_source = args[:vuln_severity_source]
 
     @skip_files = args[:skip_files].to_s.split(",") || []
     @skip_dirs = args[:skip_dirs].to_s.split(",") || []
@@ -33,6 +34,10 @@ class Policy::TrivyImage < Policy
 
     if @ignore_policy != nil
       command << "--ignore-policy #{@ignore_policy}"
+    end
+
+    if @vuln_severity_source != nil
+      command << "--vuln-severity-source #{@vuln_severity_source}"
     end
 
     @skip_files.each do |skip_file|


### PR DESCRIPTION
## 📝 Description
Adds support for configuring which vulnerability severity source to use when scanning Docker images.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
