### PR TITLE
fix(front): add https:// protocol to graph.usepylon.com in CSP form-action

### DIFF
--- a/front/lib/front_web/plugs/content_security_policy.ex
+++ b/front/lib/front_web/plugs/content_security_policy.ex
@@ -37,7 +37,7 @@ defmodule FrontWeb.Plug.ContentSecurityPolicy do
         connect_src: connect_src(),
         default_src: ~w('none'),
         form_action:
-          ~w('self' semaphoreci.zendesk.com bitbucket.org github.com gitlab.com graph.usepylon.com) ++
+          ~w('self' semaphoreci.zendesk.com bitbucket.org github.com gitlab.com https://graph.usepylon.com) ++
             ["*.#{base_domain}"],
         media_src: ~w(beacon-v2.helpscout.net),
         child_src: ~w('self'),

--- a/front/test/front_web/plugs/content_security_policy_test.exs
+++ b/front/test/front_web/plugs/content_security_policy_test.exs
@@ -23,7 +23,7 @@ defmodule FrontWeb.Plug.ContentSecurityPolicyTest do
       assert header_value =~ "storage.googleapis.com"
       assert header_value =~ "https://widget.usepylon.com"
       assert header_value =~ "https://*.usepylon.com"
-      assert header_value =~ ~r/form-action[^;]*graph\.usepylon\.com/
+      assert header_value =~ ~r/form-action[^;]*https:\/\/graph\.usepylon\.com/
       assert header_value =~ "https://pylon-avatars.s3.us-west-1.amazonaws.com"
     end
 


### PR DESCRIPTION
## 📝 Description
Adds the `https://` protocol to the Pylon form-action CSP rule.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
