### PR TITLE
feat(front): add configurable status page URL for error handling and layout

### DIFF
--- a/front/config/runtime.exs
+++ b/front/config/runtime.exs
@@ -183,3 +183,7 @@ config :front,
        System.get_env("SINGLE_TENANT") == "true"
 
 config :front, :edition, edition
+
+config :front,
+       :status_page_url,
+       System.get_env("STATUS_PAGE_URL") || "https://status.semaphore.io/"

--- a/front/lib/front_web/templates/error/500.html.eex
+++ b/front/lib/front_web/templates/error/500.html.eex
@@ -56,7 +56,7 @@
       <div class="mw6 center br3 shadow-1 pv5 bg-white ph3">
         <h1 class="fw3 lh-solid mb3" style="font-size: 112px">500</h1>
         <h2 class="f4 fw5 black-80 mb0">There’s a problem with Semaphore</h2>
-        <p class="f4 black-80 mb3=0">Try again or check <a href="https://status.<%= Application.fetch_env!(:front, :domain) %>" class="link black-50 hover-black-80">Semaphore Status →</a></p>
+        <p class="f4 black-80 mb3=0">Try again or check <a href="<%= Application.fetch_env!(:front, :status_page_url) %>" class="link black-50 hover-black-80">Semaphore Status →</a></p>
       </div>
     </div>
 

--- a/front/lib/front_web/templates/layout/_page_header.html.eex
+++ b/front/lib/front_web/templates/layout/_page_header.html.eex
@@ -127,7 +127,7 @@
       <%= support_requests_card(@conn, @layout_model) %>
       <%= render FrontWeb.LayoutView, "page_header/_menu_card.html",
             options: [target: "_blank", rel: "noopener"],
-            card_url: "https://status.#{Application.fetch_env!(:front, :domain)}",
+            card_url: Application.fetch_env!(:front, :status_page_url),
             card_title: "Status",
             card_description: "Live system health",
             tooltip: false %>


### PR DESCRIPTION
## 📝 Description

Makes status page URL configurable via environment variable with default value of https://status.semaphore.io/ instead of constructing it from domain. Updated templates.

Check this [task](https://github.com/renderedtext/tasks/issues/8781).

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
