### PR TITLE
fix(github_hooks): encode branch, tag name when fetching reference

### DIFF
--- a/github_hooks/lib/internal_api/repo_proxy/branch_payload.rb
+++ b/github_hooks/lib/internal_api/repo_proxy/branch_payload.rb
@@ -10,7 +10,8 @@ module InternalApi::RepoProxy
     def call(project, user)
       repo_host = ::RepoHost::Factory.create_from_project(project)
 
-      reference = repo_host.reference(project.repo_owner_and_name, ref.delete_prefix("refs/"))
+      encoded_ref = CGI.escape(ref.delete_prefix("refs/heads/"))
+      reference = repo_host.reference(project.repo_owner_and_name, "heads/#{encoded_ref}")
 
       branch_commit = repo_host.commit(project.repo_owner_and_name, commit_sha(sha, reference))
 

--- a/github_hooks/lib/internal_api/repo_proxy/tag_payload.rb
+++ b/github_hooks/lib/internal_api/repo_proxy/tag_payload.rb
@@ -7,7 +7,8 @@ module InternalApi::RepoProxy
     def call(project, user)
       repo_host = ::RepoHost::Factory.create_from_project(project)
 
-      reference = repo_host.reference(project.repo_owner_and_name, ref.delete_prefix("refs/"))
+      encoded_ref = CGI.escape(ref.delete_prefix("refs/tags/"))
+      reference = repo_host.reference(project.repo_owner_and_name, "tags/#{encoded_ref}")
 
       tag_commit = repo_host.commit(project.repo_owner_and_name, commit_sha(reference, repo_host, project))
 


### PR DESCRIPTION
## 📝 Description

Fixes issue where triggering workflows via API fails for branches or tags containing `#` by URI-encoding branch and tag names before retrieving references through the GitHub API.

[Task](https://github.com/renderedtext/tasks/issues/8329)

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
