### PR TITLE
toil(secrethub): set cache max-age to 15 minutes for openid-configuration endpoint

### DIFF
--- a/secrethub/lib/secrethub/open_id_connect/http_server.ex
+++ b/secrethub/lib/secrethub/open_id_connect/http_server.ex
@@ -57,7 +57,7 @@ defmodule Secrethub.OpenIDConnect.HTTPServer do
       conn
       |> put_resp_header(
         "cache-control",
-        "max-age=#{@openid_configuration_cache_max_age}, private, must-revalidate"
+        "public, max-age=#{@openid_configuration_cache_max_age}, must-revalidate"
       )
       |> json(200, configuration)
     end)

--- a/secrethub/test/secrethub/open_id_connect/http_server_test.exs
+++ b/secrethub/test/secrethub/open_id_connect/http_server_test.exs
@@ -34,7 +34,7 @@ defmodule Secrethub.OpenIDConnect.HTTPServerTest do
       {:ok, response} = request("/.well-known/openid-configuration")
 
       assert response.status_code == 200
-      assert {"cache-control", "max-age=900, private, must-revalidate"} in response.headers
+      assert {"cache-control", "public, max-age=900, must-revalidate"} in response.headers
 
       {:ok, body} = Poison.decode(response.body)
 


### PR DESCRIPTION
## 📝 Description

- We now set a 15‑minute cache window for the OpenID discovery document and mark the response as publicly cacheable, so clients can reuse it instead of re-fetching every time.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
