### PR TITLE
fix(repository_hub): URL encode branch and tag names for GitLab API

### DIFF
--- a/repository_hub/lib/repository_hub/clients/gitlab_client.ex
+++ b/repository_hub/lib/repository_hub/clients/gitlab_client.ex
@@ -349,8 +349,9 @@ defmodule RepositoryHub.GitlabClient do
   def get_branch(params, opts \\ []) do
     token = fetch_token(opts)
     project_id = project_identifier(params)
+    encoded_branch_name = URI.encode(params.branch_name, &URI.char_unreserved?/1)
 
-    "#{@api_url}/projects/#{project_id}/repository/branches/#{params.branch_name}"
+    "#{@api_url}/projects/#{project_id}/repository/branches/#{encoded_branch_name}"
     |> http_get(token, %{})
     |> process_response
     |> unwrap(fn response ->
@@ -369,8 +370,9 @@ defmodule RepositoryHub.GitlabClient do
   def get_tag(params, opts \\ []) do
     token = fetch_token(opts)
     project_id = project_identifier(params)
+    encoded_tag_name = URI.encode(params.tag_name, &URI.char_unreserved?/1)
 
-    "#{@api_url}/projects/#{project_id}/repository/tags/#{params.tag_name}"
+    "#{@api_url}/projects/#{project_id}/repository/tags/#{encoded_tag_name}"
     |> http_get(token, %{})
     |> process_response
     |> unwrap(fn response ->


### PR DESCRIPTION
## 📝 Description

Branch and tag names containing forward slashes (e.g., "feature/branch-name", "release/v1.0.0") were causing 404 errors when making API requests to GitLab. Added URI.encode with char_unreserved predicate to properly encode special characters in names according to RFC 3986.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~
