### PR TITLE
fix(zebra): properly cast uuids in queries

### DIFF
--- a/zebra/priv/legacy_repo/migrations/20260127150000_create_projects_table_for_tests.exs
+++ b/zebra/priv/legacy_repo/migrations/20260127150000_create_projects_table_for_tests.exs
@@ -1,0 +1,16 @@
+defmodule Zebra.LegacyRepo.Migrations.CreateProjectsTableForTests do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    CREATE TABLE IF NOT EXISTS projects (
+      id uuid PRIMARY KEY,
+      artifact_store_id uuid
+    )
+    """
+  end
+
+  def down do
+    execute "DROP TABLE IF EXISTS projects"
+  end
+end

--- a/zebra/test/zebra/workers/job_deletion_policy_worker_test.exs
+++ b/zebra/test/zebra/workers/job_deletion_policy_worker_test.exs
@@ -84,5 +84,40 @@ defmodule Zebra.Workers.JobDeletionPolicyWorkerTest do
         assert_called(Job.publish_job_deletion_events(expired_jobs))
       end
     end
+
+    test "handles jobs with nil artifact_store_id (orphaned projects)" do
+      worker = %Worker{limit: 10, naptime: 1000, longnaptime: 5000}
+
+      job_id_1 = Ecto.UUID.generate()
+      job_id_2 = Ecto.UUID.generate()
+      org_id = Ecto.UUID.generate()
+      project_id = Ecto.UUID.generate()
+      orphan_project_id = Ecto.UUID.generate()
+      artifact_store_id = Ecto.UUID.generate()
+
+      expired_jobs = [
+        {job_id_1, org_id, project_id, artifact_store_id},
+        {job_id_2, org_id, orphan_project_id, nil}
+      ]
+
+      with_mocks [
+        {Job, [],
+         [
+           expired_job_ids: fn _limit -> {:ok, expired_jobs} end,
+           publish_job_deletion_events: fn _jobs -> :ok end,
+           delete_job_stop_requests: fn _job_ids -> {:ok, 2} end,
+           delete_jobs: fn _job_ids -> {:ok, 2} end
+         ]},
+        {Watchman, [], [submit: fn _metric, _value, _type -> :ok end]}
+      ] do
+        result = Worker.tick(worker)
+
+        assert result == true
+        assert_called(Job.expired_job_ids(10))
+        assert_called(Job.publish_job_deletion_events(expired_jobs))
+        assert_called(Job.delete_job_stop_requests([job_id_1, job_id_2]))
+        assert_called(Job.delete_jobs([job_id_1, job_id_2]))
+      end
+    end
   end
 end


### PR DESCRIPTION
## 📝 Description

- Fix ecto uuid query casting
- Add spec for `expired_job_ids/1`

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
