### PR TITLE
feat: add migration to drop unused indexes

### DIFF
--- a/github_hooks/db/migrate/20251210135953_remove_unused_indexes.rb
+++ b/github_hooks/db/migrate/20251210135953_remove_unused_indexes.rb
@@ -1,0 +1,29 @@
+class RemoveUnusedIndexes < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :jobs, name: "index_jobs_on_project_id_and_created_at", algorithm: :concurrently, if_exists: true
+    remove_index :jobs, name: "index_jobs_on_build_server_id", algorithm: :concurrently, if_exists: true
+    remove_index :workflows, name: "index_workflows_on_ppl_id", algorithm: :concurrently, if_exists: true
+    remove_index :labels, name: "index_labels_on_object_kind_and_object_id_and_key_and_value", algorithm: :concurrently, if_exists: true
+    remove_index :job_stop_requests, name: "index_job_stop_requests_on_build_id", algorithm: :concurrently, if_exists: true
+    remove_index :branches, name: "index_branches_on_project_id_and_used_at", algorithm: :concurrently, if_exists: true
+    remove_index :jobs, name: "index_jobs_on_organization_id_and_created_at", algorithm: :concurrently, if_exists: true
+    remove_index :builds, name: "index_builds_on_workflow_id", algorithm: :concurrently, if_exists: true
+    remove_index :workflows, name: "one_hook_received_at_per_repository", algorithm: :concurrently, if_exists: true
+    remove_index :branches, name: "index_branches_on_archived_at", algorithm: :concurrently, if_exists: true
+  end
+
+  def down
+    add_index :jobs, [:project_id, :created_at], order: {created_at: "DESC"}, algorithm: :concurrently
+    add_index :jobs, [:build_server_id], name: "index_jobs_on_build_server_id", algorithm: :concurrently
+    add_index :workflows, [:ppl_id], name: "index_workflows_on_ppl_id", algorithm: :concurrently
+    add_index :labels, [:object_kind, :object_id, :key, :value], algorithm: :concurrently
+    add_index :job_stop_requests, [:build_id], name: "index_job_stop_requests_on_build_id", algorithm: :concurrently
+    add_index :branches, [:project_id, :used_at], order: {used_at: "DESC"}, algorithm: :concurrently
+    add_index :jobs, [:organization_id, :created_at], order: {created_at: "DESC"}, algorithm: :concurrently
+    add_index :builds, [:workflow_id], name: "index_builds_on_workflow_id", algorithm: :concurrently
+    add_index :workflows, [:repository_id, :received_at], where: "repository_id IS NOT NULL", name: "one_hook_received_at_per_repository", algorithm: :concurrently
+    add_index :branches, [:archived_at], algorithm: :concurrently
+  end
+end

--- a/plumber/ppl/priv/ecto_repo/migrations/20251211092816_drop_unused_indexes.exs
+++ b/plumber/ppl/priv/ecto_repo/migrations/20251211092816_drop_unused_indexes.exs
@@ -1,0 +1,26 @@
+defmodule Ppl.EctoRepo.Migrations.DropUnusedIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    execute "DROP INDEX CONCURRENTLY IF EXISTS pipelines_branch_inserted_at;"
+    execute "DROP INDEX CONCURRENTLY IF EXISTS pipelines_label_index;"
+    execute "DROP INDEX CONCURRENTLY IF EXISTS pipeline_requests_request_args___requester_id__index;"
+    execute "DROP INDEX CONCURRENTLY IF EXISTS pipeline_requests_source_args___git_ref_type__index;"
+    execute "DROP INDEX CONCURRENTLY IF EXISTS pipeline_requests_pr_head_branch_yml_file_index;"
+    execute "DROP INDEX CONCURRENTLY IF EXISTS latest_workflows_organization_id_index;"
+    execute "DROP INDEX CONCURRENTLY IF EXISTS pipeline_requests_pr_head_branch_index;"
+  end
+
+  def down do
+    execute "CREATE INDEX CONCURRENTLY pipelines_branch_inserted_at ON pipelines (branch_name, inserted_at DESC);"
+    execute "CREATE INDEX CONCURRENTLY pipelines_label_index ON pipelines (label);"
+    execute "CREATE INDEX CONCURRENTLY pipeline_requests_request_args___requester_id__index ON pipeline_requests ((request_args -> 'requester_id'));"
+    execute "CREATE INDEX CONCURRENTLY pipeline_requests_source_args___git_ref_type__index ON pipeline_requests ((source_args -> 'git_ref_type'));"
+    execute "CREATE INDEX CONCURRENTLY pipeline_requests_pr_head_branch_yml_file_index ON pipeline_requests ((request_args ->> 'project_id'), (source_args ->> 'git_ref_type'), (source_args ->> 'pr_branch_name'), (request_args ->> 'working_dir'), (request_args ->> 'file_name'), inserted_at DESC, id DESC) WHERE source_args ->> 'git_ref_type' = 'pr';"
+    execute "CREATE INDEX CONCURRENTLY latest_workflows_organization_id_index ON latest_workflows (organization_id);"
+    execute "CREATE INDEX CONCURRENTLY pipeline_requests_pr_head_branch_index ON pipeline_requests ((request_args ->> 'project_id'), (source_args ->> 'git_ref_type'), (source_args ->> 'pr_branch_name'), inserted_at DESC, id DESC) WHERE source_args ->> 'git_ref_type' = 'pr';"
+  end
+end


### PR DESCRIPTION
## 📝 Description
<!-- Describe your changes in detail -->
This PR adds migrations to remove indexes from the databases, these indexes where selected because they weren't used anymore.

front
- index_jobs_on_project_id_and_created_at
- index_jobs_on_build_server_id
- index_workflows_on_ppl_id
- index_labels_on_object_kind_and_object_id_and_key_and_value
- index_job_stop_requests_on_build_id
- index_branches_on_project_id_and_used_at
- index_jobs_on_organization_id_and_created_at
- index_builds_on_workflow_id
- one_hook_received_at_per_repository

ppl_repo
- pipelines_branch_inserted_at
- pipelines_label_index
- pipeline_requests_request_args___requester_id__index
- pipeline_requests_source_args___git_ref_type__index
- pipeline_requests_pr_head_branch_yml_file_index
- latest_workflows_organization_id_index
- pipeline_requests_pr_head_branch_index

index_branches_on_archived_at
## ✅ Checklist
- [x] I have tested this change
- [x] ~~This change requires documentation update~~
