### PR TITLE
feat(front): implement Pylon support integration

### DIFF
--- a/front/config/runtime.exs
+++ b/front/config/runtime.exs
@@ -129,7 +129,18 @@ if config_env() == :prod do
     support_app_secret: System.get_env("HELPSCOUT_APP_SECRET")
 end
 
+pylon_jwt_ttl_seconds =
+  case Integer.parse(System.get_env("PYLON_JWT_TTL_SECONDS") || "300") do
+    {value, _} -> value
+    :error -> 300
+  end
+
 config :front,
+  pylon_org_slug: System.get_env("PYLON_ORG_SLUG"),
+  pylon_jwt_secret: System.get_env("PYLON_JWT_SECRET"),
+  pylon_jwt_issuer: System.get_env("PYLON_JWT_ISSUER"),
+  pylon_jwt_callback_url: System.get_env("PYLON_JWT_CALLBACK_URL"),
+  pylon_jwt_ttl_seconds: pylon_jwt_ttl_seconds,
   zendesk_support_url: System.get_env("ZENDESK_SUPPORT_URL") || "http://support.semaphoreci.test",
   zendesk_jwt_url: System.get_env("ZENDESK_JWT_URL") || "http://support.semaphoreci.test",
   zendesk_jwt_secret: System.get_env("ZENDESK_JWT_SECRET") || "secret",

--- a/front/lib/front/pylon.ex
+++ b/front/lib/front/pylon.ex
@@ -1,0 +1,90 @@
+defmodule Front.Pylon do
+  @default_callback_url "https://graph.usepylon.com/callback/jwt"
+
+  defmodule JWT do
+    use Joken.Config
+
+    @audience "https://portal.usepylon.com"
+    @default_jwt_ttl_seconds 300
+
+    def token_config, do: default_claims(skip: [:aud, :iss, :exp, :iat, :nbf, :jti])
+
+    def generate(user, org_id) do
+      with {:ok, email} <- user_email(user),
+           {:ok, org_id} <- org_id(org_id),
+           {:ok, secret} <- jwt_secret(),
+           {:ok, issuer} <- issuer() do
+        signer = Joken.Signer.create("HS256", secret)
+        now = current_time()
+
+        %{
+          "iat" => now,
+          "exp" => now + token_ttl_seconds(),
+          "email" => email,
+          "aud" => @audience,
+          "iss" => ensure_trailing_slash(issuer)
+        }
+        |> put_account_external_id(org_id)
+        |> generate_and_sign!(signer)
+        |> then(&{:ok, &1})
+      end
+    rescue
+      _ -> {:error, :token_generation_failed}
+    end
+
+    defp token_ttl_seconds do
+      Application.get_env(:front, :pylon_jwt_ttl_seconds, @default_jwt_ttl_seconds)
+    end
+
+    defp put_account_external_id(claims, org_id),
+      do: Map.put(claims, "account_external_id", org_id)
+
+    defp user_email(%{email: email}) when is_binary(email) and email != "", do: {:ok, email}
+    defp user_email(_), do: {:error, :invalid_user_email}
+
+    defp org_id(value) when is_binary(value) and value != "", do: {:ok, value}
+    defp org_id(_), do: {:error, :invalid_org_id}
+
+    defp jwt_secret do
+      case Application.get_env(:front, :pylon_jwt_secret) do
+        secret when is_binary(secret) and secret != "" -> {:ok, secret}
+        _ -> {:error, :missing_pylon_jwt_secret}
+      end
+    end
+
+    defp issuer do
+      case Application.get_env(:front, :pylon_jwt_issuer) do
+        value when is_binary(value) and value != "" -> {:ok, value}
+        _ -> {:error, :missing_pylon_jwt_issuer}
+      end
+    end
+
+    defp ensure_trailing_slash(value) do
+      if String.ends_with?(value, "/"), do: value, else: value <> "/"
+    end
+  end
+
+  def new_ticket_location(user, org_id) do
+    with {:ok, token} <- JWT.generate(user, org_id),
+         {:ok, org_slug} <- org_slug() do
+      location =
+        "#{callback_url()}?orgSlug=#{URI.encode_www_form(org_slug)}&access_token=#{URI.encode_www_form(token)}"
+
+      {:ok, location}
+    end
+  end
+
+  defp org_slug do
+    case Application.get_env(:front, :pylon_org_slug) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, :missing_pylon_org_slug}
+    end
+  end
+
+  defp callback_url do
+    case Application.get_env(:front, :pylon_jwt_callback_url) do
+      value when is_binary(value) and value != "" -> value
+      _ -> @default_callback_url
+    end
+  end
+end

--- a/front/lib/front_web/controllers/support_controller.ex
+++ b/front/lib/front_web/controllers/support_controller.ex
@@ -17,7 +17,7 @@ defmodule FrontWeb.SupportController do
 
   plug(
     FrontWeb.Plugs.Header
-    when action in [:new, :thanks, :submit]
+    when action in [:new, :thanks, :submit, :pylon]
   )
 
   def thanks(conn, _params) do
@@ -32,6 +32,30 @@ defmodule FrontWeb.SupportController do
 
   def new(conn, _params) do
     redirect(conn, external: Front.Zendesk.new_ticket_location())
+  end
+
+  def pylon(conn, _params) do
+    org_id = conn.assigns.organization_id
+
+    if pylon_support_enabled?(org_id) do
+      user = conn.assigns.user_id |> User.find()
+
+      case Front.Pylon.new_ticket_location(user, org_id) do
+        {:ok, location} ->
+          redirect(conn, external: location)
+
+        {:error, reason} ->
+          Logger.warning("Pylon support redirect failed for org_id=#{org_id}: #{inspect(reason)}")
+
+          conn
+          |> put_flash(:alert, "Unable to open Pylon support right now. Please try again.")
+          |> redirect(to: dashboard_path(conn, :index))
+      end
+    else
+      conn
+      |> put_flash(:alert, "Pylon support is not enabled for this organization.")
+      |> redirect(to: dashboard_path(conn, :index))
+    end
   end
 
   def submit(conn, params) do
@@ -144,4 +168,12 @@ defmodule FrontWeb.SupportController do
   defp billing_url(org) do
     "https://billing.#{Application.get_env(:front, :domain)}/?organization=#{org.username}"
   end
+
+  defp pylon_support_enabled?(org_id) when is_binary(org_id) and org_id != "" do
+    FeatureProvider.feature_enabled?(:pylon_support, param: org_id)
+  rescue
+    _ -> false
+  end
+
+  defp pylon_support_enabled?(_), do: false
 end

--- a/front/lib/front_web/router.ex
+++ b/front/lib/front_web/router.ex
@@ -698,6 +698,7 @@ defmodule FrontWeb.Router do
     end
 
     # Support Page
+    get("/support/pylon", SupportController, :pylon)
     get("/support", SupportController, :new)
 
     post("/support", SupportController, :submit)

--- a/front/lib/front_web/templates/layout/_page_header.html.eex
+++ b/front/lib/front_web/templates/layout/_page_header.html.eex
@@ -124,6 +124,7 @@
             card_description: "Semaphore 2.0 documentation",
             tooltip: false %>
       <%= contact_support_card(@conn, @layout_model) %>
+      <%= pylon_contact_support_card(@conn, @layout_model) %>
       <%= support_requests_card(@conn, @layout_model) %>
       <%= render FrontWeb.LayoutView, "page_header/_menu_card.html",
             options: [target: "_blank", rel: "noopener"],

--- a/front/lib/front_web/views/shared_helpers.ex
+++ b/front/lib/front_web/views/shared_helpers.ex
@@ -486,6 +486,41 @@ defmodule FrontWeb.SharedHelpers do
     end
   end
 
+  @spec pylon_contact_support_card(Plug.Conn.t(), LayoutModel.t()) :: renderable()
+  def pylon_contact_support_card(conn, layout_model) do
+    org_id = conn.assigns[:organization_id]
+    valid_permissions? = layout_model.permissions["organization.contact_support"]
+
+    with_pylon_support? = FeatureProvider.feature_enabled?(:pylon_support, param: org_id)
+
+    organization_restricted? =
+      FeatureProvider.feature_enabled?(:restricted_support, param: org_id)
+
+    cond do
+      not with_pylon_support? ->
+        nil
+
+      organization_restricted? and not valid_permissions? ->
+        Phoenix.View.render(FrontWeb.LayoutView, "page_header/_menu_card.html",
+          options: [disabled: true],
+          card_url: "#",
+          card_title: "Contact Support (Experimental)",
+          card_description: "Pylon knowledge base and support",
+          tooltip:
+            "Your access to Semaphore support has been limited. Please contact your organization's Admin for more information."
+        )
+
+      true ->
+        Phoenix.View.render(FrontWeb.LayoutView, "page_header/_menu_card.html",
+          options: [target: "_blank", rel: "noopener"],
+          card_url: RouteHelper.support_path(conn, :pylon),
+          card_title: "Contact Support (Experimental)",
+          card_description: "Pylon knowledge base and support",
+          tooltip: false
+        )
+    end
+  end
+
   @spec support_requests_card(Plug.Conn.t(), LayoutModel.t()) :: renderable()
   def support_requests_card(conn, layout_model) do
     org_id = conn.assigns[:organization_id]

--- a/front/test/front/pylon_test.exs
+++ b/front/test/front/pylon_test.exs
@@ -1,0 +1,99 @@
+defmodule Front.PylonTest do
+  use ExUnit.Case, async: false
+
+  alias Front.Pylon
+
+  setup do
+    org_slug = Application.get_env(:front, :pylon_org_slug)
+    jwt_secret = Application.get_env(:front, :pylon_jwt_secret)
+    jwt_issuer = Application.get_env(:front, :pylon_jwt_issuer)
+    jwt_callback_url = Application.get_env(:front, :pylon_jwt_callback_url)
+    jwt_ttl_seconds = Application.get_env(:front, :pylon_jwt_ttl_seconds)
+
+    on_exit(fn ->
+      restore_env(:pylon_org_slug, org_slug)
+      restore_env(:pylon_jwt_secret, jwt_secret)
+      restore_env(:pylon_jwt_issuer, jwt_issuer)
+      restore_env(:pylon_jwt_callback_url, jwt_callback_url)
+      restore_env(:pylon_jwt_ttl_seconds, jwt_ttl_seconds)
+    end)
+
+    :ok
+  end
+
+  describe "new_ticket_location/2" do
+    test "returns callback URL with JWT token and required claims" do
+      Application.put_env(:front, :pylon_org_slug, "semaphore")
+      Application.put_env(:front, :pylon_jwt_secret, "secret")
+      Application.put_env(:front, :pylon_jwt_issuer, "https://semaphoreci.com")
+
+      Application.put_env(
+        :front,
+        :pylon_jwt_callback_url,
+        "https://graph.usepylon.com/callback/jwt"
+      )
+
+      assert {:ok, url} = Pylon.new_ticket_location(%{email: "foo@example.com"}, "org-123")
+
+      query = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+      token = query["access_token"]
+
+      assert query["orgSlug"] == "semaphore"
+      assert is_binary(token)
+      assert token != ""
+
+      signer = Joken.Signer.create("HS256", "secret")
+
+      assert {:ok, claims} = Joken.verify(token, signer)
+      assert claims["email"] == "foo@example.com"
+      assert claims["aud"] == "https://portal.usepylon.com"
+      assert claims["iss"] == "https://semaphoreci.com/"
+      assert claims["account_external_id"] == "org-123"
+      assert is_integer(claims["iat"])
+      assert is_integer(claims["exp"])
+      assert claims["exp"] > claims["iat"]
+    end
+
+    test "returns error when required config is missing" do
+      Application.delete_env(:front, :pylon_org_slug)
+      Application.delete_env(:front, :pylon_jwt_secret)
+      Application.delete_env(:front, :pylon_jwt_issuer)
+
+      assert {:error, :missing_pylon_jwt_secret} =
+               Pylon.new_ticket_location(%{email: "foo@example.com"}, "org-123")
+    end
+
+    test "returns error when org_id is missing" do
+      Application.put_env(:front, :pylon_org_slug, "semaphore")
+      Application.put_env(:front, :pylon_jwt_secret, "secret")
+      Application.put_env(:front, :pylon_jwt_issuer, "https://semaphoreci.com")
+
+      assert {:error, :invalid_org_id} =
+               Pylon.new_ticket_location(%{email: "foo@example.com"}, "")
+    end
+
+    test "uses short default JWT TTL" do
+      Application.put_env(:front, :pylon_org_slug, "semaphore")
+      Application.put_env(:front, :pylon_jwt_secret, "secret")
+      Application.put_env(:front, :pylon_jwt_issuer, "https://semaphoreci.com")
+      Application.delete_env(:front, :pylon_jwt_ttl_seconds)
+
+      assert {:ok, url} = Pylon.new_ticket_location(%{email: "foo@example.com"}, "org-123")
+
+      token =
+        url
+        |> URI.parse()
+        |> Map.fetch!(:query)
+        |> URI.decode_query()
+        |> Map.fetch!("access_token")
+
+      signer = Joken.Signer.create("HS256", "secret")
+
+      assert {:ok, claims} = Joken.verify(token, signer)
+      assert claims["exp"] - claims["iat"] == 300
+    end
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:front, key)
+  defp restore_env(key, value), do: Application.put_env(:front, key, value)
+end

--- a/front/test/front_web/controllers/support_controller_test.exs
+++ b/front/test/front_web/controllers/support_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule FrontWeb.SupportControllerTest do
   use FrontWeb.ConnCase
+  import Mock
 
   setup %{conn: conn} do
     Cacheman.clear(:front)
@@ -35,6 +36,89 @@ defmodule FrontWeb.SupportControllerTest do
         |> get("/support")
 
       assert html_response(conn, 404) =~ "404"
+    end
+
+    test "redirects to support URL", %{conn: conn} do
+      with_mock Front.Zendesk, new_ticket_location: fn -> "https://support-url.test" end do
+        conn =
+          conn
+          |> get("/support")
+
+        assert redirected_to(conn) == "https://support-url.test"
+      end
+    end
+  end
+
+  describe "GET pylon" do
+    test "redirects to pylon support URL when feature is enabled", %{
+      conn: conn,
+      organization: organization
+    } do
+      org_id = organization.id
+
+      with_mocks([
+        {FeatureProvider, [],
+         [
+           feature_enabled?: fn
+             :pylon_support, [param: ^org_id] -> true
+             _, _ -> false
+           end
+         ]},
+        {Front.Pylon, [],
+         [
+           new_ticket_location: fn %{email: email}, ^org_id ->
+             assert is_binary(email) and email != ""
+             {:ok, "https://pylon-support.test"}
+           end
+         ]}
+      ]) do
+        conn =
+          conn
+          |> get("/support/pylon")
+
+        assert redirected_to(conn) == "https://pylon-support.test"
+      end
+    end
+
+    test "shows alert when feature is disabled", %{conn: conn} do
+      with_mocks([
+        {FeatureProvider, [],
+         [
+           feature_enabled?: fn
+             :pylon_support, [param: _org_id] -> false
+             _, _ -> false
+           end
+         ]}
+      ]) do
+        conn =
+          conn
+          |> get("/support/pylon")
+
+        assert redirected_to(conn) == "/"
+        assert get_flash(conn, :alert) == "Pylon support is not enabled for this organization."
+      end
+    end
+
+    test "shows alert when pylon URL generation fails", %{conn: conn} do
+      with_mocks([
+        {FeatureProvider, [],
+         [
+           feature_enabled?: fn
+             :pylon_support, [param: _org_id] -> true
+             _, _ -> false
+           end
+         ]},
+        {Front.Pylon, [], [new_ticket_location: fn _, _ -> {:error, :missing_config} end]}
+      ]) do
+        conn =
+          conn
+          |> get("/support/pylon")
+
+        assert redirected_to(conn) == "/"
+
+        assert get_flash(conn, :alert) ==
+                 "Unable to open Pylon support right now. Please try again."
+      end
     end
   end
 

--- a/front/test/front_web/views/shared_helpers_test.exs
+++ b/front/test/front_web/views/shared_helpers_test.exs
@@ -1,5 +1,6 @@
 defmodule FrontWeb.SharedHelpersTest do
   use FrontWeb.ConnCase
+  import Mock
 
   setup do
     Support.FakeServices.stub_responses()
@@ -26,6 +27,43 @@ defmodule FrontWeb.SharedHelpersTest do
 
       {:safe, image_string_with_height} = FrontWeb.SharedHelpers.icon("test", height: "24")
       assert image_string_with_height =~ "height='24'"
+    end
+  end
+
+  describe "pylon_contact_support_card/2" do
+    test "returns nil when pylon feature is disabled", %{conn: conn} do
+      layout_model = %Front.Layout.Model{permissions: %{"organization.contact_support" => true}}
+
+      conn =
+        conn
+        |> assign(:organization_id, "org-1")
+
+      with_mock FeatureProvider, feature_enabled?: fn _, _ -> false end do
+        assert FrontWeb.SharedHelpers.pylon_contact_support_card(conn, layout_model) == nil
+      end
+    end
+
+    test "returns support menu card when pylon feature is enabled", %{conn: conn} do
+      layout_model = %Front.Layout.Model{permissions: %{"organization.contact_support" => true}}
+
+      conn =
+        conn
+        |> assign(:organization_id, "org-1")
+
+      with_mock FeatureProvider,
+        feature_enabled?: fn
+          :pylon_support, [param: "org-1"] -> true
+          :restricted_support, [param: "org-1"] -> false
+          _, _ -> false
+        end do
+        card_html =
+          conn
+          |> FrontWeb.SharedHelpers.pylon_contact_support_card(layout_model)
+          |> Phoenix.HTML.safe_to_string()
+
+        assert card_html =~ "Contact Support (Experimental)"
+        assert card_html =~ "href=\"/support/pylon\""
+      end
     end
   end
 end


### PR DESCRIPTION
## 📝 Description

Added a Pylon Support entry in the Help menu that redirects through `/support/pylon` and generates a short-lived JWT SSO URL.

More details in [the task](https://github.com/renderedtext/tasks/issues/9314).

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
