### PR TITLE
fix(docs): ToC in API refernce page now shows self-hosted agents section

### DIFF
--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -580,6 +580,8 @@ curl -H "Authorization: Token {api_token}"  \
 
 ## Tasks {#tasks}
 
+### Trigger a taks
+
 [Tasks](../using-semaphore/tasks) can be triggered via the API.
 
 To trigger a task with its default parameters:
@@ -735,9 +737,9 @@ curl -H "Authorization: Token {api_token}" \
 
 
 
-### Self-hosted agent types
+## Self-hosted agent types
 
-#### Listing agent types
+### Listing agent types
 
 ```text
 GET <organization-url>.semaphoreci.com/api/v1alpha/self_hosted_agent_types
@@ -800,7 +802,7 @@ curl -i \
 
 
 
-#### Create an agent type
+### Create an agent type
 
 ```text
 POST <organization-url>.semaphoreci.com/api/v1alpha/self_hosted_agent_types
@@ -855,7 +857,7 @@ curl -i \
 
 
 
-#### Update an agent type
+### Update an agent type
 
 ```text
 PATCH <organization-url>.semaphoreci.com/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -908,7 +910,7 @@ curl -X PATCH -i \
 ```
 
 
-#### Describe an agent type
+### Describe an agent type
 
 ```text
 GET <organization-url>.semaphoreci.com/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -951,7 +953,7 @@ curl -i \
 
 
 
-#### Delete an agent type
+### Delete an agent type
 
 ```text
 DELETE <organization-url>.semaphoreci.com/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -978,7 +980,7 @@ curl -i -X DELETE \
 
 
 
-#### Disable agents for an agent type
+### Disable agents for an agent type
 
 ```text
 POST <organization-url>.semaphoreci.com/api/v1alpha/self_hosted_agent_types/:agent_type_name/disable_all
@@ -1005,9 +1007,9 @@ curl -i \
   "https://<organization-url>.semaphoreci.com/api/v1alpha/self_hosted_agent_types/s1-aws-small/disable_all"
 ```
 
-### Self-hosted agents
+## Self-hosted agents
 
-#### List agents for an agent type
+### List agents for an agent type
 
 ```text
 GET <organization-url>.semaphoreci.com/api/v1alpha/agents?agent_type=:agent_type&page_size=:page_size&cursor=:cursor

--- a/docs/versioned_docs/version-CE-1.1/reference/api.md
+++ b/docs/versioned_docs/version-CE-1.1/reference/api.md
@@ -472,6 +472,8 @@ curl -i -X POST \
 
 ## Tasks {#tasks}
 
+### Trigger a taks
+
 [Tasks](../using-semaphore/tasks) can be triggered via the API.
 
 To trigger a task with its default parameters:
@@ -624,9 +626,9 @@ curl -H "Authorization: Token {api_token}" \
      "https://<semaphore-server-url>/api/v1alpha/logs/:job_id"
 ```
 
-### Self-hosted agent types
+## Self-hosted agent types
 
-#### Listing agent types
+### Listing agent types
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/self_hosted_agent_types
@@ -687,7 +689,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types"
 ```
 
-#### Create an agent type
+### Create an agent type
 
 ```text
 POST <semaphore-server-url>/api/v1alpha/self_hosted_agent_types
@@ -740,7 +742,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types"
 ```
 
-#### Update an agent type
+### Update an agent type
 
 ```text
 PATCH <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -792,7 +794,7 @@ curl -X PATCH -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Describe an agent type
+### Describe an agent type
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -833,7 +835,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Delete an agent type
+### Delete an agent type
 
 ```text
 DELETE <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -858,7 +860,7 @@ curl -i -X DELETE \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Disable agents for an agent type
+### Disable agents for an agent type
 
 ```text
 POST <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name/disable_all
@@ -885,9 +887,9 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small/disable_all"
 ```
 
-### Self-hosted agents
+## Self-hosted agents
 
-#### List agents for an agent type
+### List agents for an agent type
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/agents?agent_type=:agent_type&page_size=:page_size&cursor=:cursor

--- a/docs/versioned_docs/version-CE-1.2/reference/api.md
+++ b/docs/versioned_docs/version-CE-1.2/reference/api.md
@@ -472,6 +472,8 @@ curl -i -X POST \
 
 ## Tasks {#tasks}
 
+### Trigger a taks
+
 [Tasks](../using-semaphore/tasks) can be triggered via the API.
 
 To trigger a task with its default parameters:
@@ -624,9 +626,9 @@ curl -H "Authorization: Token {api_token}" \
      "https://<semaphore-server-url>/api/v1alpha/logs/:job_id"
 ```
 
-### Self-hosted agent types
+## Self-hosted agent types
 
-#### Listing agent types
+### Listing agent types
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/self_hosted_agent_types
@@ -687,7 +689,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types"
 ```
 
-#### Create an agent type
+### Create an agent type
 
 ```text
 POST <semaphore-server-url>/api/v1alpha/self_hosted_agent_types
@@ -740,7 +742,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types"
 ```
 
-#### Update an agent type
+### Update an agent type
 
 ```text
 PATCH <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -792,7 +794,7 @@ curl -X PATCH -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Describe an agent type
+### Describe an agent type
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -833,7 +835,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Delete an agent type
+### Delete an agent type
 
 ```text
 DELETE <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -858,7 +860,7 @@ curl -i -X DELETE \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Disable agents for an agent type
+### Disable agents for an agent type
 
 ```text
 POST <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name/disable_all
@@ -885,9 +887,9 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small/disable_all"
 ```
 
-### Self-hosted agents
+## Self-hosted agents
 
-#### List agents for an agent type
+### List agents for an agent type
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/agents?agent_type=:agent_type&page_size=:page_size&cursor=:cursor

--- a/docs/versioned_docs/version-CE/reference/api.md
+++ b/docs/versioned_docs/version-CE/reference/api.md
@@ -472,6 +472,8 @@ curl -i -X POST \
 
 ## Tasks {#tasks}
 
+### Trigger a taks
+
 [Tasks](../using-semaphore/tasks) can be triggered via the API.
 
 To trigger a task with its default parameters:
@@ -624,9 +626,9 @@ curl -H "Authorization: Token {api_token}" \
      "https://<semaphore-server-url>/api/v1alpha/logs/:job_id"
 ```
 
-### Self-hosted agent types
+## Self-hosted agent types
 
-#### Listing agent types
+### Listing agent types
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/self_hosted_agent_types
@@ -687,7 +689,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types"
 ```
 
-#### Create an agent type
+### Create an agent type
 
 ```text
 POST <semaphore-server-url>/api/v1alpha/self_hosted_agent_types
@@ -740,7 +742,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types"
 ```
 
-#### Update an agent type
+### Update an agent type
 
 ```text
 PATCH <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -792,7 +794,7 @@ curl -X PATCH -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Describe an agent type
+### Describe an agent type
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -833,7 +835,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Delete an agent type
+### Delete an agent type
 
 ```text
 DELETE <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -858,7 +860,7 @@ curl -i -X DELETE \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Disable agents for an agent type
+### Disable agents for an agent type
 
 ```text
 POST <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name/disable_all
@@ -885,9 +887,9 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small/disable_all"
 ```
 
-### Self-hosted agents
+## Self-hosted agents
 
-#### List agents for an agent type
+### List agents for an agent type
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/agents?agent_type=:agent_type&page_size=:page_size&cursor=:cursor

--- a/docs/versioned_docs/version-EE/reference/api.md
+++ b/docs/versioned_docs/version-EE/reference/api.md
@@ -528,6 +528,8 @@ curl -H "Authorization: Token {api_token}"  \
 
 ## Tasks {#tasks}
 
+### Trigger a taks
+
 [Tasks](../using-semaphore/tasks) can be triggered via the API.
 
 To trigger a task with its default parameters:
@@ -680,9 +682,9 @@ curl -H "Authorization: Token {api_token}" \
      "https://<semaphore-server-url>/api/v1alpha/logs/:job_id"
 ```
 
-### Self-hosted agent types
+## Self-hosted agent types
 
-#### Listing agent types
+### Listing agent types
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/self_hosted_agent_types
@@ -743,7 +745,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types"
 ```
 
-#### Create an agent type
+### Create an agent type
 
 ```text
 POST <semaphore-server-url>/api/v1alpha/self_hosted_agent_types
@@ -796,7 +798,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types"
 ```
 
-#### Update an agent type
+### Update an agent type
 
 ```text
 PATCH <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -848,7 +850,7 @@ curl -X PATCH -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Describe an agent type
+### Describe an agent type
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -889,7 +891,7 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Delete an agent type
+### Delete an agent type
 
 ```text
 DELETE <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name
@@ -914,7 +916,7 @@ curl -i -X DELETE \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small"
 ```
 
-#### Disable agents for an agent type
+### Disable agents for an agent type
 
 ```text
 POST <semaphore-server-url>/api/v1alpha/self_hosted_agent_types/:agent_type_name/disable_all
@@ -941,9 +943,9 @@ curl -i \
   "https://<semaphore-server-url>/api/v1alpha/self_hosted_agent_types/s1-aws-small/disable_all"
 ```
 
-### Self-hosted agents
+## Self-hosted agents
 
-#### List agents for an agent type
+### List agents for an agent type
 
 ```text
 GET <semaphore-server-url>/api/v1alpha/agents?agent_type=:agent_type&page_size=:page_size&cursor=:cursor


### PR DESCRIPTION
## 📝 Description

The table of contents on the right on the API reference page does not show self-hosted agents and agent types sections:
<img width="183" height="327" alt="Screenshot 2025-07-28 at 16 40 48" src="https://github.com/user-attachments/assets/41f1e453-883c-439a-b341-a9211485bbbe" />

With this change, the table of contents now properly shows sections for self-hosted agents and agent types:

<img width="230" height="637" alt="Screenshot 2025-07-28 at 16 25 14" src="https://github.com/user-attachments/assets/3cad9569-9344-436e-bb99-5572a51bd1b7" />



## ✅ Checklist
- [x] I have tested this change
- ~[x] This change requires documentation update~
