### PR TITLE
metrics(zebra): add 7-day filter to stuck jobs query

### DIFF
--- a/zebra/lib/zebra/monitor.ex
+++ b/zebra/lib/zebra/monitor.ex
@@ -212,6 +212,7 @@ defmodule Zebra.Monitor do
   def stuck_jobs do
     from(j in Job,
       where: j.aasm_state == "started",
+      where: j.started_at > date_add(^Date.utc_today(), -7, "day"),
       where:
         fragment(
           "extract(epoch from ?) + coalesce(?, ?)",


### PR DESCRIPTION
## 📝 Description
The `stuck_jobs` query was updated to only include jobs started within the last 7 days. This prevents stale jobs from accumulating in the metric and triggering false alarms, making the metric more accurate for real time monitoring.

More in [this issue](https://github.com/renderedtext/tasks/issues/8656).

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
