### PR TITLE
fix(gofer): increase the default timeout to 10s

### DIFF
--- a/ee/gofer/lib/gofer/rbac/client.ex
+++ b/ee/gofer/lib/gofer/rbac/client.ex
@@ -11,7 +11,7 @@ defmodule Gofer.RBAC.Client do
   alias Gofer.RBAC.Subject
 
   @metric_prefix "Gofer.deployments.rbac"
-  @default_timeout 3_000
+  @default_timeout 10_000
 
   def check_roles(_subject, []), do: {:ok, %{}}
 


### PR DESCRIPTION
## 📝 Description
Increase the default gofer timeout to 10 seconds.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
