### PR TITLE
toil(front): properly check service account feature access

### DIFF
--- a/front/lib/front_web/templates/people/members/_add_service_account_button.html.eex
+++ b/front/lib/front_web/templates/people/members/_add_service_account_button.html.eex
@@ -1,12 +1,10 @@
-<%= if show_people_management_buttons?(@conn, @org_scope?, @permissions) do %>
-  <div>
-    <div class="flex-m">
-      <div>
-        <button id="add_service_accounts_to_project" class="btn btn-primary flex items-center">
-          <span class="material-symbols-outlined mr2">smart_toy</span>
-          Add service accounts
-        </button>
-      </div>
+<div>
+  <div class="flex-m">
+    <div>
+      <button id="add_service_accounts_to_project" class="btn btn-primary flex items-center">
+        <span class="material-symbols-outlined mr2">smart_toy</span>
+        Add service accounts
+      </button>
     </div>
   </div>
-<% end %>
+</div>

--- a/front/lib/front_web/templates/people/members/members_list.html.eex
+++ b/front/lib/front_web/templates/people/members/members_list.html.eex
@@ -60,7 +60,7 @@
             <div class="b">Service Accounts</div>
           </div>
         </div>
-        <%= if !@org_scope? && show_people_management_buttons?(@conn, @org_scope?, @permissions) do %>
+        <%= if !@org_scope? && people_management_permissions?(@org_scope?, @permissions) do %>
           <%= render "members/_add_service_account_button.html", conn: @conn, org_scope?: @org_scope?, permissions: @permissions %>
         <% end %>
       </div>

--- a/front/lib/front_web/views/people_view.ex
+++ b/front/lib/front_web/views/people_view.ex
@@ -162,12 +162,15 @@ defmodule FrontWeb.PeopleView do
     Timex.format!(Timex.from_unix(seconds), "%b %d, %Y, %I:%M%p", :strftime)
   end
 
+  def people_management_permissions?(org_scope?, permissions) do
+    (org_scope? && permissions["organization.people.manage"]) ||
+      (!org_scope? && permissions["project.access.manage"])
+  end
+
   def show_people_management_buttons?(conn, org_scope?, permissions) do
     org_id = conn.assigns[:organization_id]
 
-    user_has_permissions? =
-      (org_scope? && permissions["organization.people.manage"]) ||
-        (!org_scope? && permissions["project.access.manage"])
+    user_has_permissions? = people_management_permissions?(org_scope?, permissions)
 
     feature_enabled? =
       org_scope? || FeatureProvider.feature_enabled?(:rbac__project_roles, param: org_id) ||


### PR DESCRIPTION
## 📝 Description

- Extracted `people_management_permissions?` helper to check only user permissions, allowing the service accounts "Add" button to work independently of the `rbac__project_roles` feature flag.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
