### PR TITLE
fix: add missing google auth dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ configure.sign:
 		--credential-source-file=/tmp/oidc_token \
 		--credential-source-type="text" && \
 	export GOOGLE_APPLICATION_CREDENTIALS=/home/semaphore/creds.json && \
-	pip install google-cloud-iam && \
+	pip install packaging google-cloud-iam && \
 	$(ROOT_MAKEFILE_PATH)/get_id_token.py $$GOOGLE_PROJECT_NAME ci-image-signer > /tmp/sigstore-token
 
 registry.push:


### PR DESCRIPTION
## 📝 Description
New version of google-cloud-iam dependency(google-api-core v2.28.0) introduced a dependency that's not installed([#1](https://github.com/googleapis/python-api-core/issues/848)). This PR fixes this.


## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
