### PR TITLE
docs(cache): fix cache key order from most specific to least specific

### DIFF
--- a/docs/docs/using-semaphore/cache.md
+++ b/docs/docs/using-semaphore/cache.md
@@ -144,9 +144,9 @@ Since *keys are not overwritten*, it's recommended to add a unique identifier fo
 
 ```shell
 # store
-cache store gems-master,gems-$SEMAPHORE_GIT_BRANCH,gems-$(checksum Gemfile.lock) vendor/bundle
+cache store gems-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH,gems-master vendor/bundle
 # retrieve
-cache restore gems-master,gems-$SEMAPHORE_GIT_BRANCH,gems-$(checksum Gemfile.lock) 
+cache restore gems-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH,gems-master 
 ```
 
 ### Managing cache space

--- a/docs/versioned_docs/version-CE-1.4/using-semaphore/cache.md
+++ b/docs/versioned_docs/version-CE-1.4/using-semaphore/cache.md
@@ -144,9 +144,9 @@ Since *keys are not overwritten*, it's recommended to add a unique identifier fo
 
 ```shell
 # store
-cache store gems-master,gems-$SEMAPHORE_GIT_BRANCH,gems-$(checksum Gemfile.lock) vendor/bundle
+cache store gems-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH,gems-master vendor/bundle
 # retrieve
-cache restore gems-master,gems-$SEMAPHORE_GIT_BRANCH,gems-$(checksum Gemfile.lock) 
+cache restore gems-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH,gems-master 
 ```
 
 ### Managing cache space

--- a/docs/versioned_docs/version-CE/using-semaphore/cache.md
+++ b/docs/versioned_docs/version-CE/using-semaphore/cache.md
@@ -144,9 +144,9 @@ Since *keys are not overwritten*, it's recommended to add a unique identifier fo
 
 ```shell
 # store
-cache store gems-master,gems-$SEMAPHORE_GIT_BRANCH,gems-$(checksum Gemfile.lock) vendor/bundle
+cache store gems-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH,gems-master vendor/bundle
 # retrieve
-cache restore gems-master,gems-$SEMAPHORE_GIT_BRANCH,gems-$(checksum Gemfile.lock) 
+cache restore gems-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH,gems-master 
 ```
 
 ### Managing cache space

--- a/docs/versioned_docs/version-EE-1.4/using-semaphore/cache.md
+++ b/docs/versioned_docs/version-EE-1.4/using-semaphore/cache.md
@@ -144,9 +144,9 @@ Since *keys are not overwritten*, it's recommended to add a unique identifier fo
 
 ```shell
 # store
-cache store gems-master,gems-$SEMAPHORE_GIT_BRANCH,gems-$(checksum Gemfile.lock) vendor/bundle
+cache store gems-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH,gems-master vendor/bundle
 # retrieve
-cache restore gems-master,gems-$SEMAPHORE_GIT_BRANCH,gems-$(checksum Gemfile.lock) 
+cache restore gems-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH,gems-master 
 ```
 
 ### Managing cache space

--- a/docs/versioned_docs/version-EE/using-semaphore/cache.md
+++ b/docs/versioned_docs/version-EE/using-semaphore/cache.md
@@ -144,9 +144,9 @@ Since *keys are not overwritten*, it's recommended to add a unique identifier fo
 
 ```shell
 # store
-cache store gems-master,gems-$SEMAPHORE_GIT_BRANCH,gems-$(checksum Gemfile.lock) vendor/bundle
+cache store gems-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH,gems-master vendor/bundle
 # retrieve
-cache restore gems-master,gems-$SEMAPHORE_GIT_BRANCH,gems-$(checksum Gemfile.lock) 
+cache restore gems-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH,gems-master 
 ```
 
 ### Managing cache space


### PR DESCRIPTION
## Description

Fixes the order of cache keys in the cache documentation to prioritize most specific matches first.

## Changes

Reordered cache keys in all documentation versions:
- `gems-$(checksum Gemfile.lock)` - most specific (exact dependency match)
- `gems-$SEMAPHORE_GIT_BRANCH` - branch-specific  
- `gems-master` - fallback

This ensures Semaphore restores the most appropriate cache entry when multiple keys match, providing the best match for the current context.

## Files Changed

- docs/docs/using-semaphore/cache.md
- docs/versioned_docs/version-CE-1.4/using-semaphore/cache.md
- docs/versioned_docs/version-CE/using-semaphore/cache.md
- docs/versioned_docs/version-EE-1.4/using-semaphore/cache.md
- docs/versioned_docs/version-EE/using-semaphore/cache.md