### PR TITLE
fix(public-api/v1alpha): run_now allowed without branch and reference  fields

### DIFF
--- a/public-api/v1alpha/lib/pipelines_api/schedules/run_now.ex
+++ b/public-api/v1alpha/lib/pipelines_api/schedules/run_now.ex
@@ -71,11 +71,9 @@ defmodule PipelinesAPI.Schedules.RunNow do
 
   defp normalize_reference_params(params) do
     cond do
-      # New reference format
       params["reference"] ->
         {:ok, params}
 
-      # Legacy branch format - convert to reference
       params["branch"] ->
         reference = %{
           "type" => "BRANCH",
@@ -89,9 +87,8 @@ defmodule PipelinesAPI.Schedules.RunNow do
 
         {:ok, updated_params}
 
-      # No reference information provided
       true ->
-        {:error, "Either 'reference' or 'branch' parameter is required"}
+        {:ok, params}
     end
   end
 
@@ -111,6 +108,8 @@ defmodule PipelinesAPI.Schedules.RunNow do
         {:error, "Reference must contain 'type' and 'name' fields"}
     end
   end
+
+  defp validate_reference_params(params), do: {:ok, params}
 
   # Enhanced error handling
 

--- a/public-api/v1alpha/test/router/schedules/run_now_test.exs
+++ b/public-api/v1alpha/test/router/schedules/run_now_test.exs
@@ -149,7 +149,7 @@ defmodule PipelinesAPI.Schedules.RunNow.Test do
              post_run_now(params, scheduler.id, 400, false)
   end
 
-  test "POST /schedules/:id/run_now - fails when both reference and branch are missing" do
+  test "POST /schedules/:id/run_now - success when both reference and branch are missing" do
     org = Support.Stubs.Organization.create_default()
     user = Support.Stubs.User.create_default()
     project = Support.Stubs.Project.create(org, user)
@@ -159,8 +159,10 @@ defmodule PipelinesAPI.Schedules.RunNow.Test do
       "pipeline_file" => ".semaphore/semaphore.yml"
     }
 
-    assert "\"Either 'reference' or 'branch' parameter is required\"" =
-             post_run_now(params, scheduler.id, 400, false)
+    assert %{"workflow_id" => workflow_id} = post_run_now(params, scheduler.id, 200)
+    assert {:ok, _} = UUID.info(workflow_id)
+
+    assert Support.Stubs.DB.find_all_by(:triggers, :periodic_id, scheduler.id) |> Enum.count() > 0
   end
 
   test "POST /schedules/:id/run_now - fails with empty reference name" do


### PR DESCRIPTION
## 📝 Description
The previously expected behavior of the run_now action was that the branch parameter was optional. If not specified, it would default to the branch defined in the task.

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
