### PR TITLE
feat(secrethub): Add compact subject to OpenID JWT claims

### DIFF
--- a/secrethub/lib/secrethub/open_id_connect/jwt.ex
+++ b/secrethub/lib/secrethub/open_id_connect/jwt.ex
@@ -8,6 +8,8 @@ defmodule Secrethub.OpenIDConnect.JWT do
     "jti",
     # Subject of the JWT
     "sub",
+    # Compact subject format with comma-separated values only
+    "sub2",
     # Recipient for which the JWT is intended
     "aud",
     # Issuer of the JWT
@@ -114,6 +116,7 @@ defmodule Secrethub.OpenIDConnect.JWT do
       "branch" => req.git_branch_name,
       "pr" => req.git_pull_request_number,
       "sub" => req.subject,
+      "sub2" => build_compact_subject(req),
       "iss" => "https://#{req.org_username}.#{domain}",
       "aud" => "https://#{req.org_username}.#{domain}",
       "job_type" => req.job_type,
@@ -153,4 +156,20 @@ defmodule Secrethub.OpenIDConnect.JWT do
 
     Secrethub.OpenIDConnect.JWTFilter.filter_claims(claims, req.org_id, req.project_id)
   end
+
+  defp build_compact_subject(req) do
+    [
+      req.org_username,
+      req.project_id,
+      req.repository_name,
+      req.git_ref_type,
+      req.git_ref
+    ]
+    |> Enum.map(&safe_string/1)
+    |> Enum.join(",")
+  end
+
+  defp safe_string(nil), do: ""
+  defp safe_string(value) when is_binary(value), do: value
+  defp safe_string(value), do: to_string(value)
 end

--- a/secrethub/lib/secrethub/open_id_connect/jwt_claim.ex
+++ b/secrethub/lib/secrethub/open_id_connect/jwt_claim.ex
@@ -113,6 +113,15 @@ defmodule Secrethub.OpenIDConnect.JWTClaim do
         is_mandatory: false,
         is_active: true
       },
+      "sub2" => %__MODULE__{
+        name: "sub2",
+        description:
+          "Compact subject (check sub) format with comma-separated values only (org,project_id,repo,ref_type,ref)",
+        is_system_claim: true,
+        is_aws_tag: false,
+        is_mandatory: false,
+        is_active: true
+      },
       "org_id" => %__MODULE__{
         name: "org_id",
         description: "Organization ID",

--- a/secrethub/test/secrethub/internal_grpc_api_test.exs
+++ b/secrethub/test/secrethub/internal_grpc_api_test.exs
@@ -835,6 +835,11 @@ defmodule Secrethub.InternalGrpcApi.Test do
       assert Map.get(jwt.fields, "aud") == "https://testera.localhost"
       assert Map.get(jwt.fields, "iss") == "https://testera.localhost"
       assert Map.get(jwt.fields, "sub") == "project:front:pipeline:semaphore.yml"
+      
+      # Verify sub2 is present and formatted correctly (compact format with comma-separated values)
+      expected_sub2 = "testera,#{req.project_id},,,"  # org_username, project_id, empty repo, empty ref_type, empty ref
+      assert Map.get(jwt.fields, "sub2") == expected_sub2
+      
       assert Map.get(jwt.fields, "prj") == req.project_name
       assert Map.get(jwt.fields, "org") == req.org_username
       refute Map.has_key?(jwt.fields, "https://aws.amazon.com/tags")
@@ -908,6 +913,10 @@ defmodule Secrethub.InternalGrpcApi.Test do
       assert Map.get(jwt.fields, "aud") == "https://testera.localhost"
       assert Map.get(jwt.fields, "iss") == "https://testera.localhost"
       assert Map.get(jwt.fields, "sub") == "project:front:pipeline:semaphore.yml"
+      
+      # Verify sub2 is present and formatted correctly for AWS tags test
+      expected_sub2 = "testera,#{req.project_id},my-repo,branch,"  # org, project_id, repo, ref_type, empty ref
+      assert Map.get(jwt.fields, "sub2") == expected_sub2
     end
 
     test "it returns a signed token with filtered claims in on_prem mode" do

--- a/secrethub/test/secrethub/open_id_connect/jwt_claim_test.exs
+++ b/secrethub/test/secrethub/open_id_connect/jwt_claim_test.exs
@@ -62,7 +62,7 @@ defmodule Secrethub.OpenIDConnect.JWTClaimTest do
       claims = JWTClaim.optional_claims()
 
       # Check for presence of some workflow-specific claims
-      workflow_claims = ~w(prj_id wf_id ppl_id job_id repo branch)
+      workflow_claims = ~w(prj_id wf_id ppl_id job_id repo branch sub sub2)
 
       for claim <- workflow_claims do
         assert Map.has_key?(claims, claim)
@@ -70,6 +70,20 @@ defmodule Secrethub.OpenIDConnect.JWTClaimTest do
         refute claim_struct.is_mandatory
         assert claim_struct.is_system_claim
       end
+    end
+
+    test "optional_claims includes sub2 compact subject claim" do
+      claims = JWTClaim.optional_claims()
+
+      assert Map.has_key?(claims, "sub2")
+      sub2_claim = Map.get(claims, "sub2")
+      
+      assert sub2_claim.name == "sub2"
+      assert String.contains?(sub2_claim.description, "comma-separated")
+      refute sub2_claim.is_mandatory
+      assert sub2_claim.is_system_claim
+      refute sub2_claim.is_aws_tag
+      assert sub2_claim.is_active
     end
 
     test "optional_claims includes AWS tag claims" do


### PR DESCRIPTION
## 📝 Description
Adds a compact and a bit shorter subject since it's easy to reach:
> The size of mapped attribute google.subject exceeds the 127 bytes limit. Either modify your attribute mapping or the incoming assertion to produce a mapped attribute that is less than 127 bytes.

error on gcp with existing `sub`. Adding it as sub2 to maintain compatibility of existing integrations.

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
