### PR TITLE
fix(repository_hub): don't parse JSON when removing webhook

### DIFF
--- a/repository_hub/lib/repository_hub/clients/github_client.ex
+++ b/repository_hub/lib/repository_hub/clients/github_client.ex
@@ -32,6 +32,8 @@ defmodule RepositoryHub.GithubClient do
   @err_not_found "Repository not found. If this is a private repository, it looks like you haven't authorized Semaphore with GitHub, please visit https://docs.semaphoreci.com/using-semaphore/connect-github#troubleshooting-guide to read more."
   @err_not_authorized "It looks like you haven't authorized Semaphore with GitHub, please visit https://docs.semaphoreci.com/using-semaphore/connect-github#troubleshooting-guide to read more."
 
+  @api_url "https://api.github.com"
+
   def repository_permissions(params, opts \\ []) do
     owner = params.repo_owner
     repo = params.repo_name
@@ -641,33 +643,28 @@ defmodule RepositoryHub.GithubClient do
   end
 
   @impl true
+  # https://docs.github.com/en/rest/repos/webhooks?apiVersion=2022-11-28#delete-a-repository-webhook
   def remove_webhook(params, opts \\ []) do
-    with_client(opts[:token], params.repo_owner, :remove_webhook, fn client ->
-      client
-      |> Tentacat.Hooks.remove(
-        params.repo_owner,
-        params.repo_name,
-        params.webhook_id
-      )
-      |> case do
-        {204, _, _} ->
-          wrap(:ok)
+    "#{@api_url}/repos/#{params.repo_owner}/#{params.repo_name}/hooks/#{params.webhook_id}"
+    |> http_delete(opts[:token])
+    |> unwrap(fn response ->
+      {response.status_code, response.body, response.headers, response.request_url}
+    end)
+    |> unwrap(fn
+      {204, _, _, _} ->
+        wrap(:ok)
 
-        {307, _, response} ->
-          fail_with(:precondition, "Removing webhook failed. #{fetch_status_message(response)}")
+      {404, _, _, _} ->
+        wrap(:ok)
 
-        {404, _, _} ->
-          wrap(:ok)
+      {status, encoded_body, _, _} ->
+        log_error([
+          "removing webhook #{params.repo_owner}/#{params.repo_name}",
+          "status: #{status}",
+          "response: #{inspect(encoded_body)}"
+        ])
 
-        {status, _, resp} ->
-          log_error([
-            "removing webhook #{params.repo_owner}/#{params.repo_name}",
-            "status: #{status}",
-            "response: #{inspect_response(resp)}"
-          ])
-
-          fail_with(:precondition, "Removing webhook failed.")
-      end
+        fail_with(:precondition, "Removing webhook failed.")
     end)
   end
 
@@ -939,6 +936,25 @@ defmodule RepositoryHub.GithubClient do
       end)
 
     inspect(%{response | request: %{response.request | headers: request_headers}})
+  end
+
+  defp http_delete(resource, token) do
+    resource
+    |> HTTPoison.delete(request_headers(token), options())
+  end
+
+  defp options(opts \\ []) do
+    [recv_timeout: 25_000]
+    |> Keyword.merge(opts)
+  end
+
+  defp request_headers(token) do
+    [
+      {"Content-Type", "application/json"},
+      {"Accept", "application/vnd.github+json"},
+      {"X-GitHub-Api-Version", "2022-11-28"},
+      {"Authorization", "Bearer #{token}"}
+    ]
   end
 
   defmodule Webhook do


### PR DESCRIPTION
## 📝 Description
Since this morning(12.09.2025), GitHub's webhook deletion API has started returning malformed responses. The response body now incorrectly includes HTTP headers along with the JSON content, causing our JSON parser to throw exceptions and fail the entire project creation process.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
