### PR TITLE
chore(docs): Configure CODEOWNERS for docs directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 /bootstrapper/ @VeljkoMaksimovic @lucaspin @forestileao
 /branch_hub/ @skipi @lucaspin @forestileao
 /dashboardhub/ @hamir-suspect @skipi @forestileao
+/docs/ @TomFern @skipi @hamir-suspect @dexyk @VeljkoMaksimovic @DamjanBecirovic 
 /ee/audit/ @hamir-suspect @dexyk @lucaspin
 /ee/gofer/ @DamjanBecirovic @dexyk @lucaspin
 /ee/pre_flight_checks/ @DamjanBecirovic @VeljkoMaksimovic @skipi


### PR DESCRIPTION
## 📝 Description

Configure CODEOWNERS for the docs directory so the PRs can be merged more easily.

## ✅ Checklist
- ~[x] I have tested this change~
- ~[x] This change requires documentation update~
