### PR TITLE
fix(github_hooks): downgrade connection_pool to version < 3 to resolve compatibility issues with Sidekiq 7

### DIFF
--- a/github_hooks/Gemfile
+++ b/github_hooks/Gemfile
@@ -22,7 +22,7 @@ gem "kaminari", "~> 1.2.2"
 gem "lograge"
 gem "octokit"
 gem "retryable"
-gem "sidekiq", "< 8"
+gem "sidekiq", "7.3.10"
 gem "connection_pool", "< 3" # Sidekiq 7 scheduler uses positional TimedStack#pop API
 gem "sidekiq-scheduler"
 gem "sidekiq-unique-jobs", "~> 8.0"

--- a/github_hooks/Gemfile
+++ b/github_hooks/Gemfile
@@ -23,6 +23,7 @@ gem "lograge"
 gem "octokit"
 gem "retryable"
 gem "sidekiq", "< 8"
+gem "connection_pool", "< 3" # Sidekiq 7 scheduler uses positional TimedStack#pop API
 gem "sidekiq-scheduler"
 gem "sidekiq-unique-jobs", "~> 8.0"
 gem "puma"

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -433,12 +433,12 @@ GEM
       activesupport (>= 4.2.0)
     show_me_the_cookies (6.0.0)
       capybara (>= 2, < 4)
-    sidekiq (7.3.9)
+    sidekiq (7.3.10)
       base64
-      connection_pool (>= 2.3.0)
+      connection_pool (>= 2.3.0, < 3)
       logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
+      rack (>= 2.2.4, < 3.3)
+      redis-client (>= 0.23.0, < 1)
     sidekiq-scheduler (6.0.1)
       rufus-scheduler (~> 3.2)
       sidekiq (>= 7.3, < 9)
@@ -553,7 +553,7 @@ DEPENDENCIES
   shoulda (~> 4.0)
   shoulda-matchers
   show_me_the_cookies
-  sidekiq (< 8)
+  sidekiq (= 7.3.10)
   sidekiq-scheduler
   sidekiq-unique-jobs (~> 8.0)
   spring (~> 4.1)

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -510,6 +510,7 @@ DEPENDENCIES
   bullet
   bundler (>= 1.8.4)
   bunny
+  connection_pool (< 3)
   database_cleaner
   dotenv (~> 3.0)
   excon (~> 0.81.0)


### PR DESCRIPTION
## 📝 Description

Pins `connection_pool` to `< 3` in `github_hooks` to maintain compatibility with the current Sidekiq 7 runtime behavior. The change prevents scheduler startup failures that were causing scheduled jobs to remain in `ScheduledSet` instead of being enqueued. This restores normal processing of `perform_in` jobs.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
