### PR TITLE
fix(front): properly pass parameters when navigating dt history pages

### DIFF
--- a/front/lib/front_web/templates/deployments/_history.html.eex
+++ b/front/lib/front_web/templates/deployments/_history.html.eex
@@ -42,21 +42,21 @@
         <%= if @page.cursor_after do %>
             <div>
                 Back to <%= link "Newest", to: deployments_path(@conn, :show, @project.name, @target.id,
-                    filters: @page_args[:filters]) %>
+                    Map.to_list(@page_args[:filters])) %>
                 <span class="ml1 mr2">·</span>
             </div>
         <% end %>
         <div class="button-group">
             <%= if @page.cursor_after do %>
                 <%= link "Newer", class: "btn btn-secondary", to: deployments_path(@conn, :show, @project.name, @target.id,
-                        direction: :AFTER, timestamp: @page.cursor_after, filters: @page_args[:filters]) %>
+                        [direction: :AFTER, timestamp: @page.cursor_after] ++ Map.to_list(@page_args[:filters])) %>
             <% else %>
                 <button class="btn btn-secondary" disabled="disabled">Newer</button>
             <% end %>
 
             <%= if @page.cursor_before do %>
                 <%= link "Older", class: "btn btn-secondary", to: deployments_path(@conn, :show, @project.name, @target.id,
-                        direction: :BEFORE, timestamp: @page.cursor_before, filters: @page_args[:filters]) %>
+                        [direction: :BEFORE, timestamp: @page.cursor_before] ++ Map.to_list(@page_args[:filters])) %>
             <% else %>
                 <button class="btn btn-secondary" disabled="disabled">Older</button>
             <% end %>


### PR DESCRIPTION
## 📝 Description
Deployment target history pagination links lose search/filter parameters when navigating pages. The PR fixes this problem.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
