### PR TITLE
docs: update main domain semaphoreci.com → semaphore.io (fixes #472)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Free and open source under [Apache 2.0 license](LICENSE). This is what you'll fi
 Our enhanced version with extra features for larger organizations, available under a commercial license. You'll find this code in the `ee/` directory. Comes with professional support to keep your CI/CD running smoothly.
 
 ### ☁️ Semaphore Cloud
-Don't want to manage your own infrastructure? Our hosted version at [semaphoreci.com](https://semaphoreci.com) gives you all the power of Semaphore without the setup. From free plans for small projects to enterprise-scale solutions.
+Don't want to manage your own infrastructure? Our hosted version at [semaphore.io](https://semaphore.io) gives you all the power of Semaphore without the setup. From free plans for small projects to enterprise-scale solutions.
 
 ___
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -80,7 +80,7 @@ Please provide as much information as possible, including:
 Stay informed about security updates:
 
 - Follow our security announcements on [discord](https://discord.com/channels/1097422014735732746/1097434200438755369)
-- Follow the announcements on our [website](https://semaphoreci.com/category/semaphore-news)
+- Follow the announcements on our [website](https://semaphore.io/category/semaphore-news)
 
 ## Attribution
 

--- a/docs/docs/getting-started/changelog.md
+++ b/docs/docs/getting-started/changelog.md
@@ -4028,7 +4028,7 @@ A new set of improvements focused on monorepo support were shipped:
 - **Clearer error messages** - Improved error messages for the most common misconfiguration issues.
 - **Improved stability** - All compilation errors arising from edge cases have been eliminated, making these features more reliable.
 
-You can read more about this feature in this [blog post](https://semaphoreci.com/blog/monorepo-support-available).
+You can read more about this feature in this [blog post](https://semaphore.io/blog/monorepo-support-available).
 
 Additional related reading:
 
@@ -4332,7 +4332,7 @@ The new UI is available to all users. Minor performance updates and fixes have b
 - **(Fixed)** fixed the issue with job logs auto-scrolling to top of the failed command output, instead of to the bottom.
 - **(Fixed)** fixed the issue with manual promotions being triggered based on promotion name.
 
-You can read more about the new UI in this [blog post](https://semaphoreci.com/blog/refreshed-new-ui-for-a-greater-experience).
+You can read more about the new UI in this [blog post](https://semaphore.io/blog/refreshed-new-ui-for-a-greater-experience).
 We appreciate your feedback and encourage you to send any suggestions to [our feedback inbox](mailto:feedback@semaphoreci.com?subject=Beta%20Feedback).
 
 **(Improved) macOS Xcode 12 image update**  
@@ -4548,7 +4548,7 @@ The new UI brings several improvements:
 - Improved job logs with collapsable command lines and a dark theme.
 - Activity Monitor page that provides a handy overview of running pipelines and quota limits.
 
-You can read more about the new UI in this [blog post](https://semaphoreci.com/blog/refreshed-new-ui-for-a-greater-experience).  
+You can read more about the new UI in this [blog post](https://semaphore.io/blog/refreshed-new-ui-for-a-greater-experience).  
 If you want to try out the new UI, but it hasn't yet rolled out to your organization, please reach out to [our support team](mailto:support@semaphoreci.com).
 
 **(Improved) macOS Xcode11 image update**  
@@ -4988,7 +4988,7 @@ A detailed list can be found in the [Docker images changelog](https://github.com
 
 ## Week of December 2, 2019
 
-- New: [Open source organizations are available](https://semaphoreci.com/blog/free-open-source-cicd).  Each open source organization receives unlimited CI/CD minutes for building public repositories, including Linux, Docker, and macOS-based environments.
+- New: [Open source organizations are available](https://semaphore.io/blog/free-open-source-cicd).  Each open source organization receives unlimited CI/CD minutes for building public repositories, including Linux, Docker, and macOS-based environments.
 - New: [Status badges](../using-semaphore/projects#badges).
 - Updates to the Ubuntu1804 image
   - Git-lfs 2.9.0  -> 2.9.1
@@ -5172,7 +5172,7 @@ A detailed list can be found in the [Docker images changelog](https://github.com
 
 ## Week of July 22, 2019
 
-- New feature: model complex workflows with pipeline dependencies. Learn more in this [blog post](https://semaphoreci.com/blog/introducing-cicd-pipeline-dependencies).
+- New feature: model complex workflows with pipeline dependencies. Learn more in this [blog post](https://semaphore.io/blog/introducing-cicd-pipeline-dependencies).
 - New feature: [fail-fast on the first failure](../using-semaphore/pipelines#fail-fast).  Now you can stop everything in your pipeline as soon as a failure is detected, or stops only the jobs and blocks in your pipeline that haven't yet started.
 - A new global sidebar that uses less screen real estate, and lets you star projects and dashboards so they appear on top of the list. Also, it loads really fast.
 - A new version of CLI v0.14.1 has been released.
@@ -5241,7 +5241,7 @@ curl https://storage.googleapis.com/sem-cli-releases/get.sh | bash
 
 ## Week of May 13, 2019
 
-- [iOS support is in GA](https://semaphoreci.com/blog/introducing-ios-cicd): Semaphore now supports building, testing, and deploying applications for any Apple device.
+- [iOS support is in GA](https://semaphore.io/blog/introducing-ios-cicd): Semaphore now supports building, testing, and deploying applications for any Apple device.
 - macOS platform:
   - Xcode upgraded to 10.2.1
 - New feature: [schedule CI/CD workflows](../using-semaphore/tasks) using standard Cron syntax.
@@ -5317,7 +5317,7 @@ curl https://storage.googleapis.com/sem-cli-releases/get.sh | bash
   widget shows CLI commands that you can run to perform the same actions that
   you see in the UI.
 - Slack notifications can be [filtered by pipeline result](../using-semaphore/notifications).
-- macOS Mojave image introduced, with iOS/macOS support in [closed beta](https://semaphoreci.com/product/ios).
+- macOS Mojave image introduced, with iOS/macOS support in [closed beta](https://semaphore.io/product/ios).
 - Syntax highlighting in docs.
 
 ## Week of Feb 11, 2019

--- a/docs/docs/getting-started/faq.md
+++ b/docs/docs/getting-started/faq.md
@@ -20,11 +20,11 @@ Yes. The list of the platform IPs used by Semaphore is [publicly available](http
 
 ### Can I use my own machines to run workflows?
 
-Yes. With the Semaphore [Hybrid Plan](https://semaphoreci.com/pricing) you can add your own machines as [self-hosted agents](../using-semaphore/self-hosted). You can use a mix of Semaphore Cloud and your own machines for your workflows.
+Yes. With the Semaphore [Hybrid Plan](https://semaphore.io/pricing) you can add your own machines as [self-hosted agents](../using-semaphore/self-hosted). You can use a mix of Semaphore Cloud and your own machines for your workflows.
 
 ### Can I run Semaphore On-Premise?
 
-Yes. The Semaphore [On-Premise Plan](https://semaphoreci.com/pricing) allows you to host a separate installation of Semaphore behind your firewall, allowing you to run CI/CD completely on your own infrastructure.
+Yes. The Semaphore [On-Premise Plan](https://semaphore.io/pricing) allows you to host a separate installation of Semaphore behind your firewall, allowing you to run CI/CD completely on your own infrastructure.
 
 ### Can I use self-signed certificates with private Docker registries?
 

--- a/docs/docs/getting-started/migration/overview.md
+++ b/docs/docs/getting-started/migration/overview.md
@@ -37,7 +37,7 @@ Here is the recommended plan to migrate from any CI provider to Semaphore.
     - Nice to have
     - Optional
 
-    Compare the list against [Semaphore Features](https://semaphoreci.com/pricing). Some of the requirements can be implemented in several ways by combining several features.
+    Compare the list against [Semaphore Features](https://semaphore.io/pricing). Some of the requirements can be implemented in several ways by combining several features.
 
 3. Create a proof of concept in Semaphore
 

--- a/docs/docs/getting-started/tour/sign-up.md
+++ b/docs/docs/getting-started/tour/sign-up.md
@@ -35,7 +35,7 @@ Before you can start using Semaphore, you need to create an account:
 
 <Steps>
 
-1. Go to [semaphoreci.com](https://semaphoreci.com)
+1. Go to [semaphore.io](https://semaphore.io)
 2. Press **Start Building for Free**
 3. Select one of the options: **Signup with GitHub** or **Signup with BitBucket**
 

--- a/docs/docs/using-semaphore/artifacts.md
+++ b/docs/docs/using-semaphore/artifacts.md
@@ -358,7 +358,7 @@ Artifacts on Semaphore Cloud are charged based on:
 - **Storage**: the amount of data stored, charged on a GB-per-month basis
 - **Traffic**: download network traffic in jobs or from the website, charged by the total GB of data per month
 
-For more information, see [Plans and Pricing](https://semaphoreci.com/pricing)
+For more information, see [Plans and Pricing](https://semaphore.io/pricing)
 
 :::note
 

--- a/docs/docs/using-semaphore/connect-bitbucket.md
+++ b/docs/docs/using-semaphore/connect-bitbucket.md
@@ -28,7 +28,7 @@ Follow these steps to create a Semaphore account using BitBucket:
 <Steps>
 
 1. Log in to your BitBucket account
-2. Navigate to the [Semaphore login page](https://semaphoreci.com/login)
+2. Navigate to the [Semaphore login page](https://semaphore.io/login)
 3. Select **Log in with BitBucket**
 4. Grant access to the Semaphore [OAuth App](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/) in BitBucket
 5. Finish the Semaphore setup

--- a/docs/docs/using-semaphore/connect-github-oauth.md
+++ b/docs/docs/using-semaphore/connect-github-oauth.md
@@ -41,7 +41,7 @@ Follow these steps to create a Semaphore account using GitHub:
 <Steps>
 
 1. Log in to your GitHub account
-2. Navigate to the [Semaphore login page](https://semaphoreci.com/login)
+2. Navigate to the [Semaphore login page](https://semaphore.io/login)
 3. Select **Log in with GitHub**
 4. Grant access to the Semaphore [OAuth App](https://github.com/settings/connections/applications/328c742132e5407abd7d) in GitHub
 5. Finish the Semaphore setup

--- a/docs/docs/using-semaphore/monorepo.md
+++ b/docs/docs/using-semaphore/monorepo.md
@@ -17,7 +17,7 @@ Semaphore features a repository change detection strategy to optimize monorepo p
 
 ## Overview
 
-A [monorepo](https://semaphoreci.com/blog/what-is-monorepo) is a repository that holds many projects. While these projects may be related, they are often logically independent, uncoupled, and sometimes even managed by different teams.
+A [monorepo](https://semaphore.io/blog/what-is-monorepo) is a repository that holds many projects. While these projects may be related, they are often logically independent, uncoupled, and sometimes even managed by different teams.
 
 Semaphore can detect changes between commits, allowing you to set up fine-grained jobs that only run when the underlying code changes. Skipping jobs covering unchanged code can greatly speed testing and reduce costs on big codebases.
 

--- a/docs/docs/using-semaphore/projects.md
+++ b/docs/docs/using-semaphore/projects.md
@@ -10,7 +10,7 @@ import Available from '@site/src/components/Available';
 import VideoTutorial from '@site/src/components/VideoTutorial';
 import Steps from '@site/src/components/Steps';
 
-Projects are codebases developed and managed through Semaphore [Continuous Integration](https://semaphoreci.com/continuous-integration). A project links your Git repository with Semaphore, so it can run [jobs](./jobs) to test, build, or deploy your application. 
+Projects are codebases developed and managed through Semaphore [Continuous Integration](https://semaphore.io/continuous-integration). A project links your Git repository with Semaphore, so it can run [jobs](./jobs) to test, build, or deploy your application. 
 
 This page explains how to set up projects and what settings are available.
 
@@ -20,7 +20,7 @@ This page explains how to set up projects and what settings are available.
 
 To create a Semaphore project you need:
 
-- A [Semaphore](https://semaphoreci.com) account with an [organization](./organizations.md)
+- A [Semaphore](https://semaphore.io) account with an [organization](./organizations.md)
 - A repository with at least one commit
 - A GitHub or Bitbucket account. For more information, see the connection guides
   - [How to connect to GitHub](./connect-github)

--- a/docs/docs/using-semaphore/promotions.md
+++ b/docs/docs/using-semaphore/promotions.md
@@ -12,7 +12,7 @@ import Steps from '@site/src/components/Steps';
 
 <VideoTutorial title="How to use promotions" src="https://www.youtube.com/embed/rbf2jb3Uh-E?si=UH-_74icf4KdGYCf" />
 
-Promotions connect [pipelines](./pipelines) to implement continuous delivery and deployment, or other types of automation, such as [blue-green](https://semaphoreci.com/blog/blue-green-deployment) deployments and [canary](https://semaphoreci.com/blog/what-is-canary-deployment) deployments. 
+Promotions connect [pipelines](./pipelines) to implement continuous delivery and deployment, or other types of automation, such as [blue-green](https://semaphore.io/blog/blue-green-deployment) deployments and [canary](https://semaphore.io/blog/what-is-canary-deployment) deployments. 
 
 This page explains promotions, how to use them to connect pipelines, and what settings are available.
 

--- a/docs/versioned_docs/version-CE-1.1/getting-started/about-semaphore.md
+++ b/docs/versioned_docs/version-CE-1.1/getting-started/about-semaphore.md
@@ -10,7 +10,7 @@ Semaphore is [Continuous Integration and Delivery](https://semaphore.io/continuo
 
 Semaphore comes in two editions:
 
-- **[Semaphore Cloud](/getting-started/about-semaphore)**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to [semaphoreci.com](https://semaphore.io) to access Semaphore Cloud
+- **[Semaphore Cloud](/getting-started/about-semaphore)**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to [semaphore.io](https://semaphore.io) to access Semaphore Cloud
 - **[Semaphore CE](/CE/getting-started/install)**: is the free and open-source Community Edition of Semaphore. Meant for anyone that wishes to host and manage their own CI/CD architecture.
 - **On-premise (Enterprise Edition)**: fully-featured Semaphore that can run behind a firewall using your infrastructure
 

--- a/docs/versioned_docs/version-CE-1.1/getting-started/faq.md
+++ b/docs/versioned_docs/version-CE-1.1/getting-started/faq.md
@@ -16,7 +16,7 @@ This page contains Frequently Asked Questions.
 
 ### What's the difference between Semaphore Community Edition (CE) and Semaphore Cloud?
 
-- **Semaphore Cloud**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to semaphoreci.com to access Semaphore Cloud
+- **Semaphore Cloud**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to semaphore.io to access Semaphore Cloud
 - **Semaphore CE**: is the free and open-source Community Edition of Semaphore. Meant for anyone that wishes to host and manage their own CI/CD architecture.
 
 ### Where can I run Semaphore CE?

--- a/docs/versioned_docs/version-CE-1.1/using-semaphore/monorepo.md
+++ b/docs/versioned_docs/version-CE-1.1/using-semaphore/monorepo.md
@@ -17,7 +17,7 @@ Semaphore features a repository change detection strategy to optimize monorepo p
 
 ## Overview
 
-A [monorepo](https://semaphoreci.com/blog/what-is-monorepo) is a repository that holds many projects. While these projects may be related, they are often logically independent, uncoupled, and sometimes even managed by different teams.
+A [monorepo](https://semaphore.io/blog/what-is-monorepo) is a repository that holds many projects. While these projects may be related, they are often logically independent, uncoupled, and sometimes even managed by different teams.
 
 Semaphore can detect changes between commits, allowing you to set up fine-grained jobs that only run when the underlying code changes. Skipping jobs covering unchanged code can greatly speed testing and reduce costs on big codebases.
 

--- a/docs/versioned_docs/version-CE-1.1/using-semaphore/projects.md
+++ b/docs/versioned_docs/version-CE-1.1/using-semaphore/projects.md
@@ -10,7 +10,7 @@ import Available from '@site/src/components/Available';
 import VideoTutorial from '@site/src/components/VideoTutorial';
 import Steps from '@site/src/components/Steps';
 
-Projects are codebases developed and managed through Semaphore [Continuous Integration](https://semaphoreci.com/continuous-integration). A project links your Git repository with Semaphore, so it can run [jobs](./jobs) to test, build, or deploy your application. 
+Projects are codebases developed and managed through Semaphore [Continuous Integration](https://semaphore.io/continuous-integration). A project links your Git repository with Semaphore, so it can run [jobs](./jobs) to test, build, or deploy your application. 
 
 This page explains how to set up projects and what settings are available. Before you can create a project you must connect Semaphore to [GitHub](./connect-github) or [BitBucket](./connect-bitbucket).
 

--- a/docs/versioned_docs/version-CE-1.2/getting-started/about-semaphore.md
+++ b/docs/versioned_docs/version-CE-1.2/getting-started/about-semaphore.md
@@ -10,7 +10,7 @@ Semaphore is [Continuous Integration and Delivery](https://semaphore.io/continuo
 
 Semaphore comes in two editions:
 
-- **[Semaphore Cloud](/getting-started/about-semaphore)**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to [semaphoreci.com](https://semaphore.io) to access Semaphore Cloud
+- **[Semaphore Cloud](/getting-started/about-semaphore)**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to [semaphore.io](https://semaphore.io) to access Semaphore Cloud
 - **[Semaphore CE](/CE/getting-started/install)**: is the free and open-source Community Edition of Semaphore. Meant for anyone that wishes to host and manage their own CI/CD architecture.
 - **On-premise (Enterprise Edition)**: fully-featured Semaphore that can run behind a firewall using your infrastructure
 

--- a/docs/versioned_docs/version-CE-1.2/getting-started/faq.md
+++ b/docs/versioned_docs/version-CE-1.2/getting-started/faq.md
@@ -16,7 +16,7 @@ This page contains Frequently Asked Questions.
 
 ### What's the difference between Semaphore Community Edition (CE) and Semaphore Cloud?
 
-- **Semaphore Cloud**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to semaphoreci.com to access Semaphore Cloud
+- **Semaphore Cloud**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to semaphore.io to access Semaphore Cloud
 - **Semaphore CE**: is the free and open-source Community Edition of Semaphore. Meant for anyone that wishes to host and manage their own CI/CD architecture.
 
 ### Where can I run Semaphore CE?

--- a/docs/versioned_docs/version-CE-1.2/using-semaphore/monorepo.md
+++ b/docs/versioned_docs/version-CE-1.2/using-semaphore/monorepo.md
@@ -17,7 +17,7 @@ Semaphore features a repository change detection strategy to optimize monorepo p
 
 ## Overview
 
-A [monorepo](https://semaphoreci.com/blog/what-is-monorepo) is a repository that holds many projects. While these projects may be related, they are often logically independent, uncoupled, and sometimes even managed by different teams.
+A [monorepo](https://semaphore.io/blog/what-is-monorepo) is a repository that holds many projects. While these projects may be related, they are often logically independent, uncoupled, and sometimes even managed by different teams.
 
 Semaphore can detect changes between commits, allowing you to set up fine-grained jobs that only run when the underlying code changes. Skipping jobs covering unchanged code can greatly speed testing and reduce costs on big codebases.
 

--- a/docs/versioned_docs/version-CE/getting-started/about-semaphore.md
+++ b/docs/versioned_docs/version-CE/getting-started/about-semaphore.md
@@ -10,7 +10,7 @@ Semaphore is [Continuous Integration and Delivery](https://semaphore.io/continuo
 
 Semaphore comes in two editions:
 
-- **[Semaphore Cloud](/getting-started/about-semaphore)**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to [semaphoreci.com](https://semaphore.io) to access Semaphore Cloud
+- **[Semaphore Cloud](/getting-started/about-semaphore)**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to [semaphore.io](https://semaphore.io) to access Semaphore Cloud
 - **[Semaphore CE](/CE/getting-started/install)**: is the free and open-source Community Edition of Semaphore. Meant for anyone that wishes to host and manage their own CI/CD architecture.
 - **On-premise (Enterprise Edition)**: fully-featured Semaphore that can run behind a firewall using your infrastructure
 

--- a/docs/versioned_docs/version-CE/getting-started/faq.md
+++ b/docs/versioned_docs/version-CE/getting-started/faq.md
@@ -16,7 +16,7 @@ This page contains Frequently Asked Questions.
 
 ### What's the difference between Semaphore Community Edition (CE) and Semaphore Cloud?
 
-- **Semaphore Cloud**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to semaphoreci.com to access Semaphore Cloud
+- **Semaphore Cloud**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to semaphore.io to access Semaphore Cloud
 - **Semaphore CE**: is the free and open-source Community Edition of Semaphore. Meant for anyone that wishes to host and manage their own CI/CD architecture.
 
 ### Where can I run Semaphore CE?

--- a/docs/versioned_docs/version-CE/using-semaphore/monorepo.md
+++ b/docs/versioned_docs/version-CE/using-semaphore/monorepo.md
@@ -17,7 +17,7 @@ Semaphore features a repository change detection strategy to optimize monorepo p
 
 ## Overview
 
-A [monorepo](https://semaphoreci.com/blog/what-is-monorepo) is a repository that holds many projects. While these projects may be related, they are often logically independent, uncoupled, and sometimes even managed by different teams.
+A [monorepo](https://semaphore.io/blog/what-is-monorepo) is a repository that holds many projects. While these projects may be related, they are often logically independent, uncoupled, and sometimes even managed by different teams.
 
 Semaphore can detect changes between commits, allowing you to set up fine-grained jobs that only run when the underlying code changes. Skipping jobs covering unchanged code can greatly speed testing and reduce costs on big codebases.
 

--- a/docs/versioned_docs/version-EE/getting-started/about-semaphore.md
+++ b/docs/versioned_docs/version-EE/getting-started/about-semaphore.md
@@ -10,7 +10,7 @@ Semaphore is [Continuous Integration and Delivery](https://semaphore.io/continuo
 
 Semaphore comes in two editions:
 
-- **[Semaphore Cloud](/getting-started/about-semaphore)**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to [semaphoreci.com](https://semaphore.io) to access Semaphore Cloud
+- **[Semaphore Cloud](/getting-started/about-semaphore)**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to [semaphore.io](https://semaphore.io) to access Semaphore Cloud
 - **[Semaphore CE](/CE/getting-started/install)**: is the free and open-source Community Edition of Semaphore. Meant for anyone that wishes to host and manage their own CI/CD architecture.
 - [Semaphore EE](/EE/getting-started/install)): commercial, fully-featured Semaphore instance. Meant for companies who wishes to host and manage their own CI/CD architecture.
 

--- a/docs/versioned_docs/version-EE/getting-started/faq.md
+++ b/docs/versioned_docs/version-EE/getting-started/faq.md
@@ -16,7 +16,7 @@ This page contains Frequently Asked Questions.
 
 ### What's the difference between Semaphore Enterprise Edition (EE) and Semaphore Cloud?
 
-- **Semaphore Cloud**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to semaphoreci.com to access Semaphore Cloud
+- **Semaphore Cloud**: is a cloud-based, fully-managed CI-as-a-Service platform. Meant for individuals and companies that don't wish to maintain a CI/CD system. Head to semaphore.io to access Semaphore Cloud
 - **Semaphore EE**: is a fully featured self-hostable version of Semaphore. Running Semaphore Enterprise Edition requires a [license](./license).
 
 ### Where can I run Semaphore EE?

--- a/docs/versioned_docs/version-EE/using-semaphore/monorepo.md
+++ b/docs/versioned_docs/version-EE/using-semaphore/monorepo.md
@@ -17,7 +17,7 @@ Semaphore features a repository change detection strategy to optimize monorepo p
 
 ## Overview
 
-A [monorepo](https://semaphoreci.com/blog/what-is-monorepo) is a repository that holds many projects. While these projects may be related, they are often logically independent, uncoupled, and sometimes even managed by different teams.
+A [monorepo](https://semaphore.io/blog/what-is-monorepo) is a repository that holds many projects. While these projects may be related, they are often logically independent, uncoupled, and sometimes even managed by different teams.
 
 Semaphore can detect changes between commits, allowing you to set up fine-grained jobs that only run when the underlying code changes. Skipping jobs covering unchanged code can greatly speed testing and reduce costs on big codebases.
 

--- a/docs/versioned_docs/version-EE/using-semaphore/projects.md
+++ b/docs/versioned_docs/version-EE/using-semaphore/projects.md
@@ -10,7 +10,7 @@ import Available from '@site/src/components/Available';
 import VideoTutorial from '@site/src/components/VideoTutorial';
 import Steps from '@site/src/components/Steps';
 
-Projects are codebases developed and managed through Semaphore [Continuous Integration](https://semaphoreci.com/continuous-integration). A project links your Git repository with Semaphore, so it can run [jobs](./jobs) to test, build, or deploy your application. 
+Projects are codebases developed and managed through Semaphore [Continuous Integration](https://semaphore.io/continuous-integration). A project links your Git repository with Semaphore, so it can run [jobs](./jobs) to test, build, or deploy your application. 
 
 This page explains how to create projects hosted on public Git hosting services such as [GitHub](./connect-github), [BitBucket](./connect-bitbucket), or [GitLab](./connect-gitlab). To create project hosted on private Git services, see the [Connect Any Git Server](./connect-git-server) page. In this page, we'll use the terms organization, server, and instance interchangeably.
 

--- a/docs/versioned_docs/version-EE/using-semaphore/promotions.md
+++ b/docs/versioned_docs/version-EE/using-semaphore/promotions.md
@@ -12,7 +12,7 @@ import Steps from '@site/src/components/Steps';
 
 <VideoTutorial title="How to use promotions" src="https://www.youtube.com/embed/rbf2jb3Uh-E?si=UH-_74icf4KdGYCf" />
 
-Promotions connect [pipelines](./pipelines) to implement continuous delivery and deployment, or other types of automation, such as [blue-green](https://semaphoreci.com/blog/blue-green-deployment) deployments and [canary](https://semaphoreci.com/blog/what-is-canary-deployment) deployments. 
+Promotions connect [pipelines](./pipelines) to implement continuous delivery and deployment, or other types of automation, such as [blue-green](https://semaphore.io/blog/blue-green-deployment) deployments and [canary](https://semaphore.io/blog/what-is-canary-deployment) deployments. 
 
 This page explains promotions, how to use them to connect pipelines, and what settings are available.
 


### PR DESCRIPTION
## 📝 Description
Title: docs: switch main-site links to semaphore.io (fixes semaphoreio/semaphore#472)

Summary
Replace root-domain semaphoreci.com with semaphore.io across docs.
Keep emails (@semaphoreci.com) and subdomains (docs/id/status.semaphoreci.com) intact.
No code or tests changed.

## ✅ Checklist
- [Yes ] I have tested this change
- [ ] This change requires documentation update

##  Testing done
- Verified no remaining root-domain refs:
  - git grep -n 'https\?://\(www\.\)\?semaphoreci\.com\b' → none
  - git grep -nP '(?<![@.])\bsemaphoreci\.com\b(?!/)' → none
- Confirmed subdomains/emails remain unchanged:
  - docs/id/status.semaphoreci.com and *@semaphoreci.com still present
- Intentionally left Kubernetes label namespace keys like
  `semaphoreci.com/resource-type` unchanged.
