### PR TITLE
fix: notifications processing crash for task triggered pipelines

### DIFF
--- a/notifications/lib/notifications/workers/coordinator.ex
+++ b/notifications/lib/notifications/workers/coordinator.ex
@@ -102,7 +102,7 @@ defmodule Notifications.Workers.Coordinator do
     end
 
     defp extract_references(pipeline, nil), do: extract_references_from_pipeline(pipeline)
-    defp extract_references(_pipeline, %{git_ref_type: :TAG} = hook), do: {hook.tag_name, nil, ""}
+    defp extract_references(_pipeline, hook = %{git_ref_type: :TAG}), do: {hook.tag_name, nil, ""}
     defp extract_references(pipeline, hook), do: {nil, pipeline.branch_name, hook.pr_branch_name}
 
     defp extract_references_from_pipeline(%{branch_name: "refs/tags" <> tag_name}),


### PR DESCRIPTION
## 📝 Description
For task runs there is no hook -> failed processing of pipeline finished message, this fixes the issue and takes if possible tag and pr names from hook, otherwise falls back to pipeline data.

#### `logs`
```
INFO 2025-09-22T15:18:44.605829774Z [resource.labels.containerName: notifications] ** (UndefinedFunctionError) function nil.git_ref_type/0 is undefined
INFO 2025-09-22T15:18:44.605831724Z [resource.labels.containerName: notifications] nil.git_ref_type()
INFO 2025-09-22T15:18:44.605834104Z [resource.labels.containerName: notifications] (notifications 0.1.0) lib/notifications/workers/coordinator.ex:29: anonymous fn/1 in Notifications.Workers.Coordinator.PipelineFinished.handle_message/1
```
this issue was present before https://github.com/semaphoreio/semaphore/pull/591 was merged also:
```
INFO 2025-09-22T12:33:05.523589599Z [resource.labels.containerName: notifications] ** (UndefinedFunctionError) function nil.pr_branch_name/0 is undefined
INFO 2025-09-22T12:33:15.596608567Z [resource.labels.containerName: notifications] ** (UndefinedFunctionError) function nil.pr_branch_name/0 is undefined
INFO 2025-09-22T12:33:25.758473405Z [resource.labels.containerName: notifications] ** (UndefinedFunctionError) function nil.pr_branch_name/0 is undefined
```
## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
