### PR TITLE
fix(zebra): workflow editor job not working because of forked_pr evaluation

### DIFF
--- a/zebra/lib/zebra/workers/job_request_factory/cache.ex
+++ b/zebra/lib/zebra/workers/job_request_factory/cache.ex
@@ -94,6 +94,7 @@ defmodule Zebra.Workers.JobRequestFactory.Cache do
   end
 
   defp forked_pr?(_repo = %{pr_slug: ""}), do: false
+  defp forked_pr?(nil), do: false
 
   defp forked_pr?(repo) do
     [pr_repo | _rest] = repo.pr_slug |> String.split("/")


### PR DESCRIPTION
## 📝 Description
Job for fetching yaml files for workflow editor was stuck in queueing state as `repo_proxy` is `nil`, broken in this PR: https://github.com/semaphoreio/semaphore/pull/480
 
Change was tested on preprod env

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
