### PR TITLE
feat: use feature flag instead of env var to apply brownout skip

### DIFF
--- a/zebra/config/runtime.exs
+++ b/zebra/config/runtime.exs
@@ -111,8 +111,6 @@ config :sentry,
 
 if config_env() == :prod do
   config :zebra, domain: System.get_env("BASE_DOMAIN")
-  config :zebra, Zebra.Machines.Brownout,
-    excluded_organization_ids: System.get_env("BROWNOUT_EXCLUDED_ORGANIZATION_IDS") || ""
 
   config :zebra, artifacthub_api_endpoint: System.fetch_env!("INTERNAL_API_URL_ARTIFACTHUB")
   config :zebra, cachehub_api_endpoint: System.fetch_env!("INTERNAL_API_URL_CACHEHUB")

--- a/zebra/lib/zebra/machines/brownout.ex
+++ b/zebra/lib/zebra/machines/brownout.ex
@@ -13,8 +13,6 @@ defmodule Zebra.Machines.Brownout do
 
   @type brownout_schedules :: [brownout_schedule]
 
-  @type organization_ids :: [String.t()]
-
   @doc """
   Returns the combined brownout schedules for all OS images.
   """
@@ -65,23 +63,6 @@ defmodule Zebra.Machines.Brownout do
 
   @spec apply_brownout_to_organization?(String.t()) :: boolean()
   defp apply_brownout_to_organization?(organization_id) do
-    organization_id not in excluded_organization_ids()
-  end
-
-  @spec excluded_organization_ids :: organization_ids()
-  defp excluded_organization_ids do
-    config()
-    |> Keyword.get(:excluded_organization_ids, "")
-    |> String.split(",")
-    |> Enum.map(&String.trim/1)
-  end
-
-  @spec config :: Keyword.t()
-  defp config do
-    Application.get_env(:zebra, __MODULE__, [])
-    |> case do
-      nil -> []
-      config -> config
-    end
+    not FeatureProvider.feature_enabled?(:exclude_from_brownouts, param: organization_id)
   end
 end

--- a/zebra/test/support/stubbed_provider.ex
+++ b/zebra/test/support/stubbed_provider.ex
@@ -3,6 +3,7 @@ defmodule Support.StubbedProvider do
 
   @e1_to_f1_org_id "org-e1-to-f1-enabled"
   @e2_to_f1_org_id "org-e2-to-f1-enabled"
+  @exclude_from_brownouts_org_id "org-exclude-from-brownouts-enabled"
 
   @test_results_no_trim_org_id "org-test-results-no-trim-enabled"
 
@@ -16,11 +17,13 @@ defmodule Support.StubbedProvider do
        max_job_time_limit_feature(org_id),
        feature("e1_to_f1_migration", e1_to_f1_traits(org_id)),
        feature("e2_to_f1_migration", e2_to_f1_traits(org_id)),
-       feature("test_results_no_trim", test_results_no_trim_traits(org_id))
+       feature("test_results_no_trim", test_results_no_trim_traits(org_id)),
+       feature("exclude_from_brownouts", exclude_from_brownouts_traits(org_id))
      ]}
   end
 
   def test_results_no_trim_org_id, do: @test_results_no_trim_org_id
+  def exclude_from_brownouts_org_id, do: @exclude_from_brownouts_org_id
 
   def e1_to_f1_org_id, do: @e1_to_f1_org_id
   def e2_to_f1_org_id, do: @e2_to_f1_org_id
@@ -53,6 +56,9 @@ defmodule Support.StubbedProvider do
 
   defp test_results_no_trim_traits(@test_results_no_trim_org_id), do: [:enabled]
   defp test_results_no_trim_traits(_org_id), do: [:hidden]
+
+  defp exclude_from_brownouts_traits(@exclude_from_brownouts_org_id), do: [:enabled]
+  defp exclude_from_brownouts_traits(_org_id), do: [:hidden]
 
   @impl FeatureProvider.Provider
   def provide_machines(_org_id \\ nil, _opts \\ []) do

--- a/zebra/test/zebra/machines/brownout_test.exs
+++ b/zebra/test/zebra/machines/brownout_test.exs
@@ -1,41 +1,22 @@
 defmodule Zebra.Machines.BrownoutTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   alias Zebra.Machines.Brownout
 
-  describe "applying brownout on a schedule" do
-    setup do
-      old_configuration = Application.get_env(:zebra, Brownout, [])
+  setup do
+    Mox.stub_with(Support.MockedProvider, Support.StubbedProvider)
 
-      Application.put_env(:zebra, Brownout, excluded_organization_ids: "2,3")
-
-      on_exit(fn ->
-        Application.put_env(:zebra, Brownout, old_configuration)
-      end)
-
-      [
-        schedules: [
-          Brownout.schedule(~N[2024-01-01 00:00:00], ~N[2024-01-01 00:15:00], ["ubuntu1804"]),
-          Brownout.schedule(~N[2024-01-02 00:00:00], ~N[2024-01-02 00:15:00], [
-            "ubuntu1804",
-            "ubuntu2004"
-          ])
-        ]
+    [
+      schedules: [
+        Brownout.schedule(~N[2024-01-01 00:00:00], ~N[2024-01-01 00:15:00], ["ubuntu1804"]),
+        Brownout.schedule(~N[2024-01-02 00:00:00], ~N[2024-01-02 00:15:00], [
+          "ubuntu1804",
+          "ubuntu2004"
+        ])
       ]
-    end
+    ]
+  end
 
-    test "ignores excluded organizations", %{schedules: schedules} do
-      assert Brownout.os_image_in_brownout?(schedules, ~N[2024-01-01 00:10:00], "2", "ubuntu1804") ==
-               false
-
-      assert Brownout.os_image_in_brownout?(schedules, ~N[2024-01-01 00:10:00], "3", "ubuntu1804") ==
-               false
-    end
-
-    test "ignores not browned out os images", %{schedules: schedules} do
-      assert Brownout.os_image_in_brownout?(schedules, ~N[2024-01-01 00:10:00], "1", "ubuntu2004") ==
-               false
-    end
-
+  describe "applying brownout on a schedule" do
     test "works on a schedule", %{schedules: schedules} do
       assert Brownout.os_image_in_brownout?(schedules, ~N[2024-12-31 23:59:59], "1", "ubuntu1804") ==
                false
@@ -68,23 +49,40 @@ defmodule Zebra.Machines.BrownoutTest do
                false
     end
 
+    test "ignores not browned out os images", %{schedules: schedules} do
+      assert Brownout.os_image_in_brownout?(schedules, ~N[2024-01-01 00:10:00], "1", "ubuntu2004") ==
+               false
+    end
+
     test "works with multiple os images", %{schedules: schedules} do
       assert Brownout.os_image_in_brownout?(schedules, ~N[2024-01-02 00:10:00], "1", "ubuntu2004") ==
                true
     end
   end
 
-  describe "applying brownout without configuration" do
-    setup do
-      old_configuration = Application.get_env(:zebra, Brownout, [])
+  describe "exclude_from_brownouts feature flag" do
+    test "excludes organization with feature enabled", %{schedules: schedules} do
+      excluded_org = Support.StubbedProvider.exclude_from_brownouts_org_id()
 
-      Application.put_env(:zebra, Brownout, nil)
-
-      on_exit(fn ->
-        Application.put_env(:zebra, Brownout, old_configuration)
-      end)
+      assert Brownout.os_image_in_brownout?(
+               schedules,
+               ~N[2024-01-01 00:10:00],
+               excluded_org,
+               "ubuntu1804"
+             ) == false
     end
 
+    test "applies brownout for organization without feature enabled", %{schedules: schedules} do
+      assert Brownout.os_image_in_brownout?(
+               schedules,
+               ~N[2024-01-01 00:10:00],
+               "regular-org",
+               "ubuntu1804"
+             ) == true
+    end
+  end
+
+  describe "applying brownout without schedules" do
     test "works" do
       assert Brownout.os_image_in_brownout?([], ~N[2024-01-01 00:10:00], "1", "ubuntu1804") ==
                false

--- a/zebra/test/zebra/workers/feature_provider_invalidator_worker_test.exs
+++ b/zebra/test/zebra/workers/feature_provider_invalidator_worker_test.exs
@@ -99,7 +99,7 @@ defmodule Zebra.Workers.FeatureProviderInvalidatorWorkerTest do
       Worker.features_changed(callback_message)
 
       {:ok, features} = FeatureProvider.list_features()
-      assert length(features) == 7
+      assert length(features) == 8
     end
 
     test "when the organization feature state changes, organization feature caches are invalidated" do


### PR DESCRIPTION
## 📝 Description
Use a feature flag instead of an env variable to perform a check for skipping a brownout.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
