### PR TITLE
fix(guard): use correct field for generating service account email domains

### DIFF
--- a/guard/lib/guard/front_repo/user.ex
+++ b/guard/lib/guard/front_repo/user.ex
@@ -272,9 +272,9 @@ defmodule Guard.FrontRepo.User do
     |> validate_length(:name, max: 255, message: "Name cannot exceed 255 characters")
     |> validate_inclusion(:creation_source, [:service_account])
     |> put_change(:single_org_user, true)
-    |> validate_format(:email, ~r/^[\w\-\.]+@service_accounts\.[\w\-\.]+\.#{escaped_domain}$/i,
+    |> validate_format(:email, ~r/^[\w\-\.]+@service-accounts\.[\w\-\.]+\.#{escaped_domain}$/i,
       message:
-        "Service account email must follow the format: name@service_accounts.organization.#{base_domain}"
+        "Service account email must follow the format: name@service-accounts.organization.#{base_domain}"
     )
     |> unique_constraint(:email, name: :index_users_on_email)
     |> unique_constraint(:authentication_token, name: :index_users_on_authentication_token)
@@ -290,7 +290,7 @@ defmodule Guard.FrontRepo.User do
     sanitized_org_name = sanitize_email_part(organization_name)
     base_domain = Application.fetch_env!(:guard, :base_domain)
 
-    "#{sanitized_sa_name}@service_accounts.#{sanitized_org_name}.#{base_domain}"
+    "#{sanitized_sa_name}@service-accounts.#{sanitized_org_name}.#{base_domain}"
   end
 
   defp sanitize_email_part(name) do

--- a/guard/lib/guard/store/service_account.ex
+++ b/guard/lib/guard/store/service_account.ex
@@ -510,20 +510,20 @@ defmodule Guard.Store.ServiceAccount do
     base_domain = Application.fetch_env!(:guard, :base_domain)
 
     case Guard.Api.Organization.fetch(org_id) do
-      %{username: org_username} ->
+      %{org_username: org_username} ->
         # Sanitize names for email compatibility
         sanitized_name =
           String.downcase(service_account_name) |> String.replace(~r/[^a-z0-9\-]/, "-")
 
         sanitized_org = String.downcase(org_username) |> String.replace(~r/[^a-z0-9\-]/, "-")
-        "#{sanitized_name}@service_accounts.#{sanitized_org}.#{base_domain}"
+        "#{sanitized_name}@service-accounts.#{sanitized_org}.#{base_domain}"
 
       _ ->
         # Fallback if org not found (shouldn't happen in normal flow)
         sanitized_name =
           String.downcase(service_account_name) |> String.replace(~r/[^a-z0-9\-]/, "-")
 
-        "#{sanitized_name}@service_accounts.unknown.#{base_domain}"
+        "#{sanitized_name}@service-accounts.unknown.#{base_domain}"
     end
   end
 

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -1386,7 +1386,7 @@ defmodule Guard.GrpcServers.UserServerTest do
       assert user_id == user.id
       assert user_email == user.email
       assert user_name == user.name
-      assert String.contains?(user_email, "@service_accounts.")
+      assert String.contains?(user_email, "@service-accounts.")
       assert String.contains?(user_email, ".#{Application.fetch_env!(:guard, :base_domain)}")
     end
 

--- a/guard/test/guard/service_account/actions_test.exs
+++ b/guard/test/guard/service_account/actions_test.exs
@@ -93,7 +93,7 @@ defmodule Guard.ServiceAccount.ActionsTest do
                   creator_id: "creator-id",
                   deactivated: false,
                   email:
-                    "test@service_accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
+                    "test@service-accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
                 },
                 api_token: "test-token"
               }}
@@ -105,7 +105,7 @@ defmodule Guard.ServiceAccount.ActionsTest do
              assert user_id == "user-id"
 
              assert email ==
-                      "test@service_accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
+                      "test@service-accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
 
              assert name == "Test SA"
              :ok
@@ -124,7 +124,7 @@ defmodule Guard.ServiceAccount.ActionsTest do
         assert_called(
           Guard.Store.RbacUser.create(
             "user-id",
-            "test@service_accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}",
+            "test@service-accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}",
             "Test SA",
             "service_account"
           )
@@ -366,7 +366,8 @@ defmodule Guard.ServiceAccount.ActionsTest do
   describe "integration tests" do
     defp setup_integration_mocks do
       [
-        {Guard.Api.Organization, [:passthrough], [fetch: fn _ -> %{username: "test-org"} end]},
+        {Guard.Api.Organization, [:passthrough],
+         [fetch: fn _ -> %InternalApi.Organization.Organization{org_username: "test-org"} end]},
         {Guard.FrontRepo.User, [:passthrough],
          [reset_auth_token: fn _ -> {:ok, "test-token"} end]},
         {Guard.Store.RbacUser, [:passthrough],
@@ -398,7 +399,7 @@ defmodule Guard.ServiceAccount.ActionsTest do
 
         assert String.contains?(
                  service_account.email,
-                 "@service_accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
+                 "@service-accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
                )
 
         # Verify event was published

--- a/guard/test/guard/store/service_account_test.exs
+++ b/guard/test/guard/store/service_account_test.exs
@@ -205,7 +205,8 @@ defmodule Guard.Store.ServiceAccountTest do
   describe "create/1" do
     test "creates service account successfully" do
       with_mocks([
-        {Guard.Api.Organization, [:passthrough], [fetch: fn _ -> %{username: "test-org"} end]},
+        {Guard.Api.Organization, [:passthrough],
+         [fetch: fn _ -> %InternalApi.Organization.Organization{org_username: "test-org"} end]},
         {Guard.FrontRepo.User, [:passthrough],
          [reset_auth_token: fn _ -> {:ok, "plain-token"} end]}
       ]) do
@@ -222,14 +223,15 @@ defmodule Guard.Store.ServiceAccountTest do
 
         assert String.contains?(
                  result.service_account.email,
-                 "@service_accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
+                 "@service-accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
                )
       end
     end
 
     test "creates user with correct service account fields" do
       with_mocks([
-        {Guard.Api.Organization, [:passthrough], [fetch: fn _ -> %{username: "test-org"} end]},
+        {Guard.Api.Organization, [:passthrough],
+         [fetch: fn _ -> %InternalApi.Organization.Organization{org_username: "test-org"} end]},
         {Guard.FrontRepo.User, [:passthrough],
          [reset_auth_token: fn _ -> {:ok, "plain-token"} end]}
       ]) do
@@ -253,7 +255,8 @@ defmodule Guard.Store.ServiceAccountTest do
 
     test "generates synthetic email correctly" do
       with_mocks([
-        {Guard.Api.Organization, [:passthrough], [fetch: fn _ -> %{username: "MyOrg-123"} end]},
+        {Guard.Api.Organization, [:passthrough],
+         [fetch: fn _ -> %InternalApi.Organization.Organization{org_username: "MyOrg-123"} end]},
         {Guard.FrontRepo.User, [:passthrough],
          [reset_auth_token: fn _ -> {:ok, "plain-token"} end]}
       ]) do
@@ -261,9 +264,9 @@ defmodule Guard.Store.ServiceAccountTest do
 
         {:ok, result} = ServiceAccount.create(params)
 
-        # Should sanitize both name and org username
+        # Should sanitize both name and org org_username
         assert result.service_account.email ==
-                 "my-service-account-@service_accounts.myorg-123.#{Application.fetch_env!(:guard, :base_domain)}"
+                 "my-service-account-@service-accounts.myorg-123.#{Application.fetch_env!(:guard, :base_domain)}"
       end
     end
 
@@ -280,7 +283,7 @@ defmodule Guard.Store.ServiceAccountTest do
         # Should use fallback email
         assert String.contains?(
                  result.service_account.email,
-                 "@service_accounts.unknown.#{Application.fetch_env!(:guard, :base_domain)}"
+                 "@service-accounts.unknown.#{Application.fetch_env!(:guard, :base_domain)}"
                )
       end
     end
@@ -298,7 +301,8 @@ defmodule Guard.Store.ServiceAccountTest do
 
     test "handles user creation validation errors" do
       with_mocks([
-        {Guard.Api.Organization, [:passthrough], [fetch: fn _ -> %{username: "test-org"} end]},
+        {Guard.Api.Organization, [:passthrough],
+         [fetch: fn _ -> %InternalApi.Organization.Organization{org_username: "test-org"} end]},
         {Guard.FrontRepo.User, [:passthrough],
          [reset_auth_token: fn _ -> {:ok, "plain-token"} end]}
       ]) do
@@ -326,7 +330,8 @@ defmodule Guard.Store.ServiceAccountTest do
     end
 
     test "updates synthetic email when name changes" do
-      with_mock Guard.Api.Organization, [:passthrough], fetch: fn _ -> %{username: "test-org"} end do
+      with_mock Guard.Api.Organization, [:passthrough],
+        fetch: fn _ -> %InternalApi.Organization.Organization{org_username: "test-org"} end do
         {:ok, %{service_account: sa}} = ServiceAccountFactory.insert()
 
         update_params = %{name: "New Name"}
@@ -337,7 +342,7 @@ defmodule Guard.Store.ServiceAccountTest do
 
         assert String.contains?(
                  updated_sa.user.email,
-                 "new-name@service_accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
+                 "new-name@service-accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
                )
       end
     end

--- a/guard/test/guard/user/actions_test.exs
+++ b/guard/test/guard/user/actions_test.exs
@@ -134,7 +134,7 @@ defmodule Guard.User.ActionsTest do
     test "should not allow creating regular user with service account email pattern" do
       with_mock Guard.Events.UserCreated, publish: fn _, _ -> :ok end do
         base_domain = Application.fetch_env!(:guard, :base_domain)
-        service_email = "test@service_accounts.org.#{base_domain}"
+        service_email = "test@service-accounts.org.#{base_domain}"
 
         user_params = %{
           email: service_email,
@@ -164,7 +164,7 @@ defmodule Guard.User.ActionsTest do
         assert updated_user.name == "Updated SA Name"
         assert updated_user.creation_source == :service_account
         assert updated_user.single_org_user == true
-        assert String.contains?(updated_user.email, "@service_accounts.")
+        assert String.contains?(updated_user.email, "@service-accounts.")
       end
     end
 

--- a/guard/test/support/factories/service_account_factory.ex
+++ b/guard/test/support/factories/service_account_factory.ex
@@ -109,7 +109,7 @@ defmodule Support.Factories.ServiceAccountFactory do
 
   defp generate_synthetic_email(name, _org_id) do
     sanitized_name = String.downcase(name) |> String.replace(~r/[^a-z0-9\-]/, "-")
-    "#{sanitized_name}@service_accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
+    "#{sanitized_name}@service-accounts.test-org.#{Application.fetch_env!(:guard, :base_domain)}"
   end
 
   defp get_role_id(nil), do: UUID.generate()


### PR DESCRIPTION
## 📝 Description
There's a problem in `guard` service causing service account email addresses to be generated improperly: test-sas@service-accounts.unknown.semaphoreci.com instead of picking the organization username, the default `unknown` name is selected. Because of this, creating a service account with a name that was already used by a different organization - fails. 

In addition, we're renaming part of the service account email suffix from `service_accounts` to `service-accounts`. 

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
