### PR TITLE
feat(front): Support tags for tasks and task just run

### DIFF
--- a/front/assets/css/app-semaphore.css
+++ b/front/assets/css/app-semaphore.css
@@ -135,6 +135,133 @@ input[type="radio"][disabled] {
     opacity: 1;
     color: #96A0A6;
 }
+/* TomSelect styling to match form-control exactly */
+.ts-control {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  outline: none;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.5;
+  padding: 4px 10px;
+  padding-right: 24px;
+  border: 0;
+  border-radius: 6px;
+  color: #202b30;
+  background-color: #fff;
+  font-family: "Fakt Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  transition: background 0.1s ease, border-color 0.1s ease;
+  position: relative;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 -1px 1px 0 #e5e8ea;
+  background-position: right 8px center;
+  background-repeat: no-repeat;
+  background-image: url('data:image/svg+xml;utf8,<svg width="6px" height="11px" viewBox="0 0 6 11" xmlns="http://www.w3.org/2000/svg"><path d="M3 0l3 4H0l3-4zm0 11L0 7h6l-3 4z" fill="%233B4148" fill-rule="evenodd"/></svg>');
+}
+
+.ts-control:focus,
+.ts-control.focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #00359f !important;
+  z-index: 4;
+}
+
+.ts-control .ts-placeholder {
+  opacity: 1;
+  color: #96a0a6;
+}
+
+/* Match disabled state */
+.ts-control.disabled,
+.ts-control[disabled] {
+  color: #96a0a6;
+  background-color: #f7fafb;
+  cursor: not-allowed;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+/* Hide TomSelect's default dropdown arrow since we're using the background image */
+.ts-control .ts-dropdown-trigger {
+  display: none;
+}
+
+/* Ensure TomSelect dropdown matches form styling */
+.ts-dropdown {
+  border-radius: 6px;
+  border: 0;
+  box-shadow: rgba(0, 0, 0, 0.35) 0px 6px 30px 3px,
+    rgba(0, 0, 0, 0.08) 0px 0px 0px 1px;
+  font-family: "Fakt Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+}
+
+/* Style TomSelect options to match */
+.ts-dropdown .ts-option {
+  padding: 4px 10px;
+  font-size: 16px;
+  font-size: 1rem;
+}
+
+.ts-dropdown .ts-option.selected {
+  background-color: #00359f;
+  color: white;
+}
+
+.ts-dropdown .ts-option.active {
+  background-color: #cedcff;
+  color: #00359f;
+}
+
+/* Ensure single value display matches */
+.ts-control.single .ts-control-input {
+  padding: 0;
+  margin: 0;
+  background: none;
+  border: none;
+  box-shadow: none;
+  font-size: 16px;
+  font-size: 1rem;
+  color: #202b30;
+  font-family: "Fakt Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+}
+
+/* Ensure input in editing mode maintains proper styling */
+.ts-control.single .ts-control-input input {
+  border: 1px solid #E5E8EA !important;
+  outline: none !important;
+  box-shadow: none !important;
+  background: none !important;
+  font-size: 16px;
+  font-size: 1rem;
+  color: #202B30;
+  font-family: 'Fakt Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}
+
+/* When TomSelect wrapper is in active states, ensure the .ts-control maintains its border */
+.ts-wrapper.dropdown-active .ts-control,
+.ts-wrapper.input-active .ts-control,
+.ts-wrapper.focus .ts-control {
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, .2), inset 0 -1px 1px 0 #E5E8EA !important;
+  border: 0 !important;
+  background-color: #FFF !important;
+  border-radius: 6px !important;
+}
+
+/* Override focus state when dropdown is active to maintain blue focus border */
+.ts-wrapper.focus .ts-control {
+  box-shadow: 0 0 0 2px #00359f !important;
+}
+
+/* Ensure TomSelect control always maintains form-control styling in all states */
+.ts-control,
+.ts-wrapper.dropdown-active .ts-control,
+.ts-wrapper.input-active .ts-control {
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, .2), inset 0 -1px 1px 0 #E5E8EA !important;
+  background-color: #FFF !important;
+  border: 0 !important;
+  border-radius: 6px !important;
+}
 textarea {
     display: block;
     min-height: 50px;

--- a/front/assets/js/tasks/components/target.js
+++ b/front/assets/js/tasks/components/target.js
@@ -1,15 +1,17 @@
 export default {
   init(params) {
-    return new TargetComponent(params.branch, params.pipeline_file)
+    return new TargetComponent(params.branch || params.reference_name, params.pipeline_file, params.reference_type || 'branch')
   }
 }
 
 import { Validator, Rule } from './validation'
 
 class TargetComponent {
-  constructor(branch, pipelineFile) {
+  constructor(referenceName, pipelineFile, referenceType = 'branch') {
+    this.currentReferenceType = referenceType
+
     this.validators = {
-      branch: new Validator('branch', branch, [
+      branch: new Validator('branch', referenceName, [
         new Rule((n) => n.length < 1, 'cannot be empty')
       ]),
       pipelineFile: new Validator('pipelineFile', pipelineFile, [
@@ -19,6 +21,10 @@ class TargetComponent {
 
     this.handleFieldChange('branch')
     this.handleFieldChange('pipelineFile')
+    this.handleReferenceTypeChange()
+    this.updateReferenceLabel()
+    this.updatePlaceholder()
+    this.updateReferenceTypeText()
   }
 
   isValid() {
@@ -35,10 +41,75 @@ class TargetComponent {
   }
 
   handleFieldChange(fieldName) {
-    document
-      .querySelector(`[data-validation-input="${fieldName}"]`)
-      .addEventListener('input', (event) => {
+    const element = document.querySelector(`[data-validation-input="${fieldName}"]`)
+    if (element) {
+      element.addEventListener('input', (event) => {
         this.changeFieldValue(fieldName, event.target.value)
       })
+    }
+  }
+
+  handleReferenceTypeChange() {
+    const referenceTypeInputs = document.querySelectorAll('[data-validation-input="referenceType"]')
+    referenceTypeInputs.forEach(input => {
+      input.addEventListener('change', (event) => {
+        this.changeReferenceType(event.target.value)
+      })
+    })
+  }
+
+  changeReferenceType(referenceType) {
+    this.currentReferenceType = referenceType
+    this.updateReferenceLabel()
+    this.updatePlaceholder()
+    this.updateReferenceTypeText()
+  }
+
+  updateReferenceLabel() {
+    const labelElement = document.querySelector('[data-reference-label]')
+    if (labelElement) {
+      switch (this.currentReferenceType) {
+        case 'tag':
+          labelElement.textContent = 'Tag'
+          break
+        case 'pr':
+          labelElement.textContent = 'Pull Request'
+          break
+        default:
+          labelElement.textContent = 'Branch'
+      }
+    }
+  }
+
+  updateReferenceTypeText() {
+    const textElement = document.querySelector('[data-reference-type-text]')
+    if (textElement) {
+      switch (this.currentReferenceType) {
+        case 'tag':
+          textElement.textContent = 'tag'
+          break
+        case 'pr':
+          textElement.textContent = 'pull request'
+          break
+        default:
+          textElement.textContent = 'branch'
+      }
+    }
+  }
+
+  updatePlaceholder() {
+    const inputElement = document.querySelector('[data-validation-input="branch"]')
+    if (inputElement) {
+      switch (this.currentReferenceType) {
+        case 'tag':
+          inputElement.placeholder = 'e.g. v1.0.0'
+          break
+        case 'pr':
+          inputElement.placeholder = 'e.g. 123'
+          break
+        default:
+          inputElement.placeholder = 'e.g. master'
+      }
+    }
   }
 }

--- a/front/assets/js/tasks/index.js
+++ b/front/assets/js/tasks/index.js
@@ -56,7 +56,8 @@ export class Tasks {
 
   static run() {
     return JustRunForm.init({
-      branch: window.InjectedDataByBackend.Tasks.Branch,
+      referenceType: window.InjectedDataByBackend.Tasks.ReferenceType,
+      referenceName: window.InjectedDataByBackend.Tasks.ReferenceName,
       pipelineFile: window.InjectedDataByBackend.Tasks.PipelineFile,
       parameters: window.InjectedDataByBackend.Tasks.Parameters,
     })

--- a/front/assets/js/workflow_view/switch.js
+++ b/front/assets/js/workflow_view/switch.js
@@ -33,7 +33,7 @@ export var Switch = {
     $("body").on("click", "[promote-button]", function(event) {
       Pollman.stop();
 
-      TargetParams.init();
+      TargetParams.init('[data-promotion-param-name]');
       let button = $(event.currentTarget);
       let switchId = Switch.parentSwitch(button);
       let promotionTarget = Switch.parentPromotionTarget(button);

--- a/front/assets/js/workflow_view/target_params.js
+++ b/front/assets/js/workflow_view/target_params.js
@@ -1,12 +1,12 @@
 import TomSelect from 'tom-select'
 
 export var TargetParams = {
-    init: function () {
-        document.querySelectorAll('[data-promotion-param-name]').forEach((element) => {
+    init: function (selector = null) {
+        document.querySelectorAll(selector).forEach((element) => {
             if (!element.tomselect) {
                 new TomSelect(element, {
                     hidePlaceholder: true,
-                    plugins: ['no_backspace_delete', 'dropdown_input'],
+                    plugins: ['no_backspace_delete'],
                 })
             }
         })

--- a/front/lib/front_web/controllers/schedulers_controller.ex
+++ b/front/lib/front_web/controllers/schedulers_controller.ex
@@ -170,7 +170,8 @@ defmodule FrontWeb.SchedulersController do
         |> Audit.add(description: "Added a periodic scheduler")
         |> Audit.add(resource_name: scheduler_input.name)
         |> Audit.metadata(
-          branch: scheduler_input.branch,
+          reference_name: scheduler_input.reference_name,
+          reference_type: scheduler_input.reference_type,
           project_name: context.project_name,
           pipeline_file: scheduler_input.pipeline_file
         )
@@ -310,7 +311,8 @@ defmodule FrontWeb.SchedulersController do
         |> Audit.add(resource_name: scheduler_input.name)
         |> Audit.add(resource_id: scheduler_id)
         |> Audit.metadata(
-          branch: scheduler_input.branch,
+          reference_name: scheduler_input.reference_name,
+          reference_type: scheduler_input.reference_type,
           project_name: context.project_name,
           pipeline_file: scheduler_input.pipeline_file
         )
@@ -679,7 +681,7 @@ defmodule FrontWeb.SchedulersController do
   defp validate_run_now_parameters(scheduler, parameters) do
     errors =
       []
-      |> validate_run_now_field(parameters, :branch)
+      |> validate_run_now_field(parameters, :reference_name)
       |> validate_run_now_field(parameters, :pipeline_file)
       |> validate_run_now_parameter_values(parameters)
 
@@ -691,7 +693,8 @@ defmodule FrontWeb.SchedulersController do
          errors: [],
          scheduler: scheduler,
          parameters: %{
-           branch: parameters.branch,
+           reference_type: parameters.reference_type,
+           reference_name: parameters.reference_name,
            pipeline_file: parameters.pipeline_file,
            parameter_values: parameter_values
          }
@@ -745,10 +748,13 @@ defmodule FrontWeb.SchedulersController do
 
   defp parse_form_input(params) do
     recurring? = params["recurring"] != "false"
+    reference_type = params["reference_type"] || "branch"
+    reference_name = String.trim(params["reference_name"] || "")
 
     %{
-      at: if(recurring?, do: String.trim(params["at"]), else: ""),
-      branch: params["branch"],
+      at: get_at_value(params, recurring?),
+      reference_type: reference_type,
+      reference_name: reference_name,
       name: params["name"],
       description: params["description"] || "",
       pipeline_file: params["pipeline_file"],
@@ -756,6 +762,9 @@ defmodule FrontWeb.SchedulersController do
       parameters: parse_form_parameters(params["parameters"] || %{})
     }
   end
+
+  defp get_at_value(params, true), do: String.trim(params["at"] || "")
+  defp get_at_value(_params, false), do: ""
 
   defp parse_form_parameters(parameters) do
     parameters |> Map.values() |> Enum.map(&parse_form_input_parameter/1)
@@ -772,23 +781,42 @@ defmodule FrontWeb.SchedulersController do
   end
 
   defp parse_just_run_form_params(params, scheduler) do
-    branch = params["branch"] || scheduler.branch
+    reference_type = params["reference_type"] || "branch"
+
+    reference_name =
+      String.trim(params["reference_name"] || params["branch"] || scheduler.reference_name || "")
+
     pipeline_file = params["pipeline_file"] || scheduler.pipeline_file
     parameter_values = params["parameters"] || %{}
 
     parameters = merge_form_values_with_default_values(scheduler, parameter_values)
-    %{branch: branch, pipeline_file: pipeline_file, parameters: parameters}
+
+    %{
+      reference_type: reference_type,
+      reference_name: reference_name,
+      pipeline_file: pipeline_file,
+      parameters: parameters
+    }
   end
 
   defp parse_just_run_trigger_params(params, scheduler) do
-    branch = params["branch"] || scheduler.branch
+    reference_type = params["reference_type"] || "branch"
+
+    reference_name = String.trim(params["reference_name"] || scheduler.reference_name || "")
+
     pipeline_file = params["pipeline_file"] || scheduler.pipeline_file
 
     parameter_values =
       (params["parameters"] || %{}) |> Map.values() |> Enum.into(%{}, &{&1["name"], &1["value"]})
 
     parameters = merge_form_values_with_default_values(scheduler, parameter_values)
-    %{branch: branch, pipeline_file: pipeline_file, parameters: parameters}
+
+    %{
+      reference_type: reference_type,
+      reference_name: reference_name,
+      pipeline_file: pipeline_file,
+      parameters: parameters
+    }
   end
 
   defp merge_form_values_with_default_values(scheduler, values) do
@@ -890,6 +918,7 @@ defmodule FrontWeb.SchedulersController do
       _ ->
         # Periodic Scheduler returned expected validation error
         # this error is communicated within the form
+        Logger.error("Failed to #{action} the scheduler: #{inspect(message)}")
 
         "Failed to #{action} the scheduler."
     end
@@ -898,7 +927,8 @@ defmodule FrontWeb.SchedulersController do
   defp compose_default_form_values(project_name) do
     %{
       at: "0 0 * * *",
-      branch: "master",
+      reference_type: "branch",
+      reference_name: "master",
       name: "",
       description: "",
       recurring: true,

--- a/front/lib/front_web/templates/schedulers/_trigger.html.eex
+++ b/front/lib/front_web/templates/schedulers/_trigger.html.eex
@@ -2,6 +2,12 @@
   <%= render FrontWeb.SchedulersView, "_workflow.html",
         conn: @conn, workflow: @trigger.workflow %>
   <div class="flex items-center">
+    <%= if @trigger.reference_type && @trigger.reference_name do %>
+      <div class="flex items-center mr2 f6 gray">
+        <span class="material-symbols-outlined f6 mr1"><%= git_ref_icon(@trigger.reference_type) %></span>
+        <span><%= @trigger.reference_name %></span>
+      </div>
+    <% end %>
     <div class="ml2 ml3-m ml0-l mr3-l tr-l f6">
       <%= time_ago(@trigger.triggered_at) %>
       <br>

--- a/front/lib/front_web/templates/schedulers/forms/_target.html.eex
+++ b/front/lib/front_web/templates/schedulers/forms/_target.html.eex
@@ -1,6 +1,7 @@
 <script nonce="<%= @conn.assigns[:script_src_nonce] %>">
     window.InjectedDataByBackend.Tasks.Target = {
-        branch: "<%= @scheduler.branch %>",
+        reference_type: "<%= @scheduler.reference_type || 'branch' %>",
+        reference_name: "<%= @scheduler.reference_name %>",
         pipeline_file: "<%= @scheduler.pipeline_file %>"
     };
 </script>
@@ -14,16 +15,42 @@
     </div>
 <% end %>
 
-<div class="ml2 mt2 mb4" data-validation="branch">
-    <%= label @form, :branch, class: "db b mb2" do %>
-        Branch <span class="gray normal">(overridable)</span>
-    <% end %>
-    <%= hidden_input @form, :id %>
-    <%= hidden_input @form, :unique_token %>
-    <%= text_input @form, :branch, value: @scheduler.branch, class: "form-control w-100 w-50-m",
-        "data-validation-input": "branch", placeholder: "e.g. master" %>
-    <p class="f6 mt1 mb0 nb1">Please ensure that selected branch exists in the repository.</p>
-    <div class="f5 b mv1 red" data-validation-message="branch"></div>
+<div class="ml2 mt2 mb4">
+    <div class="mb3">
+        <div class="mb1"><%= label @form, :reference_type, class: "db b mb2" do %>Reference Type<% end %></div>
+        <div class="flex mb3">
+            <label class="flex items-center mr4">
+                <%= radio_button @form, :reference_type, "branch",
+                      checked: (@scheduler.reference_type || "branch") == "branch",
+                      class: "mr2",
+                      'data-validation-input': "referenceType" %>
+                <span class="f6">Branch</span>
+            </label>
+            <label class="flex items-center">
+                <%= radio_button @form, :reference_type, "tag",
+                      checked: @scheduler.reference_type == "tag",
+                      class: "mr2",
+                      'data-validation-input': "referenceType" %>
+                <span class="f6">Tag</span>
+            </label>
+        </div>
+    </div>
+    <div data-validation="branch">
+        <%= label @form, :reference_name, class: "db b mb2" do %>
+            <span data-reference-label>Branch</span> Name <span class="gray normal">(overridable)</span>
+        <% end %>
+        <%= hidden_input @form, :id %>
+        <%= hidden_input @form, :unique_token %>
+        <% placeholder_text = cond do
+            @scheduler.reference_type == "tag" -> "e.g. v1.0.0"
+            true -> "e.g. master"
+        end %>
+        <%= text_input @form, :reference_name, name: "reference_name", value: @scheduler.reference_name,
+            class: "form-control w-100 w-50-m", "data-validation-input": "branch",
+            placeholder: placeholder_text %>
+        <p class="f6 mt1 mb0 nb1">Please ensure that selected <span data-reference-type-text>branch</span> exists in the repository.</p>
+        <div class="f5 b mv1 red" data-validation-message="branch"></div>
+    </div>
 </div>
 
 <div class="ml2 mt2 mb4" data-validation="pipelineFile">

--- a/front/lib/front_web/templates/schedulers/run.html.eex
+++ b/front/lib/front_web/templates/schedulers/run.html.eex
@@ -3,7 +3,8 @@
   window.InjectedDataByBackend.Tasks.Page = "run";
   window.InjectedDataByBackend.Tasks.CanLoad = <%= @permissions["project.scheduler.view"] %>
 
-  window.InjectedDataByBackend.Tasks.Branch = "<%= @form_params.branch %>";
+  window.InjectedDataByBackend.Tasks.ReferenceType = "<%= @form_params.reference_type || "branch" %>";
+  window.InjectedDataByBackend.Tasks.ReferenceName = "<%= @form_params.reference_name %>";
   window.InjectedDataByBackend.Tasks.PipelineFile = "<%= @form_params.pipeline_file %>";
   window.InjectedDataByBackend.Tasks.Parameters = <%= raw injectable(@form_params.parameters) %>;
 </script>
@@ -36,18 +37,37 @@
             <div class="mb3">
               <h3 class="b lh-title">What will run?</h3>
               <div class="mb4">
-                <div class="mb1"><%= label f, :branch, class: "f6 gray" do %>Branch<% end %></div>
-                <div class="flex flex-column" data-validation="branch">
-                  <%= text_input f, :branch, name: "branch", value: @form_params.branch,
-                        class: "form-control w-100 #{error_css_class(@validation_errors, :branch)}", autocomplete: "off",
-                        'data-validation-input': "branch", placeholder: "Enter a branch…" %>
-                  <div class="f5 b mv1 red" data-validation-message="branch"></div>
+                <div class="mb1"><%= label f, :reference_type, class: "f6 gray" do %>Reference Type<% end %></div>
+                <div class="flex mb3">
+                  <label class="flex items-center mr4">
+                    <%= radio_button f, :reference_type, "branch",
+                          checked: (@form_params.reference_type) == "branch",
+                          class: "mr2",
+                          name: "reference_type",
+                          "data-validation-input": "referenceType" %>
+                    <span class="f6">Branch</span>
+                  </label>
+                  <label class="flex items-center mr4">
+                    <%= radio_button f, :reference_type, "tag",
+                          checked: @form_params.reference_type == "tag",
+                          class: "mr2",
+                          name: "reference_type",
+                          "data-validation-input": "referenceType" %>
+                    <span class="f6">Tag</span>
+                  </label>
+                </div>
+                <div class="mb1"><%= label f, :reference_name, class: "f6 gray" do %><span data-reference-label>Branch</span> Name<% end %></div>
+                <div class="flex flex-column" data-validation="referenceName">
+                  <%= text_input f, :reference_name, name: "reference_name", value: @form_params.reference_name,
+                        class: "form-control w-100 #{error_css_class(@validation_errors, :reference_name)}", autocomplete: "off",
+                        "data-validation-input": "referenceName", placeholder: "Enter a branch or tag name…" %>
+                  <div class="f5 b mv1 red" data-validation-message="referenceName"></div>
                 </div>
                 <div class="mb1 mt3"><%= label f, :pipeline_file, class: "f6 gray" do %>Pipeline<% end %></div>
                 <div class="flex flex-column" data-validation="pipelineFile">
                   <%= text_input f, :pipeline_file, name: "pipeline_file", value: @form_params.pipeline_file,
                         class: "form-control w-100 #{error_css_class(@validation_errors, :pipeline_file)}",
-                        'data-validation-input': "pipelineFile", placeholder: "e.g. .semaphore/semaphore.yml" %>
+                        "data-validation-input": "pipelineFile", placeholder: "e.g. .semaphore/semaphore.yml" %>
                   <div class="f5 b mv1 red" data-validation-message="pipelineFile"></div>
                 </div>
               </div>
@@ -60,12 +80,13 @@
                       <%= hidden_input ff, :name, value: ff.data.name %>
                       <%= if not Enum.empty?(ff.data.options) do %>
                         <%= select ff, :value, ff.data.options, selected: ff.data.value,
-                            'data-validation-input': ff.data.name,
+                            "data-validation-input": ff.data.name,
+                            "data-parameter-select": length(ff.data.options) > 10,
                             class: "db form-control mb3 mb0-m ml3 w-100",
                             prompt: "Choose #{ff.data.name} value" %>
                       <% else %>
                         <%= text_input ff, :value, value: ff.data.value,
-                            'data-validation-input': ff.data.name,
+                            "data-validation-input": ff.data.name,
                             class: "form-control w-100 ml3",
                             placeholder: "Enter value" %>
                       <% end %>
@@ -85,7 +106,7 @@
             </div>
             <div class="flex items-center justify-between">
               <%= link "Cancel", to: schedulers_path(@conn, :index, @project.name), class: "btn btn-secondary" %>
-              <%= submit type: "button", class: "btn btn-primary flex items-center justify-between", 'data-action': "submit-form" do %>
+              <%= submit type: "button", class: "btn btn-primary flex items-center justify-between", "data-action": "submit-form" do %>
                 Run<span class="material-symbols-outlined ml2">play_circle</span>
               <% end %>
             </div>

--- a/front/lib/front_web/templates/schedulers/tasks/details.html.eex
+++ b/front/lib/front_web/templates/schedulers/tasks/details.html.eex
@@ -10,7 +10,7 @@
             <td class="v-top pr2">What will run:</td>
             <td>
               <div class="flex items-center">
-                <span class="material-symbols-outlined f6">fork_right</span>
+                <span class="material-symbols-outlined f6"><%= git_ref_icon(@scheduler.reference_type || "branch") %></span>
                 <%= target_link(@project, @scheduler) %>
               </div>
             </td>

--- a/front/lib/front_web/templates/schedulers/tasks/header.html.eex
+++ b/front/lib/front_web/templates/schedulers/tasks/header.html.eex
@@ -8,7 +8,7 @@
 </div>
 <div class="flex items-center justify-between ">
   <div class="flex items-center mr3">
-    <span class="material-symbols-outlined f6">fork_right</span>
+    <span class="material-symbols-outlined f6"><%= git_ref_icon(@scheduler.reference_type || "branch") %></span>
     <%= target_link(@project, @scheduler) %>
   </div>
   <div class="button-group">

--- a/front/lib/front_web/views/schedulers_view.ex
+++ b/front/lib/front_web/views/schedulers_view.ex
@@ -15,11 +15,14 @@ defmodule FrontWeb.SchedulersView do
   end
 
   def target_link(project, scheduler) do
-    branch = %{type: "branch", name: scheduler.branch, display_name: scheduler.branch}
-    branch_url = human_accessible_repository_url(project, branch)
+    ref_type = scheduler.reference_type || "branch"
+    ref_name = scheduler.reference_name || scheduler.branch || ""
 
-    Phoenix.HTML.Link.link("#{scheduler.branch} > #{scheduler.pipeline_file}",
-      to: branch_url <> "/" <> scheduler.pipeline_file,
+    ref_info = %{type: ref_type, name: ref_name, display_name: ref_name}
+    ref_url = human_accessible_repository_url(project, ref_info)
+
+    Phoenix.HTML.Link.link("#{ref_name} > #{scheduler.pipeline_file}",
+      to: ref_url <> "/" <> scheduler.pipeline_file,
       class: "ml1 db link dark-gray underline-hover"
     )
   end

--- a/front/lib/internal_api/periodic_scheduler.pb.ex
+++ b/front/lib/internal_api/periodic_scheduler.pb.ex
@@ -41,7 +41,7 @@ defmodule InternalApi.PeriodicScheduler.PersistRequest do
           organization_id: String.t(),
           project_name: String.t(),
           requester_id: String.t(),
-          branch: String.t(),
+          reference: String.t(),
           pipeline_file: String.t(),
           at: String.t(),
           parameters: [InternalApi.PeriodicScheduler.Periodic.Parameter.t()],
@@ -56,7 +56,7 @@ defmodule InternalApi.PeriodicScheduler.PersistRequest do
     :organization_id,
     :project_name,
     :requester_id,
-    :branch,
+    :reference,
     :pipeline_file,
     :at,
     :parameters,
@@ -71,7 +71,7 @@ defmodule InternalApi.PeriodicScheduler.PersistRequest do
   field(:organization_id, 6, type: :string)
   field(:project_name, 7, type: :string)
   field(:requester_id, 8, type: :string)
-  field(:branch, 9, type: :string)
+  field(:reference, 9, type: :string)
   field(:pipeline_file, 10, type: :string)
   field(:at, 11, type: :string)
   field(:parameters, 12, repeated: true, type: InternalApi.PeriodicScheduler.Periodic.Parameter)
@@ -160,15 +160,15 @@ defmodule InternalApi.PeriodicScheduler.RunNowRequest do
   @type t :: %__MODULE__{
           id: String.t(),
           requester: String.t(),
-          branch: String.t(),
+          reference: String.t(),
           pipeline_file: String.t(),
           parameter_values: [InternalApi.PeriodicScheduler.ParameterValue.t()]
         }
-  defstruct [:id, :requester, :branch, :pipeline_file, :parameter_values]
+  defstruct [:id, :requester, :reference, :pipeline_file, :parameter_values]
 
   field(:id, 1, type: :string)
   field(:requester, 2, type: :string)
-  field(:branch, 3, type: :string)
+  field(:reference, 3, type: :string)
   field(:pipeline_file, 4, type: :string)
   field(:parameter_values, 5, repeated: true, type: InternalApi.PeriodicScheduler.ParameterValue)
 end
@@ -227,7 +227,7 @@ defmodule InternalApi.PeriodicScheduler.Periodic do
           id: String.t(),
           name: String.t(),
           project_id: String.t(),
-          branch: String.t(),
+          reference: String.t(),
           at: String.t(),
           pipeline_file: String.t(),
           requester_id: String.t(),
@@ -246,7 +246,7 @@ defmodule InternalApi.PeriodicScheduler.Periodic do
     :id,
     :name,
     :project_id,
-    :branch,
+    :reference,
     :at,
     :pipeline_file,
     :requester_id,
@@ -265,7 +265,7 @@ defmodule InternalApi.PeriodicScheduler.Periodic do
   field(:id, 1, type: :string)
   field(:name, 2, type: :string)
   field(:project_id, 3, type: :string)
-  field(:branch, 4, type: :string)
+  field(:reference, 4, type: :string)
   field(:at, 5, type: :string)
   field(:pipeline_file, 6, type: :string)
   field(:requester_id, 7, type: :string)
@@ -308,7 +308,7 @@ defmodule InternalApi.PeriodicScheduler.Trigger do
   @type t :: %__MODULE__{
           triggered_at: Google.Protobuf.Timestamp.t(),
           project_id: String.t(),
-          branch: String.t(),
+          reference: String.t(),
           pipeline_file: String.t(),
           scheduling_status: String.t(),
           scheduled_workflow_id: String.t(),
@@ -321,7 +321,7 @@ defmodule InternalApi.PeriodicScheduler.Trigger do
   defstruct [
     :triggered_at,
     :project_id,
-    :branch,
+    :reference,
     :pipeline_file,
     :scheduling_status,
     :scheduled_workflow_id,
@@ -334,7 +334,7 @@ defmodule InternalApi.PeriodicScheduler.Trigger do
 
   field(:triggered_at, 1, type: Google.Protobuf.Timestamp)
   field(:project_id, 2, type: :string)
-  field(:branch, 3, type: :string)
+  field(:reference, 3, type: :string)
   field(:pipeline_file, 4, type: :string)
   field(:scheduling_status, 5, type: :string)
   field(:scheduled_workflow_id, 6, type: :string)

--- a/front/test/front_web/controllers/schedulers_controller_test.exs
+++ b/front/test/front_web/controllers/schedulers_controller_test.exs
@@ -7,7 +7,8 @@ defmodule FrontWeb.SchedulersControllerTest do
 
   @raw_scheduler_form_params %{
     at: "1 12,00 * * *",
-    branch: "master",
+    reference_type: "branch",
+    reference_name: "master",
     id: "888ea187-ssss-4f41-879d-a30a96faa01e",
     name: "first-scheduler",
     project_name_or_id: "ee2e6241-f30b-4892-a0d5-bd900b713430",
@@ -565,7 +566,7 @@ defmodule FrontWeb.SchedulersControllerTest do
          %{project_name: project_name} do
       changeset = %{
         errors: [
-          branch: "Required. Cannot be empty.",
+          reference: "Required. Cannot be empty.",
           pipeline_file: "Required. Cannot be empty.",
           at: "Required. Cannot be empty."
         ],
@@ -598,7 +599,7 @@ defmodule FrontWeb.SchedulersControllerTest do
         {
           Front.Models.Scheduler,
           [:passthrough],
-          [persist: fn _, _ -> {:error, %{errors: %{branch: "Error about the branch"}}} end]
+          [persist: fn _, _ -> {:error, %{errors: %{reference: "Error about the reference"}}} end]
         }
       ]) do
         conn =
@@ -785,7 +786,7 @@ defmodule FrontWeb.SchedulersControllerTest do
          %{project_name: project_name, scheduler_id: scheduler_id} do
       changeset = %{
         errors: [
-          branch: "Required. Cannot be empty.",
+          reference: "Required. Cannot be empty.",
           pipeline_file: "Required. Cannot be empty.",
           at: "Required. Cannot be empty."
         ],
@@ -846,7 +847,7 @@ defmodule FrontWeb.SchedulersControllerTest do
     test "correctly renders form with default values", %{conn: conn} do
       scheduler =
         prepare_scheduler_for_just_run(
-          branch: "develop",
+          reference: "refs/heads/develop",
           pipeline_file: "pipeline.yml",
           parameters: [
             %{name: "PARAM1", default_value: "VALUE11"},
@@ -880,7 +881,7 @@ defmodule FrontWeb.SchedulersControllerTest do
 
       # imports default values
       assert html_response(conn, 200) =~
-               "placeholder=\"Enter a branch…\" type=\"text\" value=\"\""
+               "placeholder=\"Enter a branch or tag name…\" type=\"text\" value=\"\""
 
       assert html_response(conn, 200) =~
                "placeholder=\"e.g. .semaphore/semaphore.yml\" type=\"text\" value=\"\""
@@ -889,7 +890,7 @@ defmodule FrontWeb.SchedulersControllerTest do
     test "overrides default values with query parameters", %{conn: conn} do
       scheduler =
         prepare_scheduler_for_just_run(
-          branch: "master",
+          reference: "refs/heads/master",
           parameters: [
             %{name: "PARAM1", default_value: "VALUE11"},
             %{name: "PARAM2", options: ["VALUE21", "VALUE22"]},
@@ -900,7 +901,7 @@ defmodule FrontWeb.SchedulersControllerTest do
 
       conn =
         form_just_run(conn, scheduler, %{
-          "branch" => "develop",
+          "reference_name" => "develop",
           "pipeline_file" => ".semaphore/semaphore.yml",
           "parameters" => %{
             "PARAM1" => "VALUE12",
@@ -911,7 +912,7 @@ defmodule FrontWeb.SchedulersControllerTest do
 
       # imports default values
       assert html_response(conn, 200) =~
-               "placeholder=\"Enter a branch…\" type=\"text\" value=\"develop\""
+               "placeholder=\"Enter a branch or tag name…\" type=\"text\" value=\"develop\""
 
       assert html_response(conn, 200) =~
                "placeholder=\"e.g. .semaphore/semaphore.yml\" type=\"text\" value=\".semaphore/semaphore.yml\""
@@ -959,7 +960,11 @@ defmodule FrontWeb.SchedulersControllerTest do
 
     test "when request fails because pipeline queue limit is reached it redirects to index with proper error message",
          %{conn: conn, project_name: project_name} do
-      scheduler = prepare_scheduler_for_just_run(branch: "master", pipeline_file: "pipeline.yml")
+      scheduler =
+        prepare_scheduler_for_just_run(
+          reference: "refs/heads/master",
+          pipeline_file: "pipeline.yml"
+        )
 
       with_mocks([
         {
@@ -987,7 +992,7 @@ defmodule FrontWeb.SchedulersControllerTest do
          %{conn: conn, project_name: project_name} do
       scheduler =
         prepare_scheduler_for_just_run(
-          branch: "master",
+          reference: "refs/heads/master",
           pipeline_file: "pipeline.yml",
           parameters: [
             %{name: "PARAM1", default_value: "VALUE11"},
@@ -999,7 +1004,7 @@ defmodule FrontWeb.SchedulersControllerTest do
 
       conn =
         trigger_just_run(conn, scheduler, %{
-          "branch" => "develop",
+          "reference_name" => "develop",
           "pipeline_file" => "initial.yml",
           "parameters" => %{
             "0" => %{"name" => "PARAM1", "value" => "VALUE1"},
@@ -1013,7 +1018,7 @@ defmodule FrontWeb.SchedulersControllerTest do
       assert get_flash(conn, :notice) == "Workflow started successfully."
       assert [trigger] = DB.find_all_by(:triggers, :periodic_id, scheduler.id)
 
-      assert trigger.api_model.branch == "develop"
+      assert trigger.api_model.reference == "refs/heads/develop"
       assert trigger.api_model.pipeline_file == "initial.yml"
 
       assert parameter_values =
@@ -1031,7 +1036,7 @@ defmodule FrontWeb.SchedulersControllerTest do
          %{conn: conn, project_name: project_name} do
       scheduler =
         prepare_scheduler_for_just_run(
-          branch: "master",
+          reference: "refs/heads/master",
           pipeline_file: "pipeline.yml",
           parameters: [
             %{name: "PARAM1", default_value: "VALUE11"},
@@ -1047,7 +1052,7 @@ defmodule FrontWeb.SchedulersControllerTest do
       assert get_flash(conn, :notice) == "Workflow started successfully."
       assert [trigger] = DB.find_all_by(:triggers, :periodic_id, scheduler.id)
 
-      assert trigger.api_model.branch == "master"
+      assert trigger.api_model.reference == "refs/heads/master"
       assert trigger.api_model.pipeline_file == "pipeline.yml"
 
       assert parameter_values =
@@ -1061,7 +1066,7 @@ defmodule FrontWeb.SchedulersControllerTest do
              } == parameter_values
     end
 
-    test "fails if branch is not given",
+    test "fails if reference is not given",
          %{conn: conn, project_name: _project_name} do
       scheduler =
         prepare_scheduler_for_just_run(
@@ -1081,7 +1086,7 @@ defmodule FrontWeb.SchedulersControllerTest do
          %{conn: conn, project_name: _project_name} do
       scheduler =
         prepare_scheduler_for_just_run(
-          branch: "master",
+          reference: "refs/heads/master",
           parameters: [
             %{name: "PARAM1", default_value: "VALUE11"}
           ]
@@ -1097,7 +1102,7 @@ defmodule FrontWeb.SchedulersControllerTest do
          %{conn: conn, project_name: _project_name} do
       scheduler =
         prepare_scheduler_for_just_run(
-          branch: "master",
+          reference: "refs/heads/master",
           pipeline_file: "pipeline.yml",
           parameters: [
             %{name: "PARAM1", required: true}
@@ -1119,7 +1124,7 @@ defmodule FrontWeb.SchedulersControllerTest do
       name: "JustRun Scheduler",
       recurring: false,
       at: "",
-      branch: "",
+      reference: "",
       pipeline_file: "",
       parameters: []
     ]


### PR DESCRIPTION
## 📝 Description
- Small improvement: search dropdown on `run_now` page if parameter has more than 10 possible values
- Support for tags on schedulers/tasks
- protobuf refresh
- DB stub update fixes flaky browser tests in promotions:
  - [test when deployment targets are enabled when target has deployment target that blocks promotion
](https://semaphore.semaphoreci.com/projects/semaphore/flaky_tests/028249c9-90ad-38c3-9fa3-55ddf43195c1)
  - [test when deployment targets are enabled when target has deployment target that allows promotion](https://semaphore.semaphoreci.com/projects/semaphore/flaky_tests/3c1225ae-7037-3a06-be84-47fe841887fc)
 
## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
