### PR TITLE
feat(front): add organization_id to workflow query params

### DIFF
--- a/front/lib/front_web/controllers/dashboard_controller.ex
+++ b/front/lib/front_web/controllers/dashboard_controller.ex
@@ -77,7 +77,7 @@ defmodule FrontWeb.DashboardController do
     end
   end
 
-  defp params(conn, page_token, direction, filters, project_ids) do
+  defp params(conn, page_token, direction, filters, project_ids, org_id) do
     user_id = conn.assigns.user_id
     direction = map_workflow_direction(direction)
 
@@ -90,7 +90,8 @@ defmodule FrontWeb.DashboardController do
       page_token: page_token,
       direction: direction,
       created_after: time,
-      project_ids: project_ids
+      project_ids: project_ids,
+      organization_id: org_id
     ]
     |> inject_requester(filters.requester, user_id)
   end
@@ -118,7 +119,7 @@ defmodule FrontWeb.DashboardController do
     {:ok, project_ids} = Front.RBAC.Members.list_accessible_projects(org_id, user_id)
 
     filters = %{requester: requester}
-    params = params(conn, page_token, direction, filters, project_ids)
+    params = params(conn, page_token, direction, filters, project_ids, org_id)
 
     {workflows, next_page_token, previous_page_token} = list_workflows(params)
 
@@ -140,7 +141,8 @@ defmodule FrontWeb.DashboardController do
       params: [
         page_token: page_token,
         direction: direction,
-        requester: requester
+        requester: requester,
+        organization_id: org_id
       ]
     }
 
@@ -525,7 +527,7 @@ defmodule FrontWeb.DashboardController do
         Front.RBAC.Members.list_accessible_projects(org_id, user_id)
       end)
 
-    params = params(conn, page_token, direction, filters, project_ids)
+    params = params(conn, page_token, direction, filters, project_ids, org_id)
 
     {workflows, next_page_token, previous_page_token} =
       Watchman.benchmark("home_page.list_workflows", fn ->
@@ -550,7 +552,8 @@ defmodule FrontWeb.DashboardController do
       params: [
         page_token: page_token,
         direction: direction,
-        requester: filters.requester
+        requester: filters.requester,
+        organization_id: org_id
       ]
     }
 


### PR DESCRIPTION
## 📝 Description

This change ensures that `organization_id` is included when listing workflows. By providing `organization_id` the backend can leverage more selective indexes, which should improve query planning and performance.

See [related task](https://github.com/renderedtext/tasks/issues/8617).

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
