### PR TITLE
Add organization ID variable to env vars reference page

### DIFF
--- a/docs/docs/reference/env-vars.md
+++ b/docs/docs/reference/env-vars.md
@@ -139,6 +139,13 @@ A string with a user-supplied block name.
 
 The URL for the organization that owns the project running the current job.
 
+### Organization ID {#organization-id}
+
+- **Environment variable**: `SEMAPHORE_ORGANIZATION_ID`
+- **Example**: `f580f012-1b80-437f-acaf-be038f827270`
+
+The unique identifier for your organization.
+
 ### Pipeline ID {#pipeline-id}
 
 - **Environment variable**: `SEMAPHORE_PIPELINE_ID`


### PR DESCRIPTION
## 📝 Description
The SEMAPHORE_ORGANIZATION_ID variable has been added to the CI environment to support AI Agents running inside CI.

Addresses: https://github.com/semaphoreio/semaphore/issues/719

cc @DamjanBecirovic 

## ✅ Checklist
- [X] I have tested this change
- [ ] This change requires documentation update
