### PR TITLE
fix(front): Remove mermaid sandboxing as it conflicts with csp

### DIFF
--- a/front/assets/js/report/index.tsx
+++ b/front/assets/js/report/index.tsx
@@ -9,7 +9,7 @@ import DOMPurify from 'dompurify';
 import * as toolbox from "js/toolbox";
 import { useEffect, useState } from "preact/hooks";
 
-Mermaid.initialize({ startOnLoad: false, theme: `default`, securityLevel: `sandbox` });
+Mermaid.initialize({ startOnLoad: false, theme: `default`, securityLevel: `strict` });
 const md = MarkdownIt({
   html: true,
   linkify: false,


### PR DESCRIPTION
## 📝 Description
Default sandboxing provided by mermaid-js is not compatible with our CSPs since it uses src=`data:...`  to forward the content that should be rendered in the iframe, so we're falling back to `secure`.

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
