### PR TITLE
docs(env-vars): clarify SEMAPHORE_WORKFLOW_NUMBER behavior

### DIFF
--- a/docs/docs/reference/env-vars.md
+++ b/docs/docs/reference/env-vars.md
@@ -204,9 +204,9 @@ The workflow unique identifier. All jobs belonging to all pipelines in the workf
 - **Environment variable**: `SEMAPHORE_WORKFLOW_NUMBER`
 - **Example**: `42`
 
-This number is incremented every time the workflow runs. In other words, the number is incremented by one every time there is a Git push on any branch, every time there is a pull request, or a tag is pushed to the repository. It doesn't increment with debug jobs.
+This value tracks how many workflows have run for the current branch, tag, or pull request. Each context starts at `1`, and the counter increases by one on every push or workflow rerun within that same branch, tag, or pull request. Debug jobs do not increment the number.
 
-This number is available to all jobs in all pipelines belonging to the same workflow. This includes the initial pipeline and all manually or auto-promoted pipelines in the same build.
+The value remains constant during a workflow run and is available to all jobs in every pipeline that belongs to the workflow, including the initial pipeline and any manually or auto-promoted pipelines in the same build.
 
 ### Workflow is rerun {#workflow-rerun}
 

--- a/docs/versioned_docs/version-CE-1.4/reference/env-vars.md
+++ b/docs/versioned_docs/version-CE-1.4/reference/env-vars.md
@@ -177,9 +177,9 @@ The workflow unique identifier. All jobs belonging to all pipelines in the workf
 - **Environment variable**: `SEMAPHORE_WORKFLOW_NUMBER`
 - **Example**: `42`
 
-This number is incremented every time the workflow runs. In other words, the number is incremented by one every time there is a Git push on any branch, every time there is a pull request, or a tag is pushed to the repository. It doesn't increment with debug jobs.
+This value tracks how many workflows have run for the current branch, tag, or pull request. Each context starts at `1`, and the counter increases by one on every push or workflow rerun within that same branch, tag, or pull request. Debug jobs do not increment the number.
 
-This number is available to all jobs in all pipelines belonging to the same workflow. This includes the initial pipeline and all manually or auto-promoted pipelines in the same build.
+The value remains constant during a workflow run and is available to all jobs in every pipeline that belongs to the workflow, including the initial pipeline and any manually or auto-promoted pipelines in the same build.
 
 ### Workflow is rerun {#workflow-rerun}
 

--- a/docs/versioned_docs/version-CE/reference/env-vars.md
+++ b/docs/versioned_docs/version-CE/reference/env-vars.md
@@ -177,9 +177,9 @@ The workflow unique identifier. All jobs belonging to all pipelines in the workf
 - **Environment variable**: `SEMAPHORE_WORKFLOW_NUMBER`
 - **Example**: `42`
 
-This number is incremented every time the workflow runs. In other words, the number is incremented by one every time there is a Git push on any branch, every time there is a pull request, or a tag is pushed to the repository. It doesn't increment with debug jobs.
+This value tracks how many workflows have run for the current branch, tag, or pull request. Each context starts at `1`, and the counter increases by one on every push or workflow rerun within that same branch, tag, or pull request. Debug jobs do not increment the number.
 
-This number is available to all jobs in all pipelines belonging to the same workflow. This includes the initial pipeline and all manually or auto-promoted pipelines in the same build.
+The value remains constant during a workflow run and is available to all jobs in every pipeline that belongs to the workflow, including the initial pipeline and any manually or auto-promoted pipelines in the same build.
 
 ### Workflow is rerun {#workflow-rerun}
 

--- a/docs/versioned_docs/version-EE-1.4/reference/env-vars.md
+++ b/docs/versioned_docs/version-EE-1.4/reference/env-vars.md
@@ -202,9 +202,9 @@ The workflow unique identifier. All jobs belonging to all pipelines in the workf
 - **Environment variable**: `SEMAPHORE_WORKFLOW_NUMBER`
 - **Example**: `42`
 
-This number is incremented every time the workflow runs. In other words, the number is incremented by one every time there is a Git push on any branch, every time there is a pull request, or a tag is pushed to the repository. It doesn't increment with debug jobs.
+This value tracks how many workflows have run for the current branch, tag, or pull request. Each context starts at `1`, and the counter increases by one on every push or workflow rerun within that same branch, tag, or pull request. Debug jobs do not increment the number.
 
-This number is available to all jobs in all pipelines belonging to the same workflow. This includes the initial pipeline and all manually or auto-promoted pipelines in the same build.
+The value remains constant during a workflow run and is available to all jobs in every pipeline that belongs to the workflow, including the initial pipeline and any manually or auto-promoted pipelines in the same build.
 
 ### Workflow is rerun {#workflow-rerun}
 

--- a/docs/versioned_docs/version-EE/reference/env-vars.md
+++ b/docs/versioned_docs/version-EE/reference/env-vars.md
@@ -202,9 +202,9 @@ The workflow unique identifier. All jobs belonging to all pipelines in the workf
 - **Environment variable**: `SEMAPHORE_WORKFLOW_NUMBER`
 - **Example**: `42`
 
-This number is incremented every time the workflow runs. In other words, the number is incremented by one every time there is a Git push on any branch, every time there is a pull request, or a tag is pushed to the repository. It doesn't increment with debug jobs.
+This value tracks how many workflows have run for the current branch, tag, or pull request. Each context starts at `1`, and the counter increases by one on every push or workflow rerun within that same branch, tag, or pull request. Debug jobs do not increment the number.
 
-This number is available to all jobs in all pipelines belonging to the same workflow. This includes the initial pipeline and all manually or auto-promoted pipelines in the same build.
+The value remains constant during a workflow run and is available to all jobs in every pipeline that belongs to the workflow, including the initial pipeline and any manually or auto-promoted pipelines in the same build.
 
 ### Workflow is rerun {#workflow-rerun}
 


### PR DESCRIPTION
## 📝 Description

Update every reference for `SEMAPHORE_WORKFLOW_NUMBER` so it clearly states the counter resets per branch/tag/PR, starts at 1, increments only on pushes or reruns, and remains steady across all pipelines in the workflow.

Related [task](https://github.com/renderedtext/tasks/issues/8908).

## ✅ Checklist
- [x] I have tested this change
- [x] This change requires documentation update
