### PR TITLE
toil(rbac): change default debug log level to info

### DIFF
--- a/ee/rbac/config/runtime.exs
+++ b/ee/rbac/config/runtime.exs
@@ -1,6 +1,6 @@
 import Config
 
-config :logger, level: (System.get_env("LOG_LEVEL") || "debug") |> String.to_atom()
+config :logger, level: (System.get_env("LOG_LEVEL") || "info") |> String.to_atom()
 
 config :rbac, Rbac.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/rbac/ce/config/config.exs
+++ b/rbac/ce/config/config.exs
@@ -1,6 +1,6 @@
 import Config
 
-config :logger, level: (System.get_env("LOG_LEVEL") || "debug") |> String.to_atom()
+config :logger, level: (System.get_env("LOG_LEVEL") || "info") |> String.to_atom()
 
 # Configures Elixir's Logger
 config :logger, :console,


### PR DESCRIPTION
## 📝 Description
Setting default log level for rbac service to `info` to avoid unnecessary log cluttering. 

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
