### PR TITLE
fix(plumber): submit retention metrics on every transaction

### DIFF
--- a/plumber/ppl/lib/ppl/retention/policy_applier.ex
+++ b/plumber/ppl/lib/ppl/retention/policy_applier.ex
@@ -50,6 +50,8 @@ defmodule Ppl.Retention.PolicyApplier do
     update_query = from(pr in PplRequests, where: pr.id in subquery(ids_subquery))
     {count, _} = EctoRepo.update_all(update_query, set: [expires_at: expires_at])
 
+    Watchman.submit({"retention.marked", [org_id]}, count, :count)
+
     case count do
       0 -> acc
       n -> batch_update_mark(org_id, cutoff, expires_at, batch_size, acc + n)
@@ -68,6 +70,8 @@ defmodule Ppl.Retention.PolicyApplier do
 
     update_query = from(pr in PplRequests, where: pr.id in subquery(ids_subquery))
     {count, _} = EctoRepo.update_all(update_query, set: [expires_at: nil])
+
+    Watchman.submit({"retention.unmarked", [org_id]}, count, :count)
 
     case count do
       0 -> acc

--- a/plumber/ppl/lib/ppl/retention/policy_consumer.ex
+++ b/plumber/ppl/lib/ppl/retention/policy_consumer.ex
@@ -20,8 +20,6 @@ defmodule Ppl.Retention.PolicyConsumer do
          {:ok, cutoff} <- cutoff_to_naive(event.cutoff_date),
          {:ok, org_id} <- non_empty(event.org_id) do
       {marked, unmarked} = PolicyApplier.mark_expiring(org_id, cutoff)
-      Watchman.submit({"retention.marked", [org_id]}, marked, :count)
-      Watchman.submit({"retention.unmarked", [org_id]}, unmarked, :count)
 
       Logger.info(
         "[Retention] org=#{org_id} cutoff=#{cutoff} marked=#{marked} unmarked=#{unmarked}"


### PR DESCRIPTION
## 📝 Description
Plumber retention workers should publish metrics as soon as the SQL transaction is completed. Waiting for the whole process to complete is not necessary.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
