### PR TITLE
fix(front): use proper key for fetching organization id

### DIFF
--- a/front/lib/front_web/controllers/project_controller.ex
+++ b/front/lib/front_web/controllers/project_controller.ex
@@ -155,7 +155,9 @@ defmodule FrontWeb.ProjectController do
           if Models.Project.file_exists?(project.id, project.initial_pipeline_file) do
             render_default_branch(conn)
           else
-            if FeatureProvider.feature_enabled?(:new_project_onboarding, param: project.org_id) do
+            if FeatureProvider.feature_enabled?(:new_project_onboarding,
+                 param: project.organization_id
+               ) do
               redirect(conn, to: project_onboarding_path(conn, :onboarding_index, project.name))
             else
               redirect(conn, to: project_onboarding_path(conn, :template, project.name))


### PR DESCRIPTION
## 📝 Description
Use proper parameter name for fetching organization id

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
