### PR TITLE
fix(github-hooks): support ready_for_review hook from github

### DIFF
--- a/github_hooks/lib/semaphore/repo_host/github/webhook_filter.rb
+++ b/github_hooks/lib/semaphore/repo_host/github/webhook_filter.rb
@@ -5,7 +5,7 @@ module Semaphore::RepoHost::Github
     MEMBER_GITHUB_WEBHOOK_EVENT = ["member", "membership", "team"]
     GITHUB_APP_WEBHOOK_EVENTS = ["installation", "installation_repositories"]
     SUPPORTED_GITHUB_WEBHOOK_EVENTS = ["push", "pull_request", "member", "issue_comment", "installation", "installation_repositories", "team", "membership", "repository"]
-    SUPPORTED_GITHUB_PULL_REQUEST_ACTIONS = ["opened", "synchronize", "closed", "reopened"]
+    SUPPORTED_GITHUB_PULL_REQUEST_ACTIONS = ["opened", "synchronize", "closed", "reopened", "ready_for_review"]
     SUPPORTED_PR_COMMANDS = ["/sem-approve"]
 
     def initialize(request, payload)

--- a/github_hooks/spec/lib/semaphore/repo_host/github/webhook_filter_spec.rb
+++ b/github_hooks/spec/lib/semaphore/repo_host/github/webhook_filter_spec.rb
@@ -173,6 +173,31 @@ RSpec.describe Semaphore::RepoHost::Github::WebhookFilter do
 
       end
 
+      context "ready_for_review" do
+
+        let(:payload) do
+          <<-PAYLOAD
+              {
+                "action": "ready_for_review",
+                "pull_request":{
+                  "draft": false,
+                  "head":{
+                    "label": "owner_1:branch"
+                  },
+                  "base":{
+                    "label": "owner_2:branch"
+                  }
+                }
+              }
+          PAYLOAD
+        end
+
+        it "returns false" do
+          expect(filter.unsupported_webhook?).to eql(false)
+        end
+
+      end
+
       context "other" do
 
         let(:payload) do


### PR DESCRIPTION
## 📝 Description
Draft PRs that are converted to regular PRs don't trigger builds because the GitHub webhook action `ready_for_review` is not in the list of supported actions in the webhook filter.

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
