### PR TITLE
feat(zebra): bypass max_job_execution_time_limit for verified orgs

### DIFF
--- a/zebra/lib/zebra/workers/scheduler/org.ex
+++ b/zebra/lib/zebra/workers/scheduler/org.ex
@@ -9,7 +9,7 @@ defmodule Zebra.Workers.Scheduler.Org do
   # 15 minutes
   @cache_timeout :timer.minutes(15)
 
-  defstruct [:id, :username, :suspended, :machines, :features]
+  defstruct [:id, :username, :suspended, :verified, :machines, :features]
 
   @doc """
   Returns quota information for the given organization.
@@ -17,7 +17,7 @@ defmodule Zebra.Workers.Scheduler.Org do
   {:ok, quotas} on success.
   """
   def load(org_id) do
-    Zebra.Cache.fetch!("quotas-#{org_id}-v3", @cache_timeout, fn ->
+    Zebra.Cache.fetch!("quotas-#{org_id}-v4", @cache_timeout, fn ->
       result =
         Wormhole.capture(__MODULE__, :fetch_org, [org_id],
           timeout: 10_500,
@@ -70,7 +70,8 @@ defmodule Zebra.Workers.Scheduler.Org do
     %__MODULE__{
       id: org_id,
       username: org.org_username,
-      suspended: org.suspended
+      suspended: org.suspended,
+      verified: org.verified
     }
   end
 

--- a/zebra/test/support/stubbed_provider.ex
+++ b/zebra/test/support/stubbed_provider.ex
@@ -24,6 +24,14 @@ defmodule Support.StubbedProvider do
     feature("max_job_execution_time_limit", [:enabled, {:quantity, 30}])
   end
 
+  defp max_job_time_limit_feature("enabled_30_verified") do
+    feature("max_job_execution_time_limit", [:enabled, {:quantity, 30}])
+  end
+
+  defp max_job_time_limit_feature("enabled_30_unverified") do
+    feature("max_job_execution_time_limit", [:enabled, {:quantity, 30}])
+  end
+
   defp max_job_time_limit_feature("enabled_48h") do
     feature("max_job_execution_time_limit", [:enabled, {:quantity, 48 * 60}])
   end


### PR DESCRIPTION
## 📝 Description

Verified organizations now bypass the max_job_execution_time_limit feature flag restriction, allowing them to set execution_time_limit up to the standard 24-hour maximum.

Previously, orgs with this feature flag enabled had their requested execution_time_limit silently capped to the feature quota(30 minutes), even if they requested a higher value. This caused jobs to terminate unexpectedly for customers who set longer limits.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
