### PR TITLE
feat(zebra): add ubuntu2004 brownout schedule

### DIFF
--- a/zebra/lib/zebra/machines/brownout.ex
+++ b/zebra/lib/zebra/machines/brownout.ex
@@ -3,6 +3,8 @@ defmodule Zebra.Machines.Brownout do
   This module is responsible for checking if a machine type is in brownout phase for a given organization.
   """
 
+  alias Zebra.Machines.BrownoutSchedule
+
   @type brownout_schedule :: %{
           from: DateTime.t(),
           to: DateTime.t(),
@@ -12,6 +14,22 @@ defmodule Zebra.Machines.Brownout do
   @type brownout_schedules :: [brownout_schedule]
 
   @type organization_ids :: [String.t()]
+
+  @doc """
+  Returns the combined brownout schedules for all OS images.
+  """
+  @spec schedules() :: brownout_schedules()
+  def schedules do
+    BrownoutSchedule.macosxcode14() ++ BrownoutSchedule.ubuntu2004()
+  end
+
+  @doc """
+  Checks if machine used by organization is in brownout phase using the default schedules.
+  """
+  @spec os_image_in_brownout?(Datetime.t(), String.t(), String.t()) :: boolean()
+  def os_image_in_brownout?(datetime, organization_id, machine_os_image) do
+    os_image_in_brownout?(schedules(), datetime, organization_id, machine_os_image)
+  end
 
   @doc """
   Checks if machine used by organization is in brownout phase.

--- a/zebra/lib/zebra/machines/brownout_schedule.ex
+++ b/zebra/lib/zebra/machines/brownout_schedule.ex
@@ -7,6 +7,55 @@ defmodule Zebra.Machines.BrownoutSchedule do
   @type date_or_range :: [Date.t()] | Date.Range.t()
   @type time_period :: {Time.t(), Time.t()}
 
+  @spec ubuntu2004 :: Brownout.brownout_schedules()
+  def ubuntu2004 do
+    first_phase =
+      phase(
+        Date.range(~D[2026-02-02], ~D[2026-02-08]),
+        [
+          {~T[00:00:00], ~T[00:15:00]},
+          {~T[10:00:00], ~T[10:15:00]},
+          {~T[15:00:00], ~T[15:15:00]}
+        ],
+        ["ubuntu2004"]
+      )
+
+    second_phase =
+      phase(
+        Date.range(~D[2026-02-09], ~D[2026-02-15]),
+        [
+          {~T[00:00:00], ~T[00:30:00]},
+          {~T[10:00:00], ~T[10:30:00]},
+          {~T[15:00:00], ~T[15:30:00]}
+        ],
+        ["ubuntu2004"]
+      )
+
+    third_phase =
+      phase(
+        Date.range(~D[2026-02-16], ~D[2026-02-22]),
+        [
+          {~T[00:00:00], ~T[01:00:00]},
+          {~T[10:00:00], ~T[11:00:00]},
+          {~T[15:00:00], ~T[16:00:00]}
+        ],
+        ["ubuntu2004"]
+      )
+
+    fourth_phase =
+      phase(
+        Date.range(~D[2026-02-23], ~D[2026-02-28]),
+        [
+          {~T[00:00:00], ~T[03:00:00]},
+          {~T[10:00:00], ~T[13:00:00]},
+          {~T[15:00:00], ~T[18:00:00]}
+        ],
+        ["ubuntu2004"]
+      )
+
+    first_phase ++ second_phase ++ third_phase ++ fourth_phase
+  end
+
   @spec macosxcode14 :: Brownout.brownout_schedules()
   def macosxcode14 do
     first_phase =

--- a/zebra/lib/zebra/workers/job_request_factory/machine.ex
+++ b/zebra/lib/zebra/workers/job_request_factory/machine.ex
@@ -5,11 +5,14 @@ defmodule Zebra.Workers.JobRequestFactory.Machine do
         validate_self_hosted_type(org_id, job.machine_type)
 
       Zebra.Machines.Brownout.os_image_in_brownout?(
-        Zebra.Machines.BrownoutSchedule.macosxcode14(),
         DateTime.utc_now(),
         job.organization_id,
         job.machine_os_image
       ) ->
+        Watchman.increment(
+          {"brownout.job_stopped", [job.machine_os_image, job.organization_id, job.project_id]}
+        )
+
         {
           :stop_job_processing,
           "OS image '#{job.machine_os_image}' for machine type '#{job.machine_type}' is currently in a brownout phase. Please use another OS image."

--- a/zebra/test/zebra/machines/brownout_schedule_test.exs
+++ b/zebra/test/zebra/machines/brownout_schedule_test.exs
@@ -3,6 +3,28 @@ defmodule Zebra.Machines.BrownoutScheduleTest do
   doctest Zebra.Machines.BrownoutSchedule
   alias Zebra.Machines.BrownoutSchedule
 
+  test "creates ubuntu2004 brownout schedule" do
+    schedule = BrownoutSchedule.ubuntu2004()
+
+    assert length(schedule) == 81
+
+    [first_event | _] = schedule
+
+    assert first_event == %{
+             from: ~U[2026-02-02 00:00:00Z],
+             os_images: ["ubuntu2004"],
+             to: ~U[2026-02-02 00:15:00Z]
+           }
+
+    [last_event | _] = schedule |> Enum.reverse()
+
+    assert last_event == %{
+             from: ~U[2026-02-28 15:00:00Z],
+             os_images: ["ubuntu2004"],
+             to: ~U[2026-02-28 18:00:00Z]
+           }
+  end
+
   test "creates macos-xcode14 brownout schedule" do
     schedule = BrownoutSchedule.macosxcode14()
 


### PR DESCRIPTION
## 📝 Description
Add `ubuntu2004` brownout schedule.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
