### PR TITLE
fix: use first available python in path

### DIFF
--- a/get_id_token.py
+++ b/get_id_token.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # The gcloud auth print-identity-token command does not work
 # for external account (workload identity federation).


### PR DESCRIPTION
## 📝 Description
Updated `get_id_token.py` to use `#!/usr/bin/env python3`, so the runner now picks up whatever Python is first on `PATH`

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
