### PR TITLE
fix(zebra): fix zebra queries to use index, handle empty artifact_store_ids

### DIFF
--- a/artifacthub/pkg/workers/jobdeletion/worker.go
+++ b/artifacthub/pkg/workers/jobdeletion/worker.go
@@ -90,9 +90,14 @@ func (w *Worker) handleMessage(delivery tackle.Delivery) error {
 	jobID := event.GetJobId()
 	artifactStoreID := event.GetArtifactStoreId()
 
-	if jobID == "" || artifactStoreID == "" {
-		log.Printf("JobDeletion Worker: Invalid message, missing jobID or artifactStoreID: %+v", event)
-		return fmt.Errorf("invalid message, missing jobID or artifactStoreID")
+	if jobID == "" {
+		log.Printf("JobDeletion Worker: Invalid message, missing jobID: %+v", event)
+		return fmt.Errorf("invalid message, missing jobID")
+	}
+
+	if artifactStoreID == "" {
+		log.Printf("JobDeletion Worker: Skipping job %s - no artifactStoreID", jobID)
+		return nil
 	}
 
 	artifact, err := models.FindArtifactByID(artifactStoreID)

--- a/zebra/lib/zebra/models/job.ex
+++ b/zebra/lib/zebra/models/job.ex
@@ -402,18 +402,33 @@ defmodule Zebra.Models.Job do
 
   def expired_job_ids(limit) do
     import Ecto.Query,
-      only: [from: 2, join: 5, where: 3, limit: 2, select: 2]
+      only: [from: 2, where: 3, limit: 2, select: 2, order_by: 2]
 
-    query =
+    jobs_query =
       from(j in Zebra.Models.Job,
-        join: p in "projects",
-        on: j.project_id == p.id,
         where: not is_nil(j.expires_at) and j.expires_at <= fragment("CURRENT_TIMESTAMP"),
+        order_by: [asc: j.expires_at],
         limit: ^limit,
-        select: {j.id, j.organization_id, j.project_id, p.artifact_store_id}
+        select: {j.id, j.organization_id, j.project_id}
       )
 
-    result = Zebra.LegacyRepo.all(query)
+    jobs = Zebra.LegacyRepo.all(jobs_query)
+
+    project_ids = jobs |> Enum.map(fn {_, _, project_id} -> project_id end) |> Enum.uniq()
+
+    artifact_store_map =
+      from(p in "projects",
+        where: p.id in ^project_ids,
+        select: {p.id, p.artifact_store_id}
+      )
+      |> Zebra.LegacyRepo.all()
+      |> Map.new()
+
+    result =
+      Enum.map(jobs, fn {id, org_id, project_id} ->
+        {id, org_id, project_id, Map.get(artifact_store_map, project_id)}
+      end)
+
     {:ok, result}
   end
 


### PR DESCRIPTION
## 📝 Description

- Split the query into two separate queries - first fetch expired job IDs using the index, then lookup artifact_store_id from projects table - to avoid slow heap access on a table with a lot of dead tuples.
- ack job deletion event in artifacthub when "artifact_store_id" is empty

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
