### PR TITLE
feat(github_hooks): handle service account github repo host account

### DIFF
--- a/github_hooks/app/models/user.rb
+++ b/github_hooks/app/models/user.rb
@@ -6,7 +6,11 @@ class User < ActiveRecord::Base
   end
 
   def github_repo_host_account
-    repo_host_account(::Repository::GITHUB_PROVIDER)
+    account = repo_host_account(::Repository::GITHUB_PROVIDER)
+    return account if account.present?
+    return synthetic_repo_host_account if service_account?
+
+    nil
   end
 
   def bitbucket_repo_host_account
@@ -15,5 +19,39 @@ class User < ActiveRecord::Base
 
   def repo_host_account(repo_host)
     repo_host_accounts.find_by_repo_host(repo_host)
+  end
+
+  def service_account?
+    creation_source == "service_account"
+  end
+
+  private
+
+  def synthetic_repo_host_account
+    @synthetic_repo_host_account ||= SyntheticRepoHostAccount.new(self)
+  end
+
+  class SyntheticRepoHostAccount
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def name
+      user.name || "Service Account"
+    end
+
+    def github_uid
+      "service_account_#{user.id}".hash.abs.to_s
+    end
+
+    def login
+      "service-account"
+    end
+
+    def repo_host
+      ::Repository::GITHUB_PROVIDER
+    end
   end
 end

--- a/github_hooks/spec/models/user_spec.rb
+++ b/github_hooks/spec/models/user_spec.rb
@@ -2,4 +2,92 @@ require "spec_helper"
 
 RSpec.describe User, :type => :model do
   it { is_expected.to have_many(:repo_host_accounts).dependent(:destroy) }
+
+  describe "#service_account?" do
+    context "when creation_source is 'service_account'" do
+      let(:user) { FactoryBot.build(:user, creation_source: "service_account") }
+
+      it "returns true" do
+        expect(user.service_account?).to be_truthy
+      end
+    end
+
+    context "when creation_source is not 'service_account'" do
+      let(:user) { FactoryBot.build(:user, creation_source: "github") }
+
+      it "returns false" do
+        expect(user.service_account?).to be_falsey
+      end
+    end
+
+    context "when creation_source is nil" do
+      let(:user) { FactoryBot.build(:user, creation_source: nil) }
+
+      it "returns false" do
+        expect(user.service_account?).to be_falsey
+      end
+    end
+  end
+
+  describe "#github_repo_host_account" do
+    context "when user is a regular user with github connection" do
+      let(:user) { FactoryBot.create(:user, :github_connection) }
+
+      it "returns the actual RepoHostAccount" do
+        account = user.github_repo_host_account
+        expect(account).to be_a(RepoHostAccount)
+        expect(account.repo_host).to eq(::Repository::GITHUB_PROVIDER)
+      end
+    end
+
+    context "when user is a regular user without github connection" do
+      let(:user) { FactoryBot.create(:user) }
+
+      it "returns nil" do
+        expect(user.github_repo_host_account).to be_nil
+      end
+    end
+
+    context "when user is a service account" do
+      let(:user) { FactoryBot.create(:user, creation_source: "service_account", name: "Test Service Account") }
+
+      it "returns a synthetic account object" do
+        account = user.github_repo_host_account
+        expect(account).to be_a(User::SyntheticRepoHostAccount)
+      end
+
+      it "provides expected name from user.name" do
+        account = user.github_repo_host_account
+        expect(account.name).to eq("Test Service Account")
+      end
+
+      it "provides 'Service Account' fallback when name is nil" do
+        user.update!(name: nil)
+        account = user.github_repo_host_account
+        expect(account.name).to eq("Service Account")
+      end
+
+      it "provides a deterministic github_uid based on user id" do
+        account = user.github_repo_host_account
+        expected_uid = "service_account_#{user.id}".hash.abs.to_s
+        expect(account.github_uid).to eq(expected_uid)
+      end
+
+      it "provides 'service-account' login" do
+        account = user.github_repo_host_account
+        expect(account.login).to eq("service-account")
+      end
+
+      it "provides correct repo_host" do
+        account = user.github_repo_host_account
+        expect(account.repo_host).to eq(::Repository::GITHUB_PROVIDER)
+      end
+
+      it "caches the synthetic account object" do
+        account1 = user.github_repo_host_account
+        account2 = user.github_repo_host_account
+        expect(account1).to be(account2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 📝 Description
Service accounts do not have `github_repo_host_account` hence we use their semaphore credentials when injecting a workflow request (either manual task run or manual workflow trigger via API)

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
