### PR TITLE
feat(auth): block connection in case of invalid request ip

### DIFF
--- a/auth/test/auth/ip_filter_test.exs
+++ b/auth/test/auth/ip_filter_test.exs
@@ -44,11 +44,35 @@ defmodule Auth.IpFilterTest do
              })
     end
 
-    test "single bad CIDR => returns false" do
-      refute Auth.IpFilter.block?({172, 14, 101, 99}, %{
+    test "single bad CIDR => returns true" do
+      assert Auth.IpFilter.block?({172, 14, 101, 99}, %{
                id: @org_id,
                name: "semaphore",
                ip_allow_list: ["32.109.221.12/999"]
+             })
+    end
+
+    test "single bad CIDR but allow list is empty => returns false" do
+      refute Auth.IpFilter.block?({172, 14, 101, 99}, %{
+               id: @org_id,
+               name: "semaphore",
+               ip_allow_list: []
+             })
+    end
+
+    test "nil value instead of CIDR => returns true" do
+      assert Auth.IpFilter.block?(nil, %{
+               id: @org_id,
+               name: "semaphore",
+               ip_allow_list: ["32.109.221.12/999"]
+             })
+    end
+
+    test "nil value instead of CIDR but allow list is empty => returns false" do
+      refute Auth.IpFilter.block?(nil, %{
+               id: @org_id,
+               name: "semaphore",
+               ip_allow_list: []
              })
     end
 


### PR DESCRIPTION
## 📝 Description

To strengthen the security of the application, we are going to block connections when we are not able to detect the remote IP, and the organization is using an allow IP list.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~
