### PR TITLE
fix(secrethub): align cache headers for OIDC well-known endpoints

### DIFF
--- a/secrethub/test/secrethub/open_id_connect/http_server_test.exs
+++ b/secrethub/test/secrethub/open_id_connect/http_server_test.exs
@@ -34,7 +34,8 @@ defmodule Secrethub.OpenIDConnect.HTTPServerTest do
       {:ok, response} = request("/.well-known/openid-configuration")
 
       assert response.status_code == 200
-      assert {"cache-control", "public, max-age=900, must-revalidate"} in response.headers
+
+      assert {"cache-control", "max-age=900, public, must-revalidate"} in response.headers
 
       {:ok, body} = Poison.decode(response.body)
 
@@ -49,6 +50,8 @@ defmodule Secrethub.OpenIDConnect.HTTPServerTest do
 
       assert response.status_code == 200
 
+      assert {"cache-control", "max-age=900, public, must-revalidate"} in response.headers
+
       {:ok, body} = Poison.decode(response.body)
 
       assert body == %{"keys" => Secrethub.OpenIDConnect.KeyManager.public_keys(:openid_keys)}
@@ -58,6 +61,8 @@ defmodule Secrethub.OpenIDConnect.HTTPServerTest do
       {:ok, response} = HTTPoison.get("#{@host}/.well-known/jwks")
 
       assert response.status_code == 200
+
+      assert {"cache-control", "max-age=900, public, must-revalidate"} in response.headers
 
       {:ok, body} = Poison.decode(response.body)
 
@@ -76,6 +81,16 @@ defmodule Secrethub.OpenIDConnect.HTTPServerTest do
       end)
     end
 
+    test "GET /.well-known/openid-configuration" do
+      {:ok, response} = request("/.well-known/openid-configuration")
+
+      assert response.status_code == 200
+
+      cache_max_age = Application.fetch_env!(:secrethub, :openid_keys_cache_max_age_in_s)
+
+      assert {"cache-control", "max-age=#{cache_max_age}, public, must-revalidate"} in response.headers
+    end
+
     test "GET /.well-known/jwks" do
       {:ok, response} = HTTPoison.get("#{@host}/.well-known/jwks")
 
@@ -83,7 +98,7 @@ defmodule Secrethub.OpenIDConnect.HTTPServerTest do
 
       cache_max_age = Application.fetch_env!(:secrethub, :openid_keys_cache_max_age_in_s)
 
-      assert {"cache-control", "max-age=#{cache_max_age}, private, must-revalidate"} in response.headers
+      assert {"cache-control", "max-age=#{cache_max_age}, public, must-revalidate"} in response.headers
 
       {:ok, body} = Poison.decode(response.body)
 
@@ -97,7 +112,7 @@ defmodule Secrethub.OpenIDConnect.HTTPServerTest do
 
       cache_max_age = Application.fetch_env!(:secrethub, :openid_keys_cache_max_age_in_s)
 
-      assert {"cache-control", "max-age=#{cache_max_age}, private, must-revalidate"} in response.headers
+      assert {"cache-control", "max-age=#{cache_max_age}, public, must-revalidate"} in response.headers
 
       {:ok, body} = Poison.decode(response.body)
 


### PR DESCRIPTION
## 📝 Description
We now set a 15‑minute cache window for the JWKS well‑known endpoints and mark their responses as publicly cacheable, so clients can reuse the key set instead of re-fetching on every request.

Related [task](https://github.com/renderedtext/tasks/issues/8900).

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
