### PR TITLE
feat(periodic_scheduler): support generic git ref

### DIFF
--- a/periodic_scheduler/scheduler/config/dev.exs
+++ b/periodic_scheduler/scheduler/config/dev.exs
@@ -21,3 +21,6 @@ config :watchman,
   host: "localhost",
   port: 8125,
   prefix: "periodic-sch.dev"
+
+config :scheduler,
+  feature_provider: {Scheduler.FeatureHubProvider, []}

--- a/periodic_scheduler/scheduler/docker-compose.yml
+++ b/periodic_scheduler/scheduler/docker-compose.yml
@@ -25,8 +25,8 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - .:/app:delegated
-    working_dir: "/app"
+      - ../:/app:delegated
+    working_dir: "/app/scheduler"
 
   ciapp:
     container_name: ciapp
@@ -74,6 +74,16 @@ services:
       interval: 3s
       timeout: 3s
       retries: 5
+  
+  pgweb:
+    image: sosedoff/pgweb
+    ports:
+      - 8081:8081
+    profiles: ["dev", "ci"]
+    environment:
+      - PGWEB_DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
+    depends_on:
+      - postgres
 
   rabbitmq:
     container_name: rabbitmq

--- a/periodic_scheduler/scheduler/docker-compose.yml
+++ b/periodic_scheduler/scheduler/docker-compose.yml
@@ -74,16 +74,6 @@ services:
       interval: 3s
       timeout: 3s
       retries: 5
-  
-  pgweb:
-    image: sosedoff/pgweb
-    ports:
-      - 8081:8081
-    profiles: ["dev", "ci"]
-    environment:
-      - PGWEB_DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
-    depends_on:
-      - postgres
 
   rabbitmq:
     container_name: rabbitmq

--- a/periodic_scheduler/scheduler/lib/internal_api/organization.pb.ex
+++ b/periodic_scheduler/scheduler/lib/internal_api/organization.pb.ex
@@ -24,20 +24,6 @@ defmodule InternalApi.Organization.Member.Role do
   field :ADMIN, 2
 end
 
-defmodule InternalApi.Organization.Quota.Type do
-  @moduledoc false
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  field :MAX_PEOPLE_IN_ORG, 0
-  field :MAX_PARALELLISM_IN_ORG, 1
-  field :MAX_PROJECTS_IN_ORG, 7
-  field :MAX_PARALLEL_E1_STANDARD_2, 2
-  field :MAX_PARALLEL_E1_STANDARD_4, 3
-  field :MAX_PARALLEL_E1_STANDARD_8, 4
-  field :MAX_PARALLEL_A1_STANDARD_4, 5
-  field :MAX_PARALLEL_A1_STANDARD_8, 6
-end
-
 defmodule InternalApi.Organization.OrganizationContact.ContactType do
   @moduledoc false
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
@@ -55,6 +41,7 @@ defmodule InternalApi.Organization.DescribeRequest do
   field :org_id, 1, type: :string, json_name: "orgId"
   field :org_username, 2, type: :string, json_name: "orgUsername"
   field :include_quotas, 3, type: :bool, json_name: "includeQuotas"
+  field :soft_deleted, 4, type: :bool, json_name: "softDeleted"
 end
 
 defmodule InternalApi.Organization.DescribeResponse do
@@ -70,6 +57,7 @@ defmodule InternalApi.Organization.DescribeManyRequest do
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
 
   field :org_ids, 1, repeated: true, type: :string, json_name: "orgIds"
+  field :soft_deleted, 2, type: :bool, json_name: "softDeleted"
 end
 
 defmodule InternalApi.Organization.DescribeManyResponse do
@@ -88,6 +76,7 @@ defmodule InternalApi.Organization.ListRequest do
   field :order, 4, type: InternalApi.Organization.ListRequest.Order, enum: true
   field :page_size, 5, type: :int32, json_name: "pageSize"
   field :page_token, 6, type: :string, json_name: "pageToken"
+  field :soft_deleted, 7, type: :bool, json_name: "softDeleted"
 end
 
 defmodule InternalApi.Organization.ListResponse do
@@ -114,21 +103,6 @@ defmodule InternalApi.Organization.CreateResponse do
 
   field :status, 1, type: InternalApi.ResponseStatus
   field :organization, 2, type: InternalApi.Organization.Organization
-end
-
-defmodule InternalApi.Organization.CreateWithQuotasRequest do
-  @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  field :organization, 1, type: InternalApi.Organization.Organization
-  field :quotas, 2, repeated: true, type: InternalApi.Organization.Quota
-end
-
-defmodule InternalApi.Organization.CreateWithQuotasResponse do
-  @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  field :organization, 1, type: InternalApi.Organization.Organization
 end
 
 defmodule InternalApi.Organization.UpdateRequest do
@@ -357,6 +331,13 @@ defmodule InternalApi.Organization.DestroyRequest do
   field :org_id, 1, type: :string, json_name: "orgId"
 end
 
+defmodule InternalApi.Organization.RestoreRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :org_id, 1, type: :string, json_name: "orgId"
+end
+
 defmodule InternalApi.Organization.Organization do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
@@ -375,7 +356,6 @@ defmodule InternalApi.Organization.Organization do
   field :allowed_id_providers, 13, repeated: true, type: :string, json_name: "allowedIdProviders"
   field :deny_member_workflows, 14, type: :bool, json_name: "denyMemberWorkflows"
   field :deny_non_member_workflows, 15, type: :bool, json_name: "denyNonMemberWorkflows"
-  field :quotas, 8, repeated: true, type: InternalApi.Organization.Quota
   field :settings, 16, repeated: true, type: InternalApi.Organization.OrganizationSetting
 end
 
@@ -403,50 +383,12 @@ defmodule InternalApi.Organization.Member do
   field :github_uid, 8, type: :string, json_name: "githubUid"
 end
 
-defmodule InternalApi.Organization.Quota do
-  @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  field :type, 1, type: InternalApi.Organization.Quota.Type, enum: true
-  field :value, 2, type: :uint32
-end
-
 defmodule InternalApi.Organization.OrganizationSetting do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
 
   field :key, 1, type: :string
   field :value, 2, type: :string
-end
-
-defmodule InternalApi.Organization.GetQuotasRequest do
-  @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  field :org_id, 1, type: :string, json_name: "orgId"
-  field :types, 2, repeated: true, type: InternalApi.Organization.Quota.Type, enum: true
-end
-
-defmodule InternalApi.Organization.GetQuotaResponse do
-  @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  field :quotas, 1, repeated: true, type: InternalApi.Organization.Quota
-end
-
-defmodule InternalApi.Organization.UpdateQuotasRequest do
-  @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  field :org_id, 1, type: :string, json_name: "orgId"
-  field :quotas, 2, repeated: true, type: InternalApi.Organization.Quota
-end
-
-defmodule InternalApi.Organization.UpdateQuotasResponse do
-  @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  field :quotas, 1, repeated: true, type: InternalApi.Organization.Quota
 end
 
 defmodule InternalApi.Organization.RepositoryIntegratorsRequest do
@@ -620,6 +562,14 @@ defmodule InternalApi.Organization.OrganizationDailyUpdate do
   field :timestamp, 11, type: Google.Protobuf.Timestamp
 end
 
+defmodule InternalApi.Organization.OrganizationRestored do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :org_id, 1, type: :string, json_name: "orgId"
+  field :timestamp, 2, type: Google.Protobuf.Timestamp
+end
+
 defmodule InternalApi.Organization.OrganizationService.Service do
   @moduledoc false
   use GRPC.Service,
@@ -637,10 +587,6 @@ defmodule InternalApi.Organization.OrganizationService.Service do
   rpc :List, InternalApi.Organization.ListRequest, InternalApi.Organization.ListResponse
 
   rpc :Create, InternalApi.Organization.CreateRequest, InternalApi.Organization.CreateResponse
-
-  rpc :CreateWithQuotas,
-      InternalApi.Organization.CreateWithQuotasRequest,
-      InternalApi.Organization.CreateWithQuotasResponse
 
   rpc :Update, InternalApi.Organization.UpdateRequest, InternalApi.Organization.UpdateResponse
 
@@ -684,15 +630,9 @@ defmodule InternalApi.Organization.OrganizationService.Service do
       InternalApi.Organization.ListSuspensionsRequest,
       InternalApi.Organization.ListSuspensionsResponse
 
-  rpc :UpdateQuotas,
-      InternalApi.Organization.UpdateQuotasRequest,
-      InternalApi.Organization.UpdateQuotasResponse
-
-  rpc :GetQuotas,
-      InternalApi.Organization.GetQuotasRequest,
-      InternalApi.Organization.GetQuotaResponse
-
   rpc :Destroy, InternalApi.Organization.DestroyRequest, Google.Protobuf.Empty
+
+  rpc :Restore, InternalApi.Organization.RestoreRequest, Google.Protobuf.Empty
 
   rpc :RepositoryIntegrators,
       InternalApi.Organization.RepositoryIntegratorsRequest,

--- a/periodic_scheduler/scheduler/lib/internal_api/periodic_scheduler.pb.ex
+++ b/periodic_scheduler/scheduler/lib/internal_api/periodic_scheduler.pb.ex
@@ -112,14 +112,13 @@ defmodule InternalApi.PeriodicScheduler.RunNowRequest do
 
   field :id, 1, type: :string
   field :requester, 2, type: :string
-  field :pipeline_file, 3, type: :string, json_name: "pipelineFile"
+  field :reference, 3, type: :string
+  field :pipeline_file, 4, type: :string, json_name: "pipelineFile"
 
-  field :parameter_values, 4,
+  field :parameter_values, 5,
     repeated: true,
     type: InternalApi.PeriodicScheduler.ParameterValue,
     json_name: "parameterValues"
-
-  field :reference, 5, type: :string
 end
 
 defmodule InternalApi.PeriodicScheduler.RunNowResponse do

--- a/periodic_scheduler/scheduler/lib/internal_api/periodic_scheduler.pb.ex
+++ b/periodic_scheduler/scheduler/lib/internal_api/periodic_scheduler.pb.ex
@@ -61,7 +61,7 @@ defmodule InternalApi.PeriodicScheduler.PersistRequest do
   field :organization_id, 6, type: :string, json_name: "organizationId"
   field :project_name, 7, type: :string, json_name: "projectName"
   field :requester_id, 8, type: :string, json_name: "requesterId"
-  field :branch, 9, type: :string
+  field :reference, 9, type: :string
   field :pipeline_file, 10, type: :string, json_name: "pipelineFile"
   field :at, 11, type: :string
   field :parameters, 12, repeated: true, type: InternalApi.PeriodicScheduler.Periodic.Parameter
@@ -112,13 +112,14 @@ defmodule InternalApi.PeriodicScheduler.RunNowRequest do
 
   field :id, 1, type: :string
   field :requester, 2, type: :string
-  field :branch, 3, type: :string
-  field :pipeline_file, 4, type: :string, json_name: "pipelineFile"
+  field :pipeline_file, 3, type: :string, json_name: "pipelineFile"
 
-  field :parameter_values, 5,
+  field :parameter_values, 4,
     repeated: true,
     type: InternalApi.PeriodicScheduler.ParameterValue,
     json_name: "parameterValues"
+
+  field :reference, 5, type: :string
 end
 
 defmodule InternalApi.PeriodicScheduler.RunNowResponse do
@@ -165,7 +166,7 @@ defmodule InternalApi.PeriodicScheduler.Periodic do
   field :id, 1, type: :string
   field :name, 2, type: :string
   field :project_id, 3, type: :string, json_name: "projectId"
-  field :branch, 4, type: :string
+  field :reference, 4, type: :string
   field :at, 5, type: :string
   field :pipeline_file, 6, type: :string, json_name: "pipelineFile"
   field :requester_id, 7, type: :string, json_name: "requesterId"
@@ -178,6 +179,7 @@ defmodule InternalApi.PeriodicScheduler.Periodic do
   field :recurring, 14, type: :bool
   field :parameters, 15, repeated: true, type: InternalApi.PeriodicScheduler.Periodic.Parameter
   field :description, 16, type: :string
+  field :organization_id, 17, type: :string, json_name: "organizationId"
 end
 
 defmodule InternalApi.PeriodicScheduler.Trigger do
@@ -186,7 +188,7 @@ defmodule InternalApi.PeriodicScheduler.Trigger do
 
   field :triggered_at, 1, type: Google.Protobuf.Timestamp, json_name: "triggeredAt"
   field :project_id, 2, type: :string, json_name: "projectId"
-  field :branch, 3, type: :string
+  field :reference, 3, type: :string
   field :pipeline_file, 4, type: :string, json_name: "pipelineFile"
   field :scheduling_status, 5, type: :string, json_name: "schedulingStatus"
   field :scheduled_workflow_id, 6, type: :string, json_name: "scheduledWorkflowId"

--- a/periodic_scheduler/scheduler/lib/internal_api/plumber_w_f.workflow.pb.ex
+++ b/periodic_scheduler/scheduler/lib/internal_api/plumber_w_f.workflow.pb.ex
@@ -129,6 +129,9 @@ defmodule InternalApi.PlumberWF.ScheduleRequest do
     repeated: true,
     type: InternalApi.PlumberWF.ScheduleRequest.EnvVar,
     json_name: "envVars"
+
+  field :start_in_conceived_state, 18, type: :bool, json_name: "startInConceivedState"
+  field :git_reference, 19, type: :string, json_name: "gitReference"
 end
 
 defmodule InternalApi.PlumberWF.ScheduleResponse do

--- a/periodic_scheduler/scheduler/lib/internal_api/projecthub.pb.ex
+++ b/periodic_scheduler/scheduler/lib/internal_api/projecthub.pb.ex
@@ -35,6 +35,7 @@ defmodule InternalApi.Projecthub.Project.Spec.Repository.RunType do
   field :TAGS, 1
   field :PULL_REQUESTS, 2
   field :FORKED_PULL_REQUESTS, 3
+  field :DRAFT_PULL_REQUESTS, 4
 end
 
 defmodule InternalApi.Projecthub.Project.Spec.Repository.Status.PipelineFile.Level do
@@ -70,6 +71,7 @@ defmodule InternalApi.Projecthub.Project.Status.State do
   field :INITIALIZING, 0
   field :READY, 1
   field :ERROR, 2
+  field :ONBOARDING, 3
 end
 
 defmodule InternalApi.Projecthub.ListKeysetRequest.Direction do
@@ -350,6 +352,7 @@ defmodule InternalApi.Projecthub.ListRequest do
   field :pagination, 2, type: InternalApi.Projecthub.PaginationRequest
   field :owner_id, 3, type: :string, json_name: "ownerId"
   field :repo_url, 4, type: :string, json_name: "repoUrl"
+  field :soft_deleted, 5, type: :bool, json_name: "softDeleted"
 end
 
 defmodule InternalApi.Projecthub.ListResponse do
@@ -371,6 +374,7 @@ defmodule InternalApi.Projecthub.ListKeysetRequest do
   field :direction, 4, type: InternalApi.Projecthub.ListKeysetRequest.Direction, enum: true
   field :owner_id, 5, type: :string, json_name: "ownerId"
   field :repo_url, 6, type: :string, json_name: "repoUrl"
+  field :created_after, 7, type: Google.Protobuf.Timestamp, json_name: "createdAfter"
 end
 
 defmodule InternalApi.Projecthub.ListKeysetResponse do
@@ -391,6 +395,7 @@ defmodule InternalApi.Projecthub.DescribeRequest do
   field :id, 2, type: :string
   field :name, 3, type: :string
   field :detailed, 4, type: :bool
+  field :soft_deleted, 5, type: :bool, json_name: "softDeleted"
 end
 
 defmodule InternalApi.Projecthub.DescribeResponse do
@@ -407,6 +412,7 @@ defmodule InternalApi.Projecthub.DescribeManyRequest do
 
   field :metadata, 1, type: InternalApi.Projecthub.RequestMeta
   field :ids, 2, repeated: true, type: :string
+  field :soft_deleted, 3, type: :bool, json_name: "softDeleted"
 end
 
 defmodule InternalApi.Projecthub.DescribeManyResponse do
@@ -423,6 +429,7 @@ defmodule InternalApi.Projecthub.CreateRequest do
 
   field :metadata, 1, type: InternalApi.Projecthub.RequestMeta
   field :project, 2, type: InternalApi.Projecthub.Project
+  field :skip_onboarding, 3, type: :bool, json_name: "skipOnboarding"
 end
 
 defmodule InternalApi.Projecthub.CreateResponse do
@@ -466,6 +473,21 @@ defmodule InternalApi.Projecthub.DestroyResponse do
   field :metadata, 1, type: InternalApi.Projecthub.ResponseMeta
 end
 
+defmodule InternalApi.Projecthub.RestoreRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :metadata, 1, type: InternalApi.Projecthub.RequestMeta
+  field :id, 2, type: :string
+end
+
+defmodule InternalApi.Projecthub.RestoreResponse do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :metadata, 1, type: InternalApi.Projecthub.ResponseMeta
+end
+
 defmodule InternalApi.Projecthub.UsersRequest do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
@@ -497,6 +519,7 @@ defmodule InternalApi.Projecthub.CheckDeployKeyResponse.DeployKey do
   field :title, 1, type: :string
   field :fingerprint, 2, type: :string
   field :created_at, 3, type: Google.Protobuf.Timestamp, json_name: "createdAt"
+  field :public_key, 4, type: :string, json_name: "publicKey"
 end
 
 defmodule InternalApi.Projecthub.CheckDeployKeyResponse do
@@ -525,6 +548,7 @@ defmodule InternalApi.Projecthub.RegenerateDeployKeyResponse.DeployKey do
   field :title, 1, type: :string
   field :fingerprint, 2, type: :string
   field :created_at, 3, type: Google.Protobuf.Timestamp, json_name: "createdAt"
+  field :public_key, 4, type: :string, json_name: "publicKey"
 end
 
 defmodule InternalApi.Projecthub.RegenerateDeployKeyResponse do
@@ -624,6 +648,37 @@ defmodule InternalApi.Projecthub.GithubAppSwitchResponse do
   field :metadata, 1, type: InternalApi.Projecthub.ResponseMeta
 end
 
+defmodule InternalApi.Projecthub.FinishOnboardingRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :metadata, 1, type: InternalApi.Projecthub.RequestMeta
+  field :id, 2, type: :string
+end
+
+defmodule InternalApi.Projecthub.FinishOnboardingResponse do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :metadata, 1, type: InternalApi.Projecthub.ResponseMeta
+end
+
+defmodule InternalApi.Projecthub.RegenerateWebhookSecretRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :metadata, 1, type: InternalApi.Projecthub.RequestMeta
+  field :id, 2, type: :string
+end
+
+defmodule InternalApi.Projecthub.RegenerateWebhookSecretResponse do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :metadata, 1, type: InternalApi.Projecthub.ResponseMeta
+  field :secret, 2, type: :string
+end
+
 defmodule InternalApi.Projecthub.ProjectCreated do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
@@ -634,6 +689,15 @@ defmodule InternalApi.Projecthub.ProjectCreated do
 end
 
 defmodule InternalApi.Projecthub.ProjectDeleted do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :project_id, 1, type: :string, json_name: "projectId"
+  field :timestamp, 2, type: Google.Protobuf.Timestamp
+  field :org_id, 3, type: :string, json_name: "orgId"
+end
+
+defmodule InternalApi.Projecthub.ProjectRestored do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
 
@@ -683,6 +747,8 @@ defmodule InternalApi.Projecthub.ProjectService.Service do
 
   rpc :Destroy, InternalApi.Projecthub.DestroyRequest, InternalApi.Projecthub.DestroyResponse
 
+  rpc :Restore, InternalApi.Projecthub.RestoreRequest, InternalApi.Projecthub.RestoreResponse
+
   rpc :Users, InternalApi.Projecthub.UsersRequest, InternalApi.Projecthub.UsersResponse
 
   rpc :CheckDeployKey,
@@ -701,6 +767,10 @@ defmodule InternalApi.Projecthub.ProjectService.Service do
       InternalApi.Projecthub.RegenerateWebhookRequest,
       InternalApi.Projecthub.RegenerateWebhookResponse
 
+  rpc :RegenerateWebhookSecret,
+      InternalApi.Projecthub.RegenerateWebhookSecretRequest,
+      InternalApi.Projecthub.RegenerateWebhookSecretResponse
+
   rpc :ChangeProjectOwner,
       InternalApi.Projecthub.ChangeProjectOwnerRequest,
       InternalApi.Projecthub.ChangeProjectOwnerResponse
@@ -712,6 +782,10 @@ defmodule InternalApi.Projecthub.ProjectService.Service do
   rpc :GithubAppSwitch,
       InternalApi.Projecthub.GithubAppSwitchRequest,
       InternalApi.Projecthub.GithubAppSwitchResponse
+
+  rpc :FinishOnboarding,
+      InternalApi.Projecthub.FinishOnboardingRequest,
+      InternalApi.Projecthub.FinishOnboardingResponse
 end
 
 defmodule InternalApi.Projecthub.ProjectService.Stub do

--- a/periodic_scheduler/scheduler/lib/internal_api/repo_proxy.pb.ex
+++ b/periodic_scheduler/scheduler/lib/internal_api/repo_proxy.pb.ex
@@ -187,6 +187,15 @@ defmodule InternalApi.RepoProxy.CreateBlankResponse do
   field :repo, 5, type: InternalApi.RepoProxy.CreateBlankResponse.Repo
 end
 
+defmodule InternalApi.RepoProxy.PullRequestUnmergeable do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :project_id, 1, type: :string, json_name: "projectId"
+  field :branch_name, 2, type: :string, json_name: "branchName"
+  field :timestamp, 3, type: Google.Protobuf.Timestamp
+end
+
 defmodule InternalApi.RepoProxy.RepoProxyService.Service do
   @moduledoc false
   use GRPC.Service,

--- a/periodic_scheduler/scheduler/lib/internal_api/repository.pb.ex
+++ b/periodic_scheduler/scheduler/lib/internal_api/repository.pb.ex
@@ -79,6 +79,7 @@ defmodule InternalApi.Repository.DeployKey do
   field :title, 1, type: :string
   field :fingerprint, 2, type: :string
   field :created_at, 3, type: Google.Protobuf.Timestamp, json_name: "createdAt"
+  field :public_key, 4, type: :string, json_name: "publicKey"
 end
 
 defmodule InternalApi.Repository.DescribeRemoteRepositoryRequest do
@@ -327,6 +328,7 @@ defmodule InternalApi.Repository.Repository do
   field :whitelist, 11, type: InternalApi.Projecthub.Project.Spec.Repository.Whitelist
   field :hook_id, 12, type: :string, json_name: "hookId"
   field :default_branch, 13, type: :string, json_name: "defaultBranch"
+  field :connected, 14, type: :bool
 end
 
 defmodule InternalApi.Repository.RemoteRepository do
@@ -481,6 +483,7 @@ defmodule InternalApi.Repository.CreateRequest do
     json_name: "commitStatus"
 
   field :whitelist, 9, type: InternalApi.Projecthub.Project.Spec.Repository.Whitelist
+  field :default_branch, 10, type: :string, json_name: "defaultBranch"
 end
 
 defmodule InternalApi.Repository.CreateResponse do
@@ -522,6 +525,7 @@ defmodule InternalApi.Repository.UpdateRequest do
     json_name: "commitStatus"
 
   field :whitelist, 6, type: InternalApi.Projecthub.Project.Spec.Repository.Whitelist
+  field :default_branch, 7, type: :string, json_name: "defaultBranch"
 end
 
 defmodule InternalApi.Repository.UpdateResponse do
@@ -537,6 +541,51 @@ defmodule InternalApi.Repository.RemoteRepositoryChanged do
 
   field :remote_id, 1, type: :string, json_name: "remoteId"
   field :timestamp, 3, type: Google.Protobuf.Timestamp
+end
+
+defmodule InternalApi.Repository.VerifyWebhookSignatureRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :organization_id, 1, type: :string, json_name: "organizationId"
+  field :repository_id, 2, type: :string, json_name: "repositoryId"
+  field :payload, 3, type: :string
+  field :signature, 4, type: :string
+end
+
+defmodule InternalApi.Repository.VerifyWebhookSignatureResponse do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :valid, 1, type: :bool
+end
+
+defmodule InternalApi.Repository.ClearExternalDataRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :repository_id, 1, type: :string, json_name: "repositoryId"
+end
+
+defmodule InternalApi.Repository.ClearExternalDataResponse do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :repository, 1, type: InternalApi.Repository.Repository
+end
+
+defmodule InternalApi.Repository.RegenerateWebhookSecretRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :repository_id, 1, type: :string, json_name: "repositoryId"
+end
+
+defmodule InternalApi.Repository.RegenerateWebhookSecretResponse do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  field :secret, 1, type: :string
 end
 
 defmodule InternalApi.Repository.RepositoryService.Service do
@@ -610,6 +659,18 @@ defmodule InternalApi.Repository.RepositoryService.Service do
   rpc :DescribeRevision,
       InternalApi.Repository.DescribeRevisionRequest,
       InternalApi.Repository.DescribeRevisionResponse
+
+  rpc :VerifyWebhookSignature,
+      InternalApi.Repository.VerifyWebhookSignatureRequest,
+      InternalApi.Repository.VerifyWebhookSignatureResponse
+
+  rpc :ClearExternalData,
+      InternalApi.Repository.ClearExternalDataRequest,
+      InternalApi.Repository.ClearExternalDataResponse
+
+  rpc :RegenerateWebhookSecret,
+      InternalApi.Repository.RegenerateWebhookSecretRequest,
+      InternalApi.Repository.RegenerateWebhookSecretResponse
 end
 
 defmodule InternalApi.Repository.RepositoryService.Stub do

--- a/periodic_scheduler/scheduler/lib/internal_api/repository_integrator.pb.ex
+++ b/periodic_scheduler/scheduler/lib/internal_api/repository_integrator.pb.ex
@@ -101,6 +101,16 @@ defmodule InternalApi.RepositoryIntegrator.GithubInstallationInfoResponse do
   field :installation_url, 3, type: :string, json_name: "installationUrl"
 end
 
+defmodule InternalApi.RepositoryIntegrator.InitGithubInstallationRequest do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+end
+
+defmodule InternalApi.RepositoryIntegrator.InitGithubInstallationResponse do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+end
+
 defmodule InternalApi.RepositoryIntegrator.GetRepositoriesRequest do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
@@ -156,6 +166,10 @@ defmodule InternalApi.RepositoryIntegrator.RepositoryIntegratorService.Service d
   rpc :GithubInstallationInfo,
       InternalApi.RepositoryIntegrator.GithubInstallationInfoRequest,
       InternalApi.RepositoryIntegrator.GithubInstallationInfoResponse
+
+  rpc :InitGithubInstallation,
+      InternalApi.RepositoryIntegrator.InitGithubInstallationRequest,
+      InternalApi.RepositoryIntegrator.InitGithubInstallationResponse
 
   rpc :GetRepositories,
       InternalApi.RepositoryIntegrator.GetRepositoriesRequest,

--- a/periodic_scheduler/scheduler/lib/scheduler/actions/persist_impl.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/actions/persist_impl.ex
@@ -50,7 +50,7 @@ defmodule Scheduler.Actions.PersistImpl do
   defp create(request) do
     with {:ok, project_name} <- get_project_name(request.organization_id, request.project_id),
          {:ok, params} <- form_periodic_params(request, project_name),
-         {:ok, periodic} <- PeriodicsQueries.insert(params, "v1.1"),
+         {:ok, periodic} <- PeriodicsQueries.insert(params, "v1.2"),
          {:ok, _job} <- start_periodic_job(periodic) do
       {:ok, periodic.id}
     end
@@ -58,7 +58,7 @@ defmodule Scheduler.Actions.PersistImpl do
 
   defp update(periodic, request) do
     with {:ok, params} <- form_periodic_params(request, periodic),
-         {:ok, periodic} <- PeriodicsQueries.update(periodic, params, "v1.1"),
+         {:ok, periodic} <- PeriodicsQueries.update(periodic, params, "v1.2"),
          {:ok, _job} <- start_or_stop_periodic_job(periodic) do
       {:ok, periodic.id}
     end
@@ -83,7 +83,7 @@ defmodule Scheduler.Actions.PersistImpl do
     |> Map.take(~w(
       name description recurring
       organization_id project_id requester_id
-      branch pipeline_file at
+      reference pipeline_file at
     )a)
     |> Map.put(:parameters, parameters)
     |> inject_paused(request.state)
@@ -97,7 +97,7 @@ defmodule Scheduler.Actions.PersistImpl do
     request
     |> Map.take(~w(
       name description recurring requester_id
-      branch pipeline_file at
+      reference pipeline_file at
     )a)
     |> inject_paused(request.state)
     |> Map.put(:parameters, parameters)

--- a/periodic_scheduler/scheduler/lib/scheduler/actions/run_now_impl.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/actions/run_now_impl.ex
@@ -102,7 +102,6 @@ defmodule Scheduler.Actions.RunNowImpl do
     do: "The 'requester' parameter can not be empty string." |> ToTuple.error(:INVALID_ARGUMENT)
 
   defp verify_revision_exists(periodic, params) do
-    # Handle backwards compatibility: normalize reference to full format
     git_reference = GitReference.normalize(params.reference)
 
     revision_args = [reference: git_reference, commit_sha: ""]

--- a/periodic_scheduler/scheduler/lib/scheduler/actions/run_now_impl.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/actions/run_now_impl.ex
@@ -9,6 +9,7 @@ defmodule Scheduler.Actions.RunNowImpl do
   alias Scheduler.Periodics.Model.Periodics
   alias Scheduler.Clients.{ProjecthubClient, RepositoryClient}
   alias Scheduler.Actions
+  alias Scheduler.Utils.GitReference
   alias Util.ToTuple
 
   def run_now(params) do
@@ -25,8 +26,8 @@ defmodule Scheduler.Actions.RunNowImpl do
     end
   end
 
-  defp validate_params(%Periodics{branch: nil}, %{branch: ""}),
-    do: "You have to provide branch for this task" |> ToTuple.error(:INVALID_ARGUMENT)
+  defp validate_params(%Periodics{reference: nil}, %{reference: ""}),
+    do: "You have to provide reference for this task" |> ToTuple.error(:INVALID_ARGUMENT)
 
   defp validate_params(%Periodics{pipeline_file: nil}, %{pipeline_file: ""}),
     do: "You have to provide pipeline file for this task" |> ToTuple.error(:INVALID_ARGUMENT)
@@ -35,10 +36,10 @@ defmodule Scheduler.Actions.RunNowImpl do
          periodics = %Periodics{parameters: parameters},
          params = %{parameter_values: values}
        ) do
-    branch =
-      if String.length(params.branch) > 1,
-        do: params.branch,
-        else: periodics.branch
+    reference =
+      if String.length(params.reference) > 1,
+        do: params.reference,
+        else: periodics.reference
 
     pipeline_file =
       if String.length(params.pipeline_file) > 1,
@@ -49,7 +50,7 @@ defmodule Scheduler.Actions.RunNowImpl do
       {:ok, values} ->
         {:ok,
          params
-         |> Map.put(:branch, branch)
+         |> Map.put(:reference, reference)
          |> Map.put(:pipeline_file, pipeline_file)
          |> Map.put(:parameter_values, values)}
 
@@ -101,7 +102,10 @@ defmodule Scheduler.Actions.RunNowImpl do
     do: "The 'requester' parameter can not be empty string." |> ToTuple.error(:INVALID_ARGUMENT)
 
   defp verify_revision_exists(periodic, params) do
-    revision_args = [reference: "refs/heads/" <> params.branch, commit_sha: ""]
+    # Handle backwards compatibility: normalize reference to full format
+    git_reference = GitReference.normalize(params.reference)
+
+    revision_args = [reference: git_reference, commit_sha: ""]
 
     with {:ok, repository_id} <- fetch_project_repository_id(periodic.project_id),
          {:ok, commit} <- fetch_branch_revision(repository_id, revision_args) do

--- a/periodic_scheduler/scheduler/lib/scheduler/actions/schedule_wf_impl.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/actions/schedule_wf_impl.ex
@@ -154,7 +154,7 @@ defmodule Scheduler.Actions.ScheduleWfImpl do
     |> legacy_branch_name_format()
   end
 
-  defp legacy_branch_name_format("refs/tags/" <> _ = full_ref), do: full_ref
+  defp legacy_branch_name_format(full_ref = "refs/tags/" <> _), do: full_ref
 
   defp legacy_branch_name_format("refs/pull/" <> rest) do
     pr_number = rest |> String.trim_trailing("/head")

--- a/periodic_scheduler/scheduler/lib/scheduler/actions/schedule_wf_impl.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/actions/schedule_wf_impl.ex
@@ -9,6 +9,7 @@ defmodule Scheduler.Actions.ScheduleWfImpl do
   alias Scheduler.FrontDB.Model.FrontDBQueries
   alias Scheduler.Clients.{WorkflowClient, RepoProxyClient, ProjecthubClient, RepositoryClient}
   alias Scheduler.Workers.ScheduleTaskManager
+  alias Scheduler.Utils.GitReference
   alias Util.ToTuple
   alias LogTee, as: LT
 
@@ -36,39 +37,7 @@ defmodule Scheduler.Actions.ScheduleWfImpl do
     end
   end
 
-  def schedule_wf(periodic = %{organization_id: org_id}, trigger) do
-    cond do
-      FeatureProvider.feature_enabled?(:just_run, param: org_id) ->
-        schedule_wf_just_run(periodic, trigger)
-
-      FeatureProvider.feature_enabled?(:scheduler_hook, param: org_id) ->
-        schedule_wf_run_api(periodic, trigger)
-
-      true ->
-        schedule_wf_db_query(periodic, trigger)
-    end
-  end
-
-  defp schedule_wf_run_api(periodic, trigger) do
-    with {:ok, params} <- form_create_params(periodic, trigger),
-         {:ok, wf_id} <- RepoProxyClient.create(params) do
-      params = %{
-        scheduled_workflow_id: wf_id,
-        scheduling_status: "passed",
-        error_description: nil,
-        attempts: (trigger.attempts || 0) + 1
-      }
-
-      PeriodicsTriggersQueries.update(trigger, params)
-    else
-      error ->
-        Watchman.increment({"PeriodicSch.schedule_wf_failure", ["run-wf-api"]})
-        record_error(error, trigger)
-        error
-    end
-  end
-
-  defp schedule_wf_just_run(periodic, trigger) do
+  def schedule_wf(periodic, trigger) do
     Watchman.benchmark("PeriodicSch.schedule_just_run", fn ->
       with {:ok, repository} <- fetch_project_repository(trigger.project_id),
            {:ok, params} <- form_just_run_schedule_params(periodic, trigger, repository),
@@ -92,14 +61,14 @@ defmodule Scheduler.Actions.ScheduleWfImpl do
     end)
   end
 
-  defp fetch_project_repository(project_id) do
+  def fetch_project_repository(project_id) do
     case ProjecthubClient.describe(project_id) do
       {:ok, project} -> {:ok, project.spec.repository}
       {:error, _reason} -> {:error, {:missing_project, project_id}}
     end
   end
 
-  defp fetch_branch_revision(repository_id, revision_args) do
+  def fetch_branch_revision(repository_id, revision_args) do
     case RepositoryClient.describe_revision(repository_id, revision_args) do
       {:ok, commit} -> {:ok, commit}
       {:error, _reason} -> {:error, {:missing_revision, revision_args}}
@@ -117,18 +86,24 @@ defmodule Scheduler.Actions.ScheduleWfImpl do
         do: :MANUAL_RUN,
         else: :SCHEDULE
 
+    # Handle backwards compatibility: normalize reference to full format
+    git_reference = GitReference.normalize(trigger.reference)
+
+    # Extract branch name for legacy branch_name field
+    branch_name = GitReference.extract_name(trigger.reference)
+
     %{
       service: schedule_workflow_service_type(repository.integration_type),
-      repo: %{branch_name: trigger.branch},
+      repo: %{branch_name: branch_name},
       request_token: trigger.periodic_id <> "-#{trigger.id}",
       project_id: trigger.project_id,
       requester_id: requester_id,
       definition_file: trigger.pipeline_file,
       organization_id: periodic.organization_id,
-      label: trigger.branch,
+      label: branch_name,
       scheduler_task_id: periodic.id,
       git: %{
-        reference: "refs/heads/" <> trigger.branch,
+        reference: git_reference,
         commit_sha: ""
       },
       triggered_by: triggered_by,
@@ -151,32 +126,12 @@ defmodule Scheduler.Actions.ScheduleWfImpl do
     %{name: name, value: if(is_nil(value), do: "", else: value)}
   end
 
-  defp schedule_wf_db_query(periodic, trigger) do
-    with {:ok, hook} <- FrontDBQueries.get_hook(periodic.project_id, trigger.branch),
-         {:ok, params} <- form_schedule_params(periodic, trigger, hook),
-         {:ok, wf_id} <- WorkflowClient.schedule(params) do
-      params = %{
-        scheduled_workflow_id: wf_id,
-        scheduling_status: "passed",
-        error_description: nil,
-        attempts: (trigger.attempts || 0) + 1
-      }
-
-      PeriodicsTriggersQueries.update(trigger, params)
-    else
-      error ->
-        Watchman.increment({"PeriodicSch.schedule_wf_failure", ["db-query"]})
-        record_error(error, trigger)
-        error
-    end
-  end
-
   # The error is saved in DB after each failed attempt, so we can debug months
   # later when logs are not available. If scheduling passes in the following
   # attempt, the error_description field will be cleared.
-  defp record_error({:error, error}, trigger), do: record_error(error, trigger)
+  def record_error({:error, error}, trigger), do: record_error(error, trigger)
 
-  defp record_error(error, trigger) do
+  def record_error(error, trigger) do
     with log_msg <- "Scheduling for periodic #{trigger.periodic_id} failed with error",
          str_error <- error |> to_str() |> LT.warn(log_msg),
          str_error <- str_error |> String.slice(0..253),
@@ -185,59 +140,6 @@ defmodule Scheduler.Actions.ScheduleWfImpl do
     end
   end
 
-  defp to_str(val) when is_binary(val), do: val
-  defp to_str(val), do: "#{inspect(val)}"
-
-  defp form_create_params(periodic, trigger) do
-    %{
-      request_token: trigger.periodic_id <> "-#{trigger.id}",
-      project_id: trigger.project_id,
-      requester_id: periodic.requester_id,
-      definition_file: trigger.pipeline_file,
-      git: %{
-        reference: "refs/heads/" <> trigger.branch,
-        commit_sha: ""
-      },
-      triggered_by: :SCHEDULE
-    }
-    |> ToTuple.ok()
-  end
-
-  defp form_schedule_params(periodic, trigger, hook) do
-    hook
-    |> Map.put(:service, :GIT_HUB)
-    |> Map.put(:triggered_by, :SCHEDULE)
-    |> add_trigger_data(periodic, trigger)
-    |> extract_commit_sha()
-  end
-
-  defp add_trigger_data(params, periodic, trigger) do
-    params
-    |> Map.put(:organization_id, periodic.organization_id)
-    |> Map.put(:requester_id, periodic.requester_id)
-    |> Map.put(:definition_file, trigger.pipeline_file)
-    |> Map.put(:request_token, trigger.periodic_id <> "-#{trigger.id}")
-  end
-
-  defp extract_commit_sha(params) do
-    with {:ok, payload} <- params.repo.payload |> Jason.decode(),
-         repo <- params.repo |> Map.delete(:payload),
-         {:ok, commit_sha} <- find_commit_sha(payload),
-         repo <- repo |> Map.put(:commit_sha, commit_sha) do
-      params |> Map.put(:repo, repo) |> ToTuple.ok()
-    else
-      error = {:error, _e} -> error
-      error -> {:error, error}
-    end
-  end
-
-  defp find_commit_sha(%{"head_commit" => %{"id" => commit_sha}})
-       when is_binary(commit_sha) and commit_sha != "",
-       do: {:ok, commit_sha}
-
-  defp find_commit_sha(%{"after" => commit_sha})
-       when is_binary(commit_sha) and commit_sha != "",
-       do: {:ok, commit_sha}
-
-  defp find_commit_sha(_params), do: {:error, "Hook is missing commit_sha data"}
+  def to_str(val) when is_binary(val), do: val
+  def to_str(val), do: "#{inspect(val)}"
 end

--- a/periodic_scheduler/scheduler/lib/scheduler/grpc_server.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/grpc_server.ex
@@ -161,7 +161,6 @@ defmodule Scheduler.Grpc.Server do
     Metrics.benchmark("PeriodicSch.history", __MODULE__, fn ->
       filters = Map.take(request.filters || %{}, ~w(branch_name pipeline_file triggered_by)a)
 
-      # Map branch_name to reference for backwards compatibility
       filters =
         case Map.get(filters, :branch_name) do
           nil ->

--- a/periodic_scheduler/scheduler/lib/scheduler/grpc_server.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/grpc_server.ex
@@ -161,6 +161,18 @@ defmodule Scheduler.Grpc.Server do
     Metrics.benchmark("PeriodicSch.history", __MODULE__, fn ->
       filters = Map.take(request.filters || %{}, ~w(branch_name pipeline_file triggered_by)a)
 
+      # Map branch_name to reference for backwards compatibility
+      filters =
+        case Map.get(filters, :branch_name) do
+          nil ->
+            filters
+
+          branch_name ->
+            filters
+            |> Map.delete(:branch_name)
+            |> Map.put(:reference, branch_name)
+        end
+
       params =
         request
         |> Map.take(~w(periodic_id cursor_type cursor_value)a)

--- a/periodic_scheduler/scheduler/lib/scheduler/grpc_server.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/grpc_server.ex
@@ -161,17 +161,6 @@ defmodule Scheduler.Grpc.Server do
     Metrics.benchmark("PeriodicSch.history", __MODULE__, fn ->
       filters = Map.take(request.filters || %{}, ~w(branch_name pipeline_file triggered_by)a)
 
-      filters =
-        case Map.get(filters, :branch_name) do
-          nil ->
-            filters
-
-          branch_name ->
-            filters
-            |> Map.delete(:branch_name)
-            |> Map.put(:reference, branch_name)
-        end
-
       params =
         request
         |> Map.take(~w(periodic_id cursor_type cursor_value)a)

--- a/periodic_scheduler/scheduler/lib/scheduler/periodics/model/periodics.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/periodics/model/periodics.ex
@@ -19,7 +19,7 @@ defmodule Scheduler.Periodics.Model.Periodics do
     field :description, :string
     field :project_name, :string
     field :project_id, :string
-    field :branch, :string
+    field :reference, :string, source: :branch
     field :at, :string
     field :pipeline_file, :string
     field :recurring, :boolean, read_after_writes: true, default: true
@@ -34,19 +34,19 @@ defmodule Scheduler.Periodics.Model.Periodics do
   end
 
   @required_fields_v1_0 ~w(id requester_id organization_id name project_name
-                          project_id branch at pipeline_file)a
+                          project_id reference at pipeline_file)a
   @optional_fields_v1_0 ~w(paused pause_toggled_by pause_toggled_at)a
 
   @required_fields_update_v1_0 ~w(requester_id organization_id)a
-  @optional_fields_update_v1_0 ~w(name project_name project_id branch at pipeline_file
+  @optional_fields_update_v1_0 ~w(name project_name project_id reference at pipeline_file
                                  suspended paused pause_toggled_by pause_toggled_at)a
 
   @required_fields ~w(id requester_id organization_id name project_name
-                      project_id recurring branch pipeline_file)a
+                      project_id recurring reference pipeline_file)a
   @optional_fields ~w(description at paused pause_toggled_by pause_toggled_at)a
 
   @required_fields_update ~w(requester_id organization_id)a
-  @optional_fields_update ~w(name project_name project_id branch at pipeline_file recurring
+  @optional_fields_update ~w(name project_name project_id reference at pipeline_file recurring
                              description suspended paused pause_toggled_by pause_toggled_at)a
 
   @doc """
@@ -79,7 +79,7 @@ defmodule Scheduler.Periodics.Model.Periodics do
 
       iex> alias Scheduler.Periodics.Model.Periodics
       iex> params = %{requester_id: UUID.uuid1(), organization_id: UUID.uuid1(),
-      ...>           name: "P1", project_name: "Pr1", branch: "master", project_id: "p1",
+      ...>           name: "P1", project_name: "Pr1", reference: "master", project_id: "p1",
       ...>           at: "* * * * *", id: UUID.uuid1(), pipeline_file: "deploy.yml"}
       iex> Periodics.changeset(%Periodics{}, "v1.0", params) |> Map.get(:valid?)
       true
@@ -87,7 +87,7 @@ defmodule Scheduler.Periodics.Model.Periodics do
       iex> alias Scheduler.Periodics.Model.Periodics
       iex> params = %{requester_id: UUID.uuid1(), organization_id: UUID.uuid1(), id: UUID.uuid1(),
       ...>           name: "P1", project_name: "Pr1", project_id: "p1",
-      ...>           branch: "master", pipeline_file: "deploy.yml", recurring: false,
+      ...>           reference: "master", pipeline_file: "deploy.yml", recurring: false,
       ...>           parameters: [%{name: "foo", required: true, default_value: "bar"}]}
       iex> Periodics.changeset(%Periodics{}, "v1.1", params) |> Map.get(:valid?)
       true
@@ -102,6 +102,10 @@ defmodule Scheduler.Periodics.Model.Periodics do
     do_changeset(periodic, params, api_version, @required_fields, @optional_fields)
   end
 
+  def changeset(periodic, api_version = "v1.2", params) do
+    do_changeset(periodic, params, api_version, @required_fields, @optional_fields)
+  end
+
   @doc ~S"""
   ## Examples:
 
@@ -111,7 +115,7 @@ defmodule Scheduler.Periodics.Model.Periodics do
 
       iex> alias Scheduler.Periodics.Model.Periodics
       iex> params = %{requester_id: UUID.uuid1(), organization_id: UUID.uuid1(), at: "* * * * *",
-      ...>           name: "P1",  branch: "master", pipeline_file: "deploy.yml"}
+      ...>           name: "P1",  reference: "master", pipeline_file: "deploy.yml"}
       iex> Periodics.changeset_update(%Periodics{}, "v1.0", params) |> Map.get(:valid?)
       true
 
@@ -136,6 +140,10 @@ defmodule Scheduler.Periodics.Model.Periodics do
     do_changeset(periodic, params, api_version, @required_fields_update, @optional_fields_update)
   end
 
+  def changeset_update(periodic, api_version = "v1.2", params) do
+    do_changeset(periodic, params, api_version, @required_fields_update, @optional_fields_update)
+  end
+
   defp do_changeset(periodic, params, api_version, required_fields, optional_fields) do
     periodic
     |> cast(params, required_fields ++ optional_fields)
@@ -148,19 +156,26 @@ defmodule Scheduler.Periodics.Model.Periodics do
 
   defp maybe_cast_parameters(changeset, "v1.0"), do: changeset
   defp maybe_cast_parameters(changeset, "v1.1"), do: cast_embed(changeset, :parameters)
+  defp maybe_cast_parameters(changeset, "v1.2"), do: cast_embed(changeset, :parameters)
 
   defp validate_recurring(changeset, "v1.0") do
     changeset
     |> put_change(:recurring, true)
     |> validate_inclusion(:recurring, [true])
-    |> validate_required(~w(at branch pipeline_file)a)
+    |> validate_required(~w(at reference pipeline_file)a)
   end
 
   defp validate_recurring(changeset, "v1.1"),
     do: validate_recurring(changeset, "v1.1", get_field(changeset, :recurring))
 
+  defp validate_recurring(changeset, "v1.2"),
+    do: validate_recurring(changeset, "v1.2", get_field(changeset, :recurring))
+
   defp validate_recurring(changeset, "v1.1", true), do: validate_required(changeset, [:at])
   defp validate_recurring(changeset, "v1.1", false), do: changeset
+
+  defp validate_recurring(changeset, "v1.2", true), do: validate_required(changeset, [:at])
+  defp validate_recurring(changeset, "v1.2", false), do: changeset
 
   defp validate_cron(_field_name, cron_expression) do
     case Crontab.CronExpression.Parser.parse(cron_expression) do

--- a/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/history_page.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/history_page.ex
@@ -49,7 +49,8 @@ defmodule Scheduler.PeriodicsTriggers.Model.HistoryPage do
   defp load_page(page = %__MODULE__{}) do
     {triggers, is_last?} = {list_page_triggers(page), is_last_page?(page)}
     {results, {prev, next}} = form_page_result(page, triggers, is_last?)
-    %__MODULE__{page | cursor_before: prev, cursor_after: next, results: results}
+    normalized_results = Enum.map(results, &normalize_reference/1)
+    %__MODULE__{page | cursor_before: prev, cursor_after: next, results: normalized_results}
   end
 
   # constructing page
@@ -190,9 +191,22 @@ defmodule Scheduler.PeriodicsTriggers.Model.HistoryPage do
   defp apply_filter(query, {:triggered_by, triggered_by}),
     do: Ecto.Query.where(query, [dt, s], dt.run_now_requester_id == ^triggered_by)
 
-  defp apply_filter(query, {:branch_name, branch_name}),
-    do: Ecto.Query.where(query, [dt, s], dt.branch == ^branch_name)
+  defp apply_filter(query, {:branch_name, branch_name}) do
+    # Handle both formats: "refs/heads/branch" and "branch"
+    full_ref = "refs/heads/" <> branch_name
+    Ecto.Query.where(query, [dt, s], dt.reference == ^branch_name or dt.reference == ^full_ref)
+  end
+
+  defp apply_filter(query, {:reference, reference}),
+    do: Ecto.Query.where(query, [dt, s], dt.reference == ^reference)
 
   defp apply_filter(query, {:pipeline_file, pipeline_file}),
     do: Ecto.Query.where(query, [dt, s], dt.pipeline_file == ^pipeline_file)
+
+  # Normalize reference field by stripping "refs/heads/" prefix if present
+  defp normalize_reference(trigger = %Trigger{reference: "refs/heads/" <> branch_name}) do
+    %{trigger | reference: branch_name}
+  end
+
+  defp normalize_reference(trigger), do: trigger
 end

--- a/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/history_page.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/history_page.ex
@@ -192,7 +192,6 @@ defmodule Scheduler.PeriodicsTriggers.Model.HistoryPage do
     do: Ecto.Query.where(query, [dt, s], dt.run_now_requester_id == ^triggered_by)
 
   defp apply_filter(query, {:branch_name, branch_name}) do
-    # Handle both formats: "refs/heads/branch" and "branch"
     full_ref = "refs/heads/" <> branch_name
     Ecto.Query.where(query, [dt, s], dt.reference == ^branch_name or dt.reference == ^full_ref)
   end
@@ -203,7 +202,6 @@ defmodule Scheduler.PeriodicsTriggers.Model.HistoryPage do
   defp apply_filter(query, {:pipeline_file, pipeline_file}),
     do: Ecto.Query.where(query, [dt, s], dt.pipeline_file == ^pipeline_file)
 
-  # Normalize reference field by stripping "refs/heads/" prefix if present
   defp normalize_reference(trigger = %Trigger{reference: "refs/heads/" <> branch_name}) do
     %{trigger | reference: branch_name}
   end

--- a/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/history_page.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/history_page.ex
@@ -49,8 +49,7 @@ defmodule Scheduler.PeriodicsTriggers.Model.HistoryPage do
   defp load_page(page = %__MODULE__{}) do
     {triggers, is_last?} = {list_page_triggers(page), is_last_page?(page)}
     {results, {prev, next}} = form_page_result(page, triggers, is_last?)
-    normalized_results = Enum.map(results, &normalize_reference/1)
-    %__MODULE__{page | cursor_before: prev, cursor_after: next, results: normalized_results}
+    %__MODULE__{page | cursor_before: prev, cursor_after: next, results: results}
   end
 
   # constructing page
@@ -191,20 +190,17 @@ defmodule Scheduler.PeriodicsTriggers.Model.HistoryPage do
   defp apply_filter(query, {:triggered_by, triggered_by}),
     do: Ecto.Query.where(query, [dt, s], dt.run_now_requester_id == ^triggered_by)
 
-  defp apply_filter(query, {:branch_name, branch_name}) do
-    full_ref = "refs/heads/" <> branch_name
-    Ecto.Query.where(query, [dt, s], dt.reference == ^branch_name or dt.reference == ^full_ref)
+  defp apply_filter(
+         query,
+         {:reference, %{normalized: normalized, short: short, original: original}}
+       ) do
+    possible_values = [normalized, short, original] |> Enum.uniq()
+    Ecto.Query.where(query, [dt, s], dt.reference in ^possible_values)
   end
 
-  defp apply_filter(query, {:reference, reference}),
+  defp apply_filter(query, {:reference, reference}) when is_binary(reference),
     do: Ecto.Query.where(query, [dt, s], dt.reference == ^reference)
 
   defp apply_filter(query, {:pipeline_file, pipeline_file}),
     do: Ecto.Query.where(query, [dt, s], dt.pipeline_file == ^pipeline_file)
-
-  defp normalize_reference(trigger = %Trigger{reference: "refs/heads/" <> branch_name}) do
-    %{trigger | reference: branch_name}
-  end
-
-  defp normalize_reference(trigger), do: trigger
 end

--- a/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/periodics_triggers.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/periodics_triggers.ex
@@ -18,7 +18,7 @@ defmodule Scheduler.PeriodicsTriggers.Model.PeriodicsTriggers do
     belongs_to :periodics, Periodics, type: Ecto.UUID, foreign_key: :periodic_id
     field :triggered_at, :utc_datetime_usec
     field :project_id, :string
-    field :branch, :string
+    field :reference, :string, source: :branch
     field :pipeline_file, :string
     field :scheduling_status, :string
     field :recurring, :boolean
@@ -32,7 +32,7 @@ defmodule Scheduler.PeriodicsTriggers.Model.PeriodicsTriggers do
     timestamps()
   end
 
-  @required_fields_insert ~w(periodic_id triggered_at project_id branch
+  @required_fields_insert ~w(periodic_id triggered_at project_id reference
                              pipeline_file scheduling_status recurring)a
   @optional_fields_insert ~w(run_now_requester_id)a
 
@@ -50,7 +50,7 @@ defmodule Scheduler.PeriodicsTriggers.Model.PeriodicsTriggers do
 
       iex> alias Scheduler.PeriodicsTriggers.Model.PeriodicsTriggers
       iex> params = %{periodic_id: UUID.uuid1(), triggered_at: DateTime.utc_now(),
-      ...>            branch: "master", project_id: "p1", pipeline_file: "deploy.yml",
+      ...>            reference: "master", project_id: "p1", pipeline_file: "deploy.yml",
       ...>            scheduling_status: "running", recurring: true,
       ...>            parameter_values: [%{name: "p1", value: "v1"}]}
       iex> PeriodicsTriggers.changeset_insert(%PeriodicsTriggers{}, params) |> Map.get(:valid?)

--- a/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/periodics_triggers_queries.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/periodics_triggers_queries.ex
@@ -9,6 +9,7 @@ defmodule Scheduler.PeriodicsTriggers.Model.PeriodicsTriggersQueries do
   alias Scheduler.PeriodicsRepo, as: Repo
   alias Scheduler.Periodics.Model.Periodics
   alias Scheduler.PeriodicsTriggers.Model.PeriodicsTriggers
+  alias Scheduler.Utils.GitReference
   alias LogTee, as: LT
   alias Util.ToTuple
 
@@ -36,14 +37,26 @@ defmodule Scheduler.PeriodicsTriggers.Model.PeriodicsTriggersQueries do
       triggered_at: DateTime.utc_now(),
       project_id: periodic.project_id,
       recurring: periodic.recurring,
-      branch: periodic.branch,
+      reference: periodic.reference,
       pipeline_file: periodic.pipeline_file,
       parameter_values: Periodics.default_parameter_values(periodic),
       scheduling_status: "running",
       run_now_requester_id: params[:requester]
     }
 
-    default_params |> Map.merge(params) |> insert_()
+    merged_params = default_params |> Map.merge(params)
+
+    # Normalize reference field to ensure consistent format
+    normalized_params =
+      case merged_params.reference do
+        ref when is_binary(ref) ->
+          Map.put(merged_params, :reference, GitReference.normalize(ref))
+
+        _ ->
+          merged_params
+      end
+
+    insert_(normalized_params)
   end
 
   defp insert_(params) do

--- a/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/periodics_triggers_queries.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/periodics_triggers/model/periodics_triggers_queries.ex
@@ -46,7 +46,6 @@ defmodule Scheduler.PeriodicsTriggers.Model.PeriodicsTriggersQueries do
 
     merged_params = default_params |> Map.merge(params)
 
-    # Normalize reference field to ensure consistent format
     normalized_params =
       case merged_params.reference do
         ref when is_binary(ref) ->

--- a/periodic_scheduler/scheduler/lib/scheduler/utils/git_reference.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/utils/git_reference.ex
@@ -1,0 +1,129 @@
+defmodule Scheduler.Utils.GitReference do
+  @moduledoc """
+  Utilities for handling Git reference normalization and conversion.
+
+  Git references can come in various formats:
+  - Branch names: "master", "develop", "feature-branch"
+  - Full branch refs: "refs/heads/master", "refs/heads/develop"
+  - Tag refs: "refs/tags/v1.0.0", "refs/tags/release"
+  - PR refs: "refs/pull/123/head"
+  """
+
+  @doc """
+  Normalizes a git reference to its full form.
+
+  ## Examples
+
+      iex> Scheduler.Utils.GitReference.normalize("master")
+      "refs/heads/master"
+
+      iex> Scheduler.Utils.GitReference.normalize("refs/heads/master")
+      "refs/heads/master"
+
+      iex> Scheduler.Utils.GitReference.normalize("refs/tags/v1.0.0")
+      "refs/tags/v1.0.0"
+
+      iex> Scheduler.Utils.GitReference.normalize("refs/pull/123/head")
+      "refs/pull/123/head"
+  """
+  def normalize(reference) when is_binary(reference) do
+    if String.starts_with?(reference, "refs/") do
+      # Already a full reference
+      reference
+    else
+      # Assume it's a branch name and add refs/heads/ prefix
+      "refs/heads/" <> reference
+    end
+  end
+
+  def normalize(nil), do: nil
+
+  @doc """
+  Extracts the short name from a full git reference.
+
+  ## Examples
+
+      iex> Scheduler.Utils.GitReference.extract_name("refs/heads/master")
+      "master"
+
+      iex> Scheduler.Utils.GitReference.extract_name("refs/tags/v1.0.0")
+      "v1.0.0"
+
+      iex> Scheduler.Utils.GitReference.extract_name("refs/pull/123/head")
+      "123/head"
+
+      iex> Scheduler.Utils.GitReference.extract_name("feature-branch")
+      "feature-branch"
+  """
+  def extract_name(reference) when is_binary(reference) do
+    cond do
+      String.starts_with?(reference, "refs/heads/") ->
+        String.replace_prefix(reference, "refs/heads/", "")
+
+      String.starts_with?(reference, "refs/tags/") ->
+        String.replace_prefix(reference, "refs/tags/", "")
+
+      String.starts_with?(reference, "refs/pull/") ->
+        String.replace_prefix(reference, "refs/pull/", "")
+
+      true ->
+        # Not a full reference, return as-is
+        reference
+    end
+  end
+
+  def extract_name(nil), do: nil
+
+  @doc """
+  Builds a full git reference from type and name.
+
+  ## Examples
+
+      iex> Scheduler.Utils.GitReference.build_full_reference("BRANCH", "master")
+      "refs/heads/master"
+
+      iex> Scheduler.Utils.GitReference.build_full_reference("TAG", "v1.0.0")
+      "refs/tags/v1.0.0"
+
+      iex> Scheduler.Utils.GitReference.build_full_reference("PR", "123")
+      "refs/pull/123/head"
+
+      iex> Scheduler.Utils.GitReference.build_full_reference("UNKNOWN", "something")
+      "something"
+  """
+  def build_full_reference("BRANCH", name), do: "refs/heads/" <> name
+  def build_full_reference("TAG", name), do: "refs/tags/" <> name
+  def build_full_reference("PR", name), do: "refs/pull/" <> name <> "/head"
+  def build_full_reference(_unknown_type, name), do: name
+
+  @doc """
+  Determines the type of git reference.
+
+  ## Examples
+
+      iex> Scheduler.Utils.GitReference.get_type("refs/heads/master")
+      :branch
+
+      iex> Scheduler.Utils.GitReference.get_type("refs/tags/v1.0.0")
+      :tag
+
+      iex> Scheduler.Utils.GitReference.get_type("refs/pull/123/head")
+      :pull_request
+
+      iex> Scheduler.Utils.GitReference.get_type("master")
+      :branch
+
+      iex> Scheduler.Utils.GitReference.get_type("refs/invalid")
+      :branch
+  """
+  def get_type(reference) when is_binary(reference) do
+    cond do
+      String.starts_with?(reference, "refs/heads/") -> :branch
+      String.starts_with?(reference, "refs/tags/") -> :tag
+      String.starts_with?(reference, "refs/pull/") -> :pull_request
+      true -> :branch
+    end
+  end
+
+  def get_type(nil), do: nil
+end

--- a/periodic_scheduler/scheduler/lib/scheduler/utils/git_reference.ex
+++ b/periodic_scheduler/scheduler/lib/scheduler/utils/git_reference.ex
@@ -28,10 +28,8 @@ defmodule Scheduler.Utils.GitReference do
   """
   def normalize(reference) when is_binary(reference) do
     if String.starts_with?(reference, "refs/") do
-      # Already a full reference
       reference
     else
-      # Assume it's a branch name and add refs/heads/ prefix
       "refs/heads/" <> reference
     end
   end
@@ -67,7 +65,6 @@ defmodule Scheduler.Utils.GitReference do
         String.replace_prefix(reference, "refs/pull/", "")
 
       true ->
-        # Not a full reference, return as-is
         reference
     end
   end

--- a/periodic_scheduler/scheduler/mix.lock
+++ b/periodic_scheduler/scheduler/mix.lock
@@ -63,7 +63,7 @@
   "tzdata": {:hex, :tzdata, "1.1.1", "20c8043476dfda8504952d00adac41c6eda23912278add38edc140ae0c5bcc46", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "a69cec8352eafcd2e198dea28a34113b60fdc6cb57eb5ad65c10292a6ba89787"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
   "unsafe": {:hex, :unsafe, "1.0.1", "a27e1874f72ee49312e0a9ec2e0b27924214a05e3ddac90e91727bc76f8613d8", [:mix], [], "hexpm", "6c7729a2d214806450d29766abc2afaa7a2cbecf415be64f36a6691afebb50e5"},
-  "util": {:git, "https://github.com/renderedtext/elixir-util.git", "7a35f61a97ea37b8a5861a1e6aa00d39ffb54f12", []},
+  "util": {:git, "https://github.com/renderedtext/elixir-util.git", "34548a46450465b2fc69642d81f3ff282b1aa097", []},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
   "vmstats": {:hex, :vmstats, "2.4.0", "57763d3edc861da2de02b2f0df3adc37e5a140117147937e83908cac40a10c9b", [:rebar3], [], "hexpm", "266f464e64b459f614ed64e25bda270f8a77951868bbaf0e2209274efc3d9b6d"},
   "watchman": {:git, "https://github.com/renderedtext/ex-watchman.git", "b7a205b47a34106a3c865f7dde624381d795a876", []},

--- a/periodic_scheduler/scheduler/test/actions/apply_impl_test.exs
+++ b/periodic_scheduler/scheduler/test/actions/apply_impl_test.exs
@@ -11,6 +11,9 @@ defmodule Test.Actions.ApplyImpl.Test do
 
     start_supervised!(QuantumScheduler)
 
+    # Ensure v1.2 schema is cached for tests that use it
+    GenServer.call(DefinitionValidator.YamlMapValidator.Server, {:cache_schema, "v1.2"})
+
     {:ok, params}
   end
 
@@ -154,6 +157,76 @@ defmodule Test.Actions.ApplyImpl.Test do
     refute periodic_id |> String.to_atom() |> QuantumScheduler.find_job()
   end
 
+  test "apply v1.2 doesn't start quantum job when periodic is non-recurring", ctx do
+    yml_definition = """
+    apiVersion: v1.2
+    kind: Schedule
+    metadata:
+      name: test periodic v1.2
+    spec:
+      project: Project 1
+      recurring: false
+      reference:
+        type: BRANCH
+        name: master
+      at: ""
+      pipeline_file: .semaphore/cron.yml
+      parameters:
+        - name: example
+          description: Exemplary parameter
+          required: true
+          default_value: option1
+          options:
+            - option1
+            - option2
+            - option3
+    """
+
+    assert {:ok, periodic_id} =
+             ApplyImpl.apply(%{
+               organization_id: ctx.org_id,
+               requester_id: ctx.usr_id,
+               yml_definition: yml_definition
+             })
+
+    refute periodic_id |> String.to_atom() |> QuantumScheduler.find_job()
+  end
+
+  test "apply v1.2 does start quantum job when periodic is recurring", ctx do
+    yml_definition = """
+    apiVersion: v1.2
+    kind: Schedule
+    metadata:
+      name: test periodic v1.2
+    spec:
+      project: Project 1
+      recurring: true
+      reference:
+        type: BRANCH
+        name: master
+      at: "0 0 * * *"
+      pipeline_file: .semaphore/cron.yml
+      parameters:
+        - name: example
+          description: Exemplary parameter
+          required: true
+          default_value: option1
+          options:
+            - option1
+            - option2
+            - option3
+    """
+
+    assert {:ok, periodic_id} =
+             ApplyImpl.apply(%{
+               organization_id: ctx.org_id,
+               requester_id: ctx.usr_id,
+               yml_definition: yml_definition
+             })
+
+    assert periodic_id |> String.to_atom() |> QuantumScheduler.find_job()
+  end
+
   defp insert_periodics(ids, extra \\ %{}) do
     %{
       requester_id: ids.usr_id,
@@ -162,7 +235,7 @@ defmodule Test.Actions.ApplyImpl.Test do
       project_name: "Project_1",
       recurring: if(is_nil(extra[:recurring]), do: true, else: extra[:recurring]),
       project_id: ids.pr_id,
-      branch: extra[:branch] || "master",
+      reference: extra[:reference] || "master",
       at: extra[:at] || "0 0 * * *",
       paused: if(is_nil(extra[:paused]), do: false, else: extra[:paused]),
       pipeline_file: extra[:pipeline_file] || "deploy.yml",

--- a/periodic_scheduler/scheduler/test/actions/describe_impl_test.exs
+++ b/periodic_scheduler/scheduler/test/actions/describe_impl_test.exs
@@ -14,7 +14,7 @@ defmodule Test.Actions.DescribeImpl.Test do
                project_name: "Project_1",
                project_id: UUID.uuid4(),
                recurring: true,
-               branch: "master",
+               reference: "master",
                at: "* * * * *",
                pipeline_file: "deploy.yml",
                parameters: [

--- a/periodic_scheduler/scheduler/test/actions/history_impl_test.exs
+++ b/periodic_scheduler/scheduler/test/actions/history_impl_test.exs
@@ -81,7 +81,7 @@ defmodule Test.Actions.HistoryImpl.Test do
 
   test "periodic has many triggers and filters are passed => list page", ctx do
     insert_triggers_for_past(ctx, 60, :minutes)
-    insert_triggers_for_past(ctx, 5, :minutes, branch: "develop")
+    insert_triggers_for_past(ctx, 5, :minutes, reference: "develop")
     insert_triggers_for_past(ctx, 5, :minutes, pipeline_file: ".semaphore/semaphore.yml")
     insert_triggers_for_past(ctx, 5, :minutes, triggered_by: "scheduler")
 

--- a/periodic_scheduler/scheduler/test/actions/persist_impl_test.exs
+++ b/periodic_scheduler/scheduler/test/actions/persist_impl_test.exs
@@ -24,7 +24,7 @@ defmodule Test.Actions.PersistImpl.Test do
         organization_id: ctx.org_id,
         project_id: ctx.pr_id,
         requester_id: ctx.usr_id,
-        branch: "master",
+        reference: "master",
         pipeline_file: ".semaphore/cron.yml",
         at: "",
         parameters: [
@@ -47,7 +47,7 @@ defmodule Test.Actions.PersistImpl.Test do
     assert periodic.project_name == "Project 1"
     assert periodic.project_id == ctx.pr_id
     assert periodic.requester_id == ctx.usr_id
-    assert periodic.branch == "master"
+    assert periodic.reference == "master"
     assert periodic.pipeline_file == ".semaphore/cron.yml"
     refute periodic.at
 
@@ -72,7 +72,7 @@ defmodule Test.Actions.PersistImpl.Test do
         organization_id: ctx.org_id,
         project_id: ctx.pr_id,
         requester_id: ctx.usr_id,
-        branch: "master",
+        reference: "master",
         pipeline_file: ".semaphore/cron.yml",
         at: "0 0 * * *",
         parameters: []
@@ -87,7 +87,7 @@ defmodule Test.Actions.PersistImpl.Test do
     assert periodic.project_name == "Project 1"
     assert periodic.project_id == ctx.pr_id
     assert periodic.requester_id == ctx.usr_id
-    assert periodic.branch == "master"
+    assert periodic.reference == "master"
     assert periodic.pipeline_file == ".semaphore/cron.yml"
     assert periodic.at == "0 0 * * *"
     assert periodic.parameters == []
@@ -112,7 +112,7 @@ defmodule Test.Actions.PersistImpl.Test do
         name: "test periodic new",
         recurring: false,
         requester_id: UUID.uuid4(),
-        branch: "master",
+        reference: "master",
         pipeline_file: ".semaphore/cron.yml",
         at: "",
         parameters: [
@@ -136,7 +136,7 @@ defmodule Test.Actions.PersistImpl.Test do
     assert periodic.project_name == "Project"
     assert periodic.project_id == ctx.pr_id
     assert periodic.requester_id != ctx.usr_id
-    assert periodic.branch == "master"
+    assert periodic.reference == "master"
     assert periodic.pipeline_file == ".semaphore/cron.yml"
     refute periodic.at
 
@@ -169,7 +169,7 @@ defmodule Test.Actions.PersistImpl.Test do
         name: "test periodic new",
         recurring: false,
         requester_id: UUID.uuid4(),
-        branch: "master",
+        reference: "master",
         pipeline_file: ".semaphore/cron.yml",
         at: "",
         parameters: [

--- a/periodic_scheduler/scheduler/test/actions/run_now_impl_test.exs
+++ b/periodic_scheduler/scheduler/test/actions/run_now_impl_test.exs
@@ -60,19 +60,21 @@ defmodule Scheduler.Actions.RunNowImpl.Test do
 
       assert {:ok, %{trigger: trigger}} = RunNowImpl.run_now(run_now_params(periodics))
 
-      assert %{branch: "master", pipeline_file: "deploy.yml", parameter_values: []} = trigger
+      assert %{reference: "refs/heads/master", pipeline_file: "deploy.yml", parameter_values: []} =
+               trigger
     end
 
     test "when periodic has default branch and pipeline file then these are overriden", ctx do
       assert {:ok, periodics} =
-               insert_periodics(ctx.ids, %{branch: "develop", pipeline_file: "test.yml"})
+               insert_periodics(ctx.ids, %{reference: "develop", pipeline_file: "test.yml"})
 
       assert {:ok, %{trigger: trigger}} =
                RunNowImpl.run_now(
-                 run_now_params(periodics, %{branch: "master", pipeline_file: "deploy.yml"})
+                 run_now_params(periodics, %{reference: "master", pipeline_file: "deploy.yml"})
                )
 
-      assert %{branch: "master", pipeline_file: "deploy.yml", parameter_values: []} = trigger
+      assert %{reference: "refs/heads/master", pipeline_file: "deploy.yml", parameter_values: []} =
+               trigger
     end
 
     test "when periodic has required parameters without defaults and value is not provided then returns error",
@@ -284,7 +286,7 @@ defmodule Scheduler.Actions.RunNowImpl.Test do
       project_name: "Project_1",
       recurring: if(is_nil(extra[:recurring]), do: true, else: extra[:recurring]),
       project_id: ids.pr_id,
-      branch: extra[:branch] || "master",
+      reference: extra[:reference] || "master",
       at: extra[:at] || "* * * * *",
       pipeline_file: extra[:pipeline_file] || "deploy.yml",
       parameters: extra[:parameters] || []
@@ -296,7 +298,7 @@ defmodule Scheduler.Actions.RunNowImpl.Test do
     %{
       id: periodic.id,
       requester: extra[:requester_id] || periodic.requester_id,
-      branch: extra[:branch] || "",
+      reference: extra[:reference] || "",
       pipeline_file: extra[:pipeline_file] || "",
       parameter_values: extra[:parameter_values] || []
     }

--- a/periodic_scheduler/scheduler/test/actions/unpause_impl_test.exs
+++ b/periodic_scheduler/scheduler/test/actions/unpause_impl_test.exs
@@ -42,7 +42,7 @@ defmodule Test.Actions.UnpauseImpl.Test do
       project_name: "Project_1",
       recurring: if(is_nil(extra[:recurring]), do: true, else: extra[:recurring]),
       project_id: ids.pr_id,
-      branch: extra[:branch] || "master",
+      reference: extra[:reference] || "master",
       at: extra[:at] || "* * * * *",
       paused: if(is_nil(extra[:paused]), do: false, else: extra[:paused]),
       pipeline_file: extra[:pipeline_file] || "deploy.yml",

--- a/periodic_scheduler/scheduler/test/events_consumers/org_blocked_test.exs
+++ b/periodic_scheduler/scheduler/test/events_consumers/org_blocked_test.exs
@@ -64,7 +64,7 @@ defmodule Scheduler.EventsConsumers.OrgBlocked.Test do
 
   defp valid_yml_definition(params) do
     %{
-      branch: "master",
+      reference: "master",
       at: "0 0 * * * *",
       project: "Project 1",
       name: "P1",

--- a/periodic_scheduler/scheduler/test/periodics/initializer_test.exs
+++ b/periodic_scheduler/scheduler/test/periodics/initializer_test.exs
@@ -36,7 +36,7 @@ defmodule Scheduler.Workers.Initializer.Test do
       name: "Periodic_#{ind}",
       project_name: "Project_1",
       project_id: ids.pr_id,
-      branch: "master",
+      reference: "master",
       at: "* * * * *",
       pipeline_file: "deploy.yml"
     }

--- a/periodic_scheduler/scheduler/test/periodics/model/periodics_test.exs
+++ b/periodic_scheduler/scheduler/test/periodics/model/periodics_test.exs
@@ -13,21 +13,21 @@ defmodule Scheduler.Periodics.Model.Periodics.Test do
       assert [at: {"can't be blank", _}] = errors
 
       full_params =
-        Map.merge(ctx.params, %{at: "* * * * *", branch: "master", pipeline_file: "deploy.yml"})
+        Map.merge(ctx.params, %{at: "* * * * *", reference: "master", pipeline_file: "deploy.yml"})
 
       assert %Ecto.Changeset{valid?: true} =
                Periodics.changeset(%Periodics{}, "v1.1", full_params)
     end
 
-    test "when recurring is true then validates if periodics has cron, branch and pipeline file",
+    test "when recurring is true then validates if periodics has cron, reference and pipeline file",
          ctx do
       partial_params =
-        Map.merge(ctx.params, %{recurring: true}) |> Map.drop(~w(at branch pipeline_file)a)
+        Map.merge(ctx.params, %{recurring: true}) |> Map.drop(~w(at reference pipeline_file)a)
 
       assert %Ecto.Changeset{valid?: false, errors: errors} =
                Periodics.changeset(%Periodics{}, "v1.1", partial_params)
 
-      assert [:at, :branch, :pipeline_file] = errors |> Keyword.keys()
+      assert [:at, :reference, :pipeline_file] = errors |> Keyword.keys()
 
       assert ["can't be blank"] =
                errors |> Keyword.values() |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
@@ -35,7 +35,7 @@ defmodule Scheduler.Periodics.Model.Periodics.Test do
       full_params =
         Map.merge(partial_params, %{
           at: "* * * * *",
-          branch: "master",
+          reference: "master",
           pipeline_file: "deploy.yml"
         })
 
@@ -49,7 +49,7 @@ defmodule Scheduler.Periodics.Model.Periodics.Test do
     end
 
     test "when cron expression is invalid then invalid", ctx do
-      params = Map.merge(ctx.params, %{branch: "master", pipeline_file: "deploy.yml"})
+      params = Map.merge(ctx.params, %{reference: "master", pipeline_file: "deploy.yml"})
 
       invalid_params = Map.put(params, :at, "0 0 * * 12")
 
@@ -71,7 +71,7 @@ defmodule Scheduler.Periodics.Model.Periodics.Test do
        name: "P1",
        project_name: "Pr1",
        project_id: "p1",
-       branch: "master",
+       reference: "master",
        pipeline_file: "deploy.yml",
        id: UUID.uuid1()
      }}

--- a/periodic_scheduler/scheduler/test/periodics_triggers/model/history_page_test.exs
+++ b/periodic_scheduler/scheduler/test/periodics_triggers/model/history_page_test.exs
@@ -415,14 +415,26 @@ defmodule Scheduler.PeriodicsTriggers.Model.HistoryPage.Test do
     end
 
     test "filters for particular branch", ctx do
-      insert_triggers_for_past(ctx, 15..22, :days, branch: "develop")
+      insert_triggers_for_past(ctx, 15..22, :days, reference: "develop")
 
       assert %HistoryPage{results: results} =
                load_page_with_cursor(ctx, {:BEFORE, cursor_ago(ctx, 2, :days)},
                  branch_name: "develop"
                )
 
-      assert Enum.all?(results, &(&1.branch == "develop"))
+      assert Enum.all?(results, &(&1.reference == "develop"))
+      assert Enum.count(results) == 7
+    end
+
+    test "filters for particular branch with new reference format", ctx do
+      insert_triggers_for_past(ctx, 15..22, :days, reference: "refs/heads/develop")
+
+      assert %HistoryPage{results: results} =
+               load_page_with_cursor(ctx, {:BEFORE, cursor_ago(ctx, 2, :days)},
+                 branch_name: "develop"
+               )
+
+      assert Enum.all?(results, &(&1.reference == "develop"))
       assert Enum.count(results) == 7
     end
 

--- a/periodic_scheduler/scheduler/test/periodics_triggers/model/history_page_test.exs
+++ b/periodic_scheduler/scheduler/test/periodics_triggers/model/history_page_test.exs
@@ -419,7 +419,11 @@ defmodule Scheduler.PeriodicsTriggers.Model.HistoryPage.Test do
 
       assert %HistoryPage{results: results} =
                load_page_with_cursor(ctx, {:BEFORE, cursor_ago(ctx, 2, :days)},
-                 branch_name: "develop"
+                 reference: %{
+                   normalized: "refs/heads/develop",
+                   short: "develop",
+                   original: "develop"
+                 }
                )
 
       assert Enum.all?(results, &(&1.reference == "develop"))
@@ -431,10 +435,14 @@ defmodule Scheduler.PeriodicsTriggers.Model.HistoryPage.Test do
 
       assert %HistoryPage{results: results} =
                load_page_with_cursor(ctx, {:BEFORE, cursor_ago(ctx, 2, :days)},
-                 branch_name: "develop"
+                 reference: %{
+                   normalized: "refs/heads/develop",
+                   short: "develop",
+                   original: "develop"
+                 }
                )
 
-      assert Enum.all?(results, &(&1.reference == "develop"))
+      assert Enum.all?(results, &(&1.reference == "refs/heads/develop"))
       assert Enum.count(results) == 7
     end
 

--- a/periodic_scheduler/scheduler/test/support/factory.ex
+++ b/periodic_scheduler/scheduler/test/support/factory.ex
@@ -21,7 +21,7 @@ defmodule Test.Support.Factory do
       project_name: "Project",
       recurring: true,
       pipeline_file: "deploy.yml",
-      branch: "master",
+      reference: "master",
       at: "0 0 * * *",
       name: "Periodic",
       id: UUID.uuid4()
@@ -42,7 +42,7 @@ defmodule Test.Support.Factory do
       periodic_id: context.periodic.id,
       project_id: context.periodic.project_id,
       recurring: context.periodic.recurring,
-      branch: extra[:branch] || context.periodic.branch,
+      reference: extra[:reference] || context.periodic.reference,
       pipeline_file: extra[:pipeline_file] || context.periodic.pipeline_file,
       scheduling_status: extra[:scheduling_status] || "passed",
       run_now_requester_id: extra[:triggered_by] || UUID.uuid4(),

--- a/periodic_scheduler/scheduler/test/support/yaml.ex
+++ b/periodic_scheduler/scheduler/test/support/yaml.ex
@@ -4,14 +4,18 @@ defmodule Support.Yaml do
   """
 
   def valid_definition(params) do
+    version = Map.get(params, :version, "v1.0")
+    branch_or_reference_field = if version == "v1.2", do: "reference", else: "branch"
+    branch_or_reference_value = Map.get(params, :reference, Map.get(params, :branch, "master"))
+
     """
-    apiVersion: v1.0
+    apiVersion: #{version}
     kind: Schedule
     metadata:
       name: #{params.name}
     spec:
       project: #{params.project}
-      branch: #{params.branch}
+      #{branch_or_reference_field}: #{branch_or_reference_value}
       at: #{params.at}
       pipeline_file: #{params.pipeline_file}
     """

--- a/periodic_scheduler/scheduler/test/utils/git_reference_test.exs
+++ b/periodic_scheduler/scheduler/test/utils/git_reference_test.exs
@@ -1,0 +1,97 @@
+defmodule Scheduler.Utils.GitReference.Test do
+  use ExUnit.Case
+  doctest Scheduler.Utils.GitReference
+
+  alias Scheduler.Utils.GitReference
+
+  describe "normalize/1" do
+    test "converts branch name to full reference" do
+      assert GitReference.normalize("master") == "refs/heads/master"
+      assert GitReference.normalize("develop") == "refs/heads/develop"
+      assert GitReference.normalize("feature-branch") == "refs/heads/feature-branch"
+    end
+
+    test "leaves full references unchanged" do
+      assert GitReference.normalize("refs/heads/master") == "refs/heads/master"
+      assert GitReference.normalize("refs/tags/v1.0.0") == "refs/tags/v1.0.0"
+      assert GitReference.normalize("refs/pull/123/head") == "refs/pull/123/head"
+    end
+
+    test "handles nil input" do
+      assert GitReference.normalize(nil) == nil
+    end
+  end
+
+  describe "extract_name/1" do
+    test "extracts branch name from full reference" do
+      assert GitReference.extract_name("refs/heads/master") == "master"
+      assert GitReference.extract_name("refs/heads/develop") == "develop"
+      assert GitReference.extract_name("refs/heads/feature-branch") == "feature-branch"
+    end
+
+    test "extracts tag name from full reference" do
+      assert GitReference.extract_name("refs/tags/v1.0.0") == "v1.0.0"
+      assert GitReference.extract_name("refs/tags/release") == "release"
+    end
+
+    test "extracts PR reference from full reference" do
+      assert GitReference.extract_name("refs/pull/123/head") == "123/head"
+    end
+
+    test "leaves short names unchanged" do
+      assert GitReference.extract_name("master") == "master"
+      assert GitReference.extract_name("develop") == "develop"
+    end
+
+    test "handles nil input" do
+      assert GitReference.extract_name(nil) == nil
+    end
+  end
+
+  describe "build_full_reference/2" do
+    test "builds branch references" do
+      assert GitReference.build_full_reference("BRANCH", "master") == "refs/heads/master"
+      assert GitReference.build_full_reference("BRANCH", "develop") == "refs/heads/develop"
+    end
+
+    test "builds tag references" do
+      assert GitReference.build_full_reference("TAG", "v1.0.0") == "refs/tags/v1.0.0"
+      assert GitReference.build_full_reference("TAG", "release") == "refs/tags/release"
+    end
+
+    test "builds PR references" do
+      assert GitReference.build_full_reference("PR", "123") == "refs/pull/123/head"
+    end
+
+    test "returns name unchanged for unknown types" do
+      assert GitReference.build_full_reference("UNKNOWN", "something") == "something"
+      assert GitReference.build_full_reference("", "test") == "test"
+    end
+  end
+
+  describe "get_type/1" do
+    test "identifies branch references" do
+      assert GitReference.get_type("refs/heads/master") == :branch
+      assert GitReference.get_type("refs/heads/develop") == :branch
+      # short names assumed to be branches
+      assert GitReference.get_type("master") == :branch
+    end
+
+    test "identifies tag references" do
+      assert GitReference.get_type("refs/tags/v1.0.0") == :tag
+      assert GitReference.get_type("refs/tags/release") == :tag
+    end
+
+    test "identifies PR references" do
+      assert GitReference.get_type("refs/pull/123/head") == :pull_request
+    end
+
+    test "handles unknown ref types" do
+      assert GitReference.get_type("refs/unknown/something") == :branch
+    end
+
+    test "handles nil input" do
+      assert GitReference.get_type(nil) == nil
+    end
+  end
+end

--- a/periodic_scheduler/scheduler/test/utils/git_reference_test.exs
+++ b/periodic_scheduler/scheduler/test/utils/git_reference_test.exs
@@ -73,7 +73,6 @@ defmodule Scheduler.Utils.GitReference.Test do
     test "identifies branch references" do
       assert GitReference.get_type("refs/heads/master") == :branch
       assert GitReference.get_type("refs/heads/develop") == :branch
-      # short names assumed to be branches
       assert GitReference.get_type("master") == :branch
     end
 

--- a/periodic_scheduler/spec/priv/v1.2.yml
+++ b/periodic_scheduler/spec/priv/v1.2.yml
@@ -1,0 +1,51 @@
+$schema: http://json-schema.org/draft-04/schema#
+version: v1.2
+title: Semaphore pipeline definition file specification
+type: object
+properties:
+  project:
+    type: string
+  reference:
+    type: object
+    properties:
+      type:
+        type: string
+        enum: [BRANCH, TAG, PR]
+        description: "The type of Git reference"
+      name:
+        type: string
+        description: "The name of the reference (branch name, tag name, or PR number)"
+    additionalProperties: false
+    required: [type, name]
+  at:
+    type: string
+  pipeline_file:
+    type: string
+  paused:
+    type: boolean
+  recurring:
+    type: boolean
+  parameters:
+    type: array
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+        options:
+          type: array
+          items:
+            type: string
+        required:
+          type: boolean
+        default_value:
+          type: string
+        description:
+          type: string
+      additionalProperties: false
+      required: [name, required]
+additionalProperties: false
+required: [project, recurring]
+anyOf:
+  - required: [reference]
+  - required: [branch]


### PR DESCRIPTION
## 📝 Description
  - Adds support for scheduling periodic workflows on Git tags in addition to branches
  - Introduces a new git_reference utility module to handle both branch and tag references
  - Updates the periodic scheduler to accept and process tag-based schedules
  - **gRPC/Protocol buffer updates:** Regenerated protocol buffer definitions to rename `branch` field into `reference`, will still work if caller service uses `branch` field name ([since type and order in api is preserved](https://stackoverflow.com/questions/45431685/protocol-buffer-does-changing-field-name-break-the-message))

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
