### PR TITLE
feat(repository_hub): add support for GitLab subgroup repositories

### DIFF
--- a/repository_hub/lib/repository_hub/adapters/gitlab/describe_remote_repository_action.ex
+++ b/repository_hub/lib/repository_hub/adapters/gitlab/describe_remote_repository_action.ex
@@ -12,7 +12,7 @@ defimpl RepositoryHub.Server.DescribeRemoteRepositoryAction, for: RepositoryHub.
 
   @impl true
   def execute(_adapter, request) do
-    with {:ok, git_repository} <- GitRepository.new(request.url),
+    with {:ok, git_repository} <- GitRepository.from_gitlab(request.url),
          {:ok, gitlab_token} <- GitlabAdapter.fetch_token(request.user_id),
          {:ok, repository} <-
            GitlabClient.find_repository(

--- a/repository_hub/test/repository_hub/adapters/gitlab/create_action_test.exs
+++ b/repository_hub/test/repository_hub/adapters/gitlab/create_action_test.exs
@@ -30,6 +30,21 @@ defmodule RepositoryHub.Server.GitLab.CreateActionTest do
       assert repository.integration_type == :GITLAB
     end
 
+    test "should create a repository for subgroup namespace", %{gitlab_adapter: adapter} do
+      request =
+        InternalApiFactory.create_request(
+          integration_type: :GITLAB,
+          repository_url: "git@gitlab.com:testorg/testgroup/testrepo.git"
+        )
+
+      assert {:ok, %CreateResponse{repository: repository}} = CreateAction.execute(adapter, request)
+      assert repository.owner == "testorg/testgroup"
+      assert repository.name == "testrepo"
+      assert repository.url == "git@gitlab.com:testorg/testgroup/testrepo.git"
+      assert repository.provider == "gitlab"
+      assert repository.integration_type == :GITLAB
+    end
+
     test "should validate a request", %{gitlab_adapter: adapter} do
       assertions = [
         {false, []},
@@ -40,7 +55,8 @@ defmodule RepositoryHub.Server.GitLab.CreateActionTest do
         {false, integration_type: -1},
         {true, integration_type: :GITLAB, repository_url: "git@gitlab.com:dummy/repository.git"},
         {false, repository_url: ""},
-        {true, integration_type: :GITLAB, repository_url: "https://gitlab.com/foo/bar"}
+        {true, integration_type: :GITLAB, repository_url: "https://gitlab.com/foo/bar"},
+        {true, integration_type: :GITLAB, repository_url: "https://gitlab.com/foo/bar/baz"}
       ]
 
       for {true, params} <- assertions do

--- a/repository_hub/test/repository_hub/adapters/gitlab/describe_remote_repository_action_test.exs
+++ b/repository_hub/test/repository_hub/adapters/gitlab/describe_remote_repository_action_test.exs
@@ -31,6 +31,20 @@ defmodule RepositoryHub.Server.GitLab.DescribeRemoteRepositoryActionTest do
       assert response.remote_repository.full_name == "repositoryhub/semaphoreci"
     end
 
+    test "should describe repository in subgroup namespace", %{gitlab_adapter: adapter} do
+      request =
+        InternalApiFactory.describe_remote_repository_request(
+          url: "https://gitlab.com/testorg/testgroup/testrepo",
+          integration_type: :GITLAB
+        )
+
+      assert {:ok, %DescribeRemoteRepositoryResponse{} = response} =
+               DescribeRemoteRepositoryAction.execute(adapter, request)
+
+      assert response.remote_repository.name == "testrepo"
+      assert response.remote_repository.full_name == "testorg/testgroup/testrepo"
+    end
+
     test "should fail with invalid repository url", %{gitlab_adapter: adapter} do
       request =
         InternalApiFactory.describe_remote_repository_request(

--- a/repository_hub/test/repository_hub/model/git_repository_test.exs
+++ b/repository_hub/test/repository_hub/model/git_repository_test.exs
@@ -107,6 +107,28 @@ defmodule RepositoryHub.Model.GitRepositoryTest do
       assert url_parts.owner == "marvinwills"
       assert url_parts.repo == "base-app"
     end
+
+    test "GitLab subgroup SSH URL => ✅" do
+      url = "git@gitlab.com:testorg/testgroup/testrepo.git"
+
+      {:ok, url_parts} = GitRepository.from_gitlab(url)
+      assert url_parts.protocol == ""
+      assert url_parts.host == "gitlab.com"
+      assert url_parts.owner == "testorg/testgroup"
+      assert url_parts.repo == "testrepo"
+      assert url_parts.ssh_git_url == "git@gitlab.com:testorg/testgroup/testrepo.git"
+    end
+
+    test "GitLab subgroup HTTPS URL => ✅" do
+      url = "https://gitlab.com/testorg/testgroup/testrepo.git"
+
+      {:ok, url_parts} = GitRepository.from_gitlab(url)
+      assert url_parts.protocol == "https://"
+      assert url_parts.host == "gitlab.com"
+      assert url_parts.owner == "testorg/testgroup"
+      assert url_parts.repo == "testrepo"
+      assert url_parts.ssh_git_url == "git@gitlab.com:testorg/testgroup/testrepo.git"
+    end
   end
 
   describe ".equal?" do


### PR DESCRIPTION
## 📝 Description

Add support for parsing and handling GitLab repository URLs with subgroup namespaces (e.g., `testorg/testgroup/testrepo`). Introduce `dissect_gitlab/1` function to properly parse multi-level GitLab paths and update `from_gitlab/1` to use the new parser.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
