### PR TITLE
  fix(public-api/v1alpha): handle empty reference fields correctly

### DIFF
--- a/public-api/v1alpha/test/periodic_scheduler_client/request_formatter_test.exs
+++ b/public-api/v1alpha/test/periodic_scheduler_client/request_formatter_test.exs
@@ -206,7 +206,7 @@ defmodule PipelinesAPI.PeriodicSchedulerClient.RequestFormatter.Test do
 
     assert request.id == params["periodic_id"]
     assert request.requester == "test_user"
-    assert request.reference == "refs/heads/"
+    assert request.reference == ""
     assert request.pipeline_file == ""
     assert request.parameter_values == []
   end


### PR DESCRIPTION
## 📝 Description
If reference and branch are both empty in request the run_now request should also be empty

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
