### PR TITLE
feat(plumber): populate SEMAPHORE_PIPELINE_NAME env. var.

### DIFF
--- a/docs/docs/reference/env-vars.md
+++ b/docs/docs/reference/env-vars.md
@@ -146,6 +146,13 @@ The URL for the organization that owns the project running the current job.
 
 The unique identifier for the current workflow. All jobs that belong to the same pipeline share the same ID.
 
+### Pipeline name {#pipeline-name}
+
+- **Environment variable**: `SEMAPHORE_PIPELINE_NAME`
+- **Example**: `my-pipeline`
+
+The name of the pipeline.
+
 ### Pipeline is promotion {#pipeline-promotion}
 
 - **Environment variable**: `SEMAPHORE_PIPELINE_PROMOTION`

--- a/plumber/ppl/docker-compose.yml
+++ b/plumber/ppl/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     tty: true
     volumes:
       - .:/app:delegated
+      - elixir_deps:/app/deps
+      - elixir_build:/app/_build
 
   db:
     image: "postgres:9.6"
@@ -121,3 +123,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
+
+volumes:
+  elixir_deps:
+  elixir_build:

--- a/plumber/ppl/lib/ppl/definition_reviser/blocks_reviser.ex
+++ b/plumber/ppl/lib/ppl/definition_reviser/blocks_reviser.ex
@@ -11,6 +11,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
 
   @ppl_artefact_id_env_var_name "SEMAPHORE_PIPELINE_ARTEFACT_ID"
   @ppl_id_env_var_name "SEMAPHORE_PIPELINE_ID"
+  @ppl_name_env_var_name "SEMAPHORE_PIPELINE_NAME"
   @pipeline_rerun "SEMAPHORE_PIPELINE_RERUN"
   @block_name "SEMAPHORE_BLOCK_NAME"
   @pipeline_promotion "SEMAPHORE_PIPELINE_PROMOTION"
@@ -92,7 +93,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
     with {:ok, block_def}  <- set_agent(block_def, ppl_def),
          {:ok, ppl_def}    <- global_config_cmd_file_to_cmds(ppl_def, ppl_req.request_args),
          {:ok, block_def}  <- merge_with_global_job_config(block_def, ppl_def),
-         {:ok, block_def}  <- set_ppl_env_vars(block_def, ppl_req)
+         {:ok, block_def}  <- set_ppl_env_vars(block_def, ppl_def, ppl_req)
     do
       blocks ++ [block_def] |> ToTuple.ok()
     else
@@ -103,7 +104,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
   defp set_additional_after_ppl_fields(error = {:error, _e}, _, _, _), do: error
   defp set_additional_after_ppl_fields({:ok, blocks}, block_def, ppl_def, ppl_req) do
     with {:ok, block_def}  <- set_agent(block_def, ppl_def),
-         {:ok, block_def}  <- set_ppl_env_vars(block_def, ppl_req)
+         {:ok, block_def}  <- set_ppl_env_vars(block_def, ppl_def, ppl_req)
     do
       blocks ++ [block_def] |> ToTuple.ok()
     else
@@ -111,11 +112,11 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
     end
   end
 
-  def set_ppl_env_vars(block_def, ppl_req) do
+  def set_ppl_env_vars(block_def, ppl_def, ppl_req) do
     with {:ok, ppl}        <- PplsQueries.get_by_id(ppl_req.id),
          {:ok, promoter}   <- promoted_by?(ppl_req.request_args),
          {:ok, triggerer}  <- triggered_by?(ppl_req),
-    do: set_ppl_env_vars_(block_def, ppl_req, ppl, promoter, triggerer)
+    do: set_ppl_env_vars_(block_def, ppl_def, ppl_req, ppl, promoter, triggerer)
   end
 
   defp promoted_by?(%{"auto_promoted" => true}), do: {:ok, "auto-promotion"}
@@ -233,10 +234,10 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
   defp merge_vals(global_vals, block_vals, :global_first), do: global_vals ++ block_vals
   defp merge_vals(global_vals, block_vals, :block_first), do: block_vals ++ global_vals
 
-  defp set_ppl_env_vars_(block_def, ppl_req, ppl, promoter, triggerer) do
+  defp set_ppl_env_vars_(block_def, ppl_def, ppl_req, ppl, promoter, triggerer) do
     ppl_env_vars =
       ppl_req
-      |> basic_env_vars(ppl, promoter, triggerer, block_def)
+      |> basic_env_vars(ppl_def, ppl, promoter, triggerer, block_def)
       |> env_vars_from_prev_ppl_artefact_ids(ppl_req.prev_ppl_artefact_ids ++ [ppl_req.ppl_artefact_id])
       |> Enum.concat(Map.get(ppl_req.request_args, "env_vars", []))
 
@@ -255,7 +256,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
     list ++ prev_ids_env_vars
   end
 
-  defp basic_env_vars(ppl_req, ppl, promoter, triggerer, block_def) do
+  defp basic_env_vars(ppl_req, ppl_def, ppl, promoter, triggerer, block_def) do
     snapshot_id = get_snapshot_id(ppl_req.request_args)
     block_name = get_block_name(block_def)
 
@@ -270,6 +271,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser do
      %{"name" => @workflow_triggered_by_manual_run, "value" => manual_run?(ppl_req.request_args)},
      %{"name" => @ppl_artefact_id_env_var_name, "value" => "#{ppl_req.ppl_artefact_id}"},
      %{"name" => @ppl_id_env_var_name, "value" => "#{ppl_req.id}"},
+     %{"name" => @ppl_name_env_var_name, "value" => "#{ppl_def["name"]}"},
      %{"name" => @block_name, "value" => block_name},
      %{"name" => @pipeline_rerun, "value" => ppl_rerun?(ppl.partial_rebuild_of)},
      %{"name" => @pipeline_promotion, "value" => promotion?(ppl.extension_of)},

--- a/plumber/ppl/lib/ppl/ppl_sub_inits/stm_handler/compilation/definition.ex
+++ b/plumber/ppl/lib/ppl/ppl_sub_inits/stm_handler/compilation/definition.ex
@@ -160,7 +160,7 @@ defmodule Ppl.PplSubInits.STMHandler.Compilation.Definition do
 
   defp ppl_env_vars(ppl_req) do
     %{"build" => %{}}
-    |> BlocksReviser.set_ppl_env_vars(ppl_req)
+    |> BlocksReviser.set_ppl_env_vars(%{"name" => ""}, ppl_req)
     |> extract_ppl_env_vars()
   end
 

--- a/plumber/ppl/test/definition_reviser/blocks_reviser_test.exs
+++ b/plumber/ppl/test/definition_reviser/blocks_reviser_test.exs
@@ -27,7 +27,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
 
     agent = %{"machine" => %{"type" => "e1-standard-2", "os_image" => "ubuntu1804"}}
     blocks = [%{"build" => %{}, "name" => "blk 0"}, %{"build" => %{}, "name" => "blk 1"}]
-    ppl_def = %{"agent" => agent, "blocks" => blocks}
+    ppl_def = %{"agent" => agent, "blocks" => blocks, "name" => "Test Pipeline"}
     args = %{"service" => "local", "repo_name" => "4_cmd_file", "branch_name" => "master",
             "commit_sha" => "sha_1", "working_dir" => ".semaphore", "file_name" => "semaphore.yml"}
     source_args = %{"repo_host_username" => "gh_username_1", "commit_author" => "gh_username_2"}
@@ -37,6 +37,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
   end
 
   @ppl_id_env_var_name "SEMAPHORE_PIPELINE_ID"
+  @ppl_name_env_var_name "SEMAPHORE_PIPELINE_NAME"
   @artefact_id_env_var_name "SEMAPHORE_PIPELINE_ARTEFACT_ID"
   @block_name "SEMAPHORE_BLOCK_NAME"
   @pipeline_rerun "SEMAPHORE_PIPELINE_RERUN"
@@ -88,6 +89,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
         %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
         %{"name" => @artefact_id_env_var_name, "value" => "A1"},
         %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
+        %{"name" => @ppl_name_env_var_name, "value" => ctx.ppl_def["name"]},
         %{"name" => @block_name, "value" => block["name"]},
         %{"name" => @pipeline_rerun, "value" => "false"},
         %{"name" => @pipeline_promotion, "value" => "false"},
@@ -121,6 +123,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
         %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
         %{"name" => @artefact_id_env_var_name, "value" => "A1"},
         %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
+        %{"name" => @ppl_name_env_var_name, "value" => ctx.ppl_def["name"]},
         %{"name" => @block_name, "value" => block["name"]},
         %{"name" => @pipeline_rerun, "value" => "false"},
         %{"name" => @pipeline_promotion, "value" => "false"},
@@ -152,6 +155,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
         %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
         %{"name" => @artefact_id_env_var_name, "value" => "A1"},
         %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
+        %{"name" => @ppl_name_env_var_name, "value" => ctx.ppl_def["name"]},
         %{"name" => @block_name, "value" => block["name"]},
         %{"name" => @pipeline_rerun, "value" => "false"},
         %{"name" => @pipeline_promotion, "value" => "false"},
@@ -215,6 +219,7 @@ defmodule Ppl.DefinitionReviser.BlocksReviser.Test do
         %{"name" => @workflow_triggered_by_manual_run, "value" => "false"},
         %{"name" => @artefact_id_env_var_name, "value" => "A1"},
         %{"name" => @ppl_id_env_var_name, "value" => ctx.ppl_req.id},
+        %{"name" => @ppl_name_env_var_name, "value" => ctx.ppl_def["name"]},
         %{"name" => @block_name, "value" => block["name"]},
         %{"name" => @pipeline_rerun, "value" => "false"},
         %{"name" => @pipeline_promotion, "value" => "false"},

--- a/plumber/ppl/test/ppl_blocks/stm_handler/run_test.exs
+++ b/plumber/ppl/test/ppl_blocks/stm_handler/run_test.exs
@@ -27,7 +27,7 @@ defmodule Ppl.PplBlocks.STMHandler.WaitingState.Test do
     jobs_list = [job_1, job_2]
     task = %{"jobs" => jobs_list}
     agent = %{"machine" => %{"type" => "foo", "os_image" => "bar"}}
-    definition = %{"version" => "v1.0", "agent" => agent,
+    definition = %{"version" => "v1.0", "agent" => agent, "name" => "Test Pipeline",
       "blocks" => [%{"name" => "blk 0", "task" => task},
         %{"name" => "blk 1", "task" => task}]}
 
@@ -135,6 +135,7 @@ defmodule Ppl.PplBlocks.STMHandler.WaitingState.Test do
                     %{"name" => "SEMAPHORE_WORKFLOW_TRIGGERED_BY_MANUAL_RUN", "value" => "false"},
                     %{"name" => "SEMAPHORE_PIPELINE_ARTEFACT_ID", "value" => "#{id}"},
                     %{"name" => "SEMAPHORE_PIPELINE_ID", "value" => "#{id}"},
+                    %{"name" => "SEMAPHORE_PIPELINE_NAME", "value" => "Test Pipeline"},
                     %{"name" => "SEMAPHORE_BLOCK_NAME", "value" => blk_name},
                     %{"name" => "SEMAPHORE_PIPELINE_RERUN", "value" => "false"},
                     %{"name" => "SEMAPHORE_PIPELINE_PROMOTION", "value" => "false"},

--- a/plumber/ppl/test/ppl_sub_inits/stm_handler/compilation/definition_test.exs
+++ b/plumber/ppl/test/ppl_sub_inits/stm_handler/compilation/definition_test.exs
@@ -526,7 +526,7 @@ defmodule Ppl.PplSubInits.STMHandler.Compilation.Definition.Test do
     assert {:ok, definition} = Definition.form_definition(ppl_req, :undefined, settings, :prod)
     assert list = Map.get(definition, "jobs") |> Enum.at(0) |> Map.get("env_vars")
     assert is_list(list)
-    assert Enum.count(list) == 19
+    assert Enum.count(list) == 20
 
     yml_path_ev = Enum.find(list, fn map -> map["name"] == "SEMAPHORE_YAML_FILE_PATH" end)
     assert yml_path_ev["value"] == ".semaphore/semaphore.yml"


### PR DESCRIPTION
## 📝 Description

This change introduces the `SEMAPHORE_PIPELINE_NAME` environment variable to CI jobs. It is automatically populated with the name of the pipeline.

More in [this task](https://github.com/renderedtext/tasks/issues/8564).

## ✅ Checklist
- [x] I have tested this change
- [x] This change requires documentation update
