### PR TITLE
docs: add R1 pricing to billing documentation

### DIFF
--- a/docs/docs/using-semaphore/billing.md
+++ b/docs/docs/using-semaphore/billing.md
@@ -62,6 +62,7 @@ Each cloud machine type has its own **price per minute**, listed in the table be
 | E1 (Linux) |       $0.0075       |       $0.015        |        $0.03        |
 | E2 (Linux) |        $0.01        |        $0.02        |          /          |
 | F1 (Linux) |       $0.015        |        $0.03        |          /          |
+| R1 (Linux) |       $0.00225      |        $0.0045      |          /          |
 | A1 (MacOS ARM64) |          /          |        $0.03        |          /          |
 | A2 (MacOS Silicon) |          /          |        $0.09        |          /          |
 


### PR DESCRIPTION
fixes #770

## 📝 Description
Adds missing pricing for R1 machines

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
