### PR TITLE
fix(notifications): log errors when delivering webhook notification

### DIFF
--- a/notifications/lib/notifications/workers/webhook.ex
+++ b/notifications/lib/notifications/workers/webhook.ex
@@ -31,8 +31,8 @@ defmodule Notifications.Workers.Webhook do
           {:ok, response}
 
         {:error, error} ->
-          Logger.debug(fn ->
-            "#{request_id} Failure with #{endpoint} #{body} and signature '#{signature}' error: #{inspect(error)}"
+          Logger.error(fn ->
+            "#{request_id} Failure with #{endpoint} error: #{inspect(error)}"
           end)
 
           Watchman.increment("notification.webhook.failure")


### PR DESCRIPTION
## 📝 Description

Log errors when there are issues delivering webhook notifications.

## ✅ Checklist
- [ ] I have tested this change
- [x] ~This change requires documentation update~ N/A
