### PR TITLE
fix: fix undefined on the edit workflow on a restricted secret

### DIFF
--- a/front/assets/js/workflow_editor/models/secrets.js
+++ b/front/assets/js/workflow_editor/models/secrets.js
@@ -59,7 +59,7 @@ export class Secrets {
 
   allSecretNames() {
     let allSecretsInOrg = _.cloneDeep(Secrets.validSecretNames())
-    let allSecretsOnBlock = this.secrets.map((s) => s.name())
+    let allSecretsOnBlock = this.secrets.map((s) => s.name()).filter(Boolean)
 
     let allSecrets = _.concat(allSecretsInOrg, allSecretsOnBlock).sort()
 


### PR DESCRIPTION
## 📝 Description
<!-- Describe your changes in detail -->

Fixes a bug where having a secret not whitelisted to a new project caused the edit workflow to show undefined as an option of secret. The undefined won't be shown with this.

So steps to reproduce:

1. Create an org secret with project whitelisting (only allow specific projects)
2. In a different project's semaphore.yml, reference that secret
3. Open the workflow editor for that project → you'll see the error + undefined


## ✅ Checklist
- [x] I have tested this change
- [x] ~~This change requires documentation update~~
