### PR TITLE
fix(front): enhance error handling for workflow fetching in project page

### DIFF
--- a/front/lib/front/models/workflow.ex
+++ b/front/lib/front/models/workflow.ex
@@ -258,8 +258,16 @@ defmodule Front.Models.Workflow do
       |> Keyword.merge(git_ref_types: ref_types, direction: direction)
       |> ListLatestWorkflowsRequest.new()
 
-    {:ok, response} = Clients.Workflow.list_latest_workflows(req)
-    {construct(response.workflows), response.next_page_token, response.previous_page_token}
+    case Clients.Workflow.list_latest_workflows(req) do
+      {:ok, %InternalApi.PlumberWF.ListLatestWorkflowsResponse{} = response} ->
+        {construct(response.workflows), response.next_page_token, response.previous_page_token}
+
+      {:ok, unexpected_response} ->
+        {:error, {:unexpected_response, unexpected_response}}
+
+      error ->
+        error
+    end
   end
 
   defp request_stream(req, tracing_headers, override \\ nil) do

--- a/front/lib/front/project_page/model.ex
+++ b/front/lib/front/project_page/model.ex
@@ -12,6 +12,7 @@ defmodule Front.ProjectPage.Model do
     field(:user_page?, boolean())
     field(:ref_types, String.t())
     field(:workflows, [Front.Model.Workflow.t()], enforce: true)
+    field(:workflow_fetch_error, String.t())
     field(:branches, [Front.Model.Branch.t()])
     field(:organization, Front.Model.Organization.t())
     field(:pagination, Front.ProjectPage.Model.Pagination.t())
@@ -45,6 +46,8 @@ defmodule Front.ProjectPage.Model do
 
   @cache_prefix "project_page_model"
   @cache_version :crypto.hash(:md5, File.read(__ENV__.file) |> elem(1)) |> Base.encode64()
+  @workflow_timeout_error_message "Loading workflows timed out. Please try again in a moment."
+  @workflow_fetch_error_message "We couldn't load workflows right now. Please try again in a moment."
   # Used to update the model cache version, when there is no change in the model file
   # @cache_hidden_version = "2"
 
@@ -93,7 +96,9 @@ defmodule Front.ProjectPage.Model do
     load_from_api(params)
     |> case do
       {:ok, data, _} ->
-        Cacheman.put(:front, cache_key(params), encode(data))
+        if is_nil(data.workflow_fetch_error) do
+          Cacheman.put(:front, cache_key(params), encode(data))
+        end
 
         {:ok, data, :from_api}
 
@@ -149,7 +154,11 @@ defmodule Front.ProjectPage.Model do
           end)
         end)
 
-      {:ok, {workflows, next_page_token, previous_page_token}} = Async.await(fetch_workflows)
+      {workflows, next_page_token, previous_page_token, workflow_fetch_error} =
+        fetch_workflows
+        |> Async.await()
+        |> workflow_data(params)
+
       {:ok, organization} = Async.await(fetch_organization)
       {:ok, project} = Async.await(fetch_project)
 
@@ -175,6 +184,7 @@ defmodule Front.ProjectPage.Model do
           user_page?: params.user_page?,
           ref_types: params.ref_types,
           workflows: workflows,
+          workflow_fetch_error: workflow_fetch_error,
           branches: [],
           organization: organization,
           pagination: pagination
@@ -218,17 +228,26 @@ defmodule Front.ProjectPage.Model do
         "project_page_model_list_latest_workflows"
       end
 
-    {wfs, next_page_token, previous_page_token} =
+    workflow_response =
       Watchman.benchmark(workflow_api_metric_name, fn ->
         Models.Workflow.list_latest_workflows(list_params)
       end)
 
-    workflows =
-      Watchman.benchmark("project_page_model_decorate_workflows", fn ->
-        Decorators.Workflow.decorate_many(wfs)
-      end)
+    case workflow_response do
+      {wfs, next_page_token, previous_page_token} when is_list(wfs) ->
+        workflows =
+          Watchman.benchmark("project_page_model_decorate_workflows", fn ->
+            Decorators.Workflow.decorate_many(wfs)
+          end)
 
-    {workflows, next_page_token, previous_page_token}
+        {:ok, {workflows, next_page_token, previous_page_token}}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      unexpected ->
+        {:error, {:unexpected_workflow_response, unexpected}}
+    end
   end
 
   defp list_workflows_keyset(params) do
@@ -252,17 +271,26 @@ defmodule Front.ProjectPage.Model do
         "project_page_model_list_keyset"
       end
 
-    {wfs, next_page_token, previous_page_token} =
+    workflow_response =
       Watchman.benchmark(workflow_api_metric_name, fn ->
         Models.Workflow.list_keyset(list_params)
       end)
 
-    workflows =
-      Watchman.benchmark("project_page_model_decorate_workflows", fn ->
-        Decorators.Workflow.decorate_many(wfs)
-      end)
+    case workflow_response do
+      {wfs, next_page_token, previous_page_token} when is_list(wfs) ->
+        workflows =
+          Watchman.benchmark("project_page_model_decorate_workflows", fn ->
+            Decorators.Workflow.decorate_many(wfs)
+          end)
 
-    {workflows, next_page_token, previous_page_token}
+        {:ok, {workflows, next_page_token, previous_page_token}}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      unexpected ->
+        {:error, {:unexpected_workflow_response, unexpected}}
+    end
   end
 
   defp maybe_put_requester(list_params, true, requester_id),
@@ -273,4 +301,50 @@ defmodule Front.ProjectPage.Model do
   defp keyset_direction("next"), do: KeysetDirection.value(:NEXT)
   defp keyset_direction("previous"), do: KeysetDirection.value(:PREVIOUS)
   defp keyset_direction(_), do: nil
+
+  defp workflow_data({:ok, {:ok, {workflows, next_page_token, previous_page_token}}}, _params),
+    do: {workflows, next_page_token, previous_page_token, nil}
+
+  defp workflow_data({:ok, {workflows, next_page_token, previous_page_token}}, _params)
+       when is_list(workflows),
+       do: {workflows, next_page_token, previous_page_token, nil}
+
+  defp workflow_data({:ok, {:error, reason}}, params),
+    do: workflow_fetch_error_payload(reason, params)
+
+  defp workflow_data({:exit, reason}, params), do: workflow_fetch_error_payload(reason, params)
+  defp workflow_data({:error, reason}, params), do: workflow_fetch_error_payload(reason, params)
+
+  defp workflow_data(unexpected, params),
+    do: workflow_fetch_error_payload({:unexpected_async_response, unexpected}, params)
+
+  defp workflow_fetch_error_payload(reason, params) do
+    Logger.error(
+      "[PROJECT PAGE MODEL] Workflow fetch failed for org_id=#{params.organization_id} project_id=#{params.project_id} user_id=#{params.user_id}: #{inspect(reason)}"
+    )
+
+    {[], "", "", workflow_fetch_error_message(reason)}
+  end
+
+  defp workflow_fetch_error_message(error) do
+    if workflow_timeout_error?(error) do
+      @workflow_timeout_error_message
+    else
+      @workflow_fetch_error_message
+    end
+  end
+
+  defp workflow_timeout_error?(error) do
+    error
+    |> workflow_error_message()
+    |> String.downcase()
+    |> then(fn message ->
+      String.contains?(message, "deadline") or
+        String.contains?(message, "timeout") or
+        String.contains?(message, "timed out")
+    end)
+  end
+
+  defp workflow_error_message(%MatchError{term: term}), do: inspect(term)
+  defp workflow_error_message(error), do: inspect(error)
 end

--- a/front/lib/front/project_page/model.ex
+++ b/front/lib/front/project_page/model.ex
@@ -305,10 +305,6 @@ defmodule Front.ProjectPage.Model do
   defp workflow_data({:ok, {:ok, {workflows, next_page_token, previous_page_token}}}, _params),
     do: {workflows, next_page_token, previous_page_token, nil}
 
-  defp workflow_data({:ok, {workflows, next_page_token, previous_page_token}}, _params)
-       when is_list(workflows),
-       do: {workflows, next_page_token, previous_page_token, nil}
-
   defp workflow_data({:ok, {:error, reason}}, params),
     do: workflow_fetch_error_payload(reason, params)
 

--- a/front/lib/front_web/controllers/project_controller.ex
+++ b/front/lib/front_web/controllers/project_controller.ex
@@ -124,7 +124,8 @@ defmodule FrontWeb.ProjectController do
         workflows: model.workflows,
         pagination: model.pagination,
         pollman: pollman(conn, model),
-        page: :project
+        page: :project,
+        workflow_fetch_error: model.workflow_fetch_error
       )
     end)
   end

--- a/front/test/front/models/workflow_test.exs
+++ b/front/test/front/models/workflow_test.exs
@@ -193,6 +193,16 @@ defmodule Front.Models.WorkflowTest do
     end
   end
 
+  describe ".list_latest_workflows" do
+    test "returns client error when list_latest_workflows fails" do
+      with_mock Front.Clients.Workflow, [:passthrough],
+        list_latest_workflows: fn _ -> {:error, "Error when opening connection: :timeout"} end do
+        assert {:error, "Error when opening connection: :timeout"} =
+                 Workflow.list_latest_workflows()
+      end
+    end
+  end
+
   defp sample_hook do
     %InternalApi.RepoProxy.DescribeResponse{
       hook: %InternalApi.RepoProxy.Hook{

--- a/front/test/front/project_page/model_test.exs
+++ b/front/test/front/project_page/model_test.exs
@@ -1,6 +1,8 @@
 defmodule Front.ProjectPage.ModelTest do
   use ExUnit.Case
 
+  import Mock
+
   alias Front.ProjectPage.Model
   alias Front.ProjectPage.Model.LoadParams
 
@@ -21,6 +23,49 @@ defmodule Front.ProjectPage.ModelTest do
         )
 
       {:ok, _data, :from_api} = Model.load_from_api(params)
+    end
+
+    test "returns degraded model when workflow list times out" do
+      params =
+        struct!(LoadParams,
+          project_id: "2e4ca2aa-ab16-4eb7-924d-0d698f7ca555",
+          organization_id: "2e4ca2aa-ab16-4eb7-924d-0d698f7ca555",
+          page_token: "dae0438b-4645-49a0-8254-19e4ea7b9f89",
+          direction: "next",
+          user_page?: false,
+          ref_types: ["branch"]
+        )
+
+      with_mock Front.Models.Workflow, [:passthrough],
+        list_latest_workflows: fn _ -> {:error, :timeout} end do
+        {:ok, data, :from_api} = Model.load_from_api(params)
+
+        assert data.workflows == []
+        assert data.workflow_fetch_error =~ "Loading workflows timed out"
+      end
+    end
+
+    test "returns degraded model when keyset workflow fetch fails" do
+      params =
+        struct!(LoadParams,
+          project_id: "2e4ca2aa-ab16-4eb7-924d-0d698f7ca555",
+          organization_id: "2e4ca2aa-ab16-4eb7-924d-0d698f7ca555",
+          page_token: "",
+          direction: "next",
+          list_mode: "all_pipelines",
+          user_page?: false,
+          ref_types: ["pr"]
+        )
+
+      rpc_error = %GRPC.RPCError{status: 2, message: "Internal Server Error"}
+
+      with_mock Front.Models.Workflow, [:passthrough],
+        list_keyset: fn _ -> {:error, rpc_error} end do
+        {:ok, data, :from_api} = Model.load_from_api(params)
+
+        assert data.workflows == []
+        assert data.workflow_fetch_error =~ "couldn't load workflows"
+      end
     end
   end
 

--- a/front/test/front_web/controllers/project_controller_test.exs
+++ b/front/test/front_web/controllers/project_controller_test.exs
@@ -362,6 +362,44 @@ defmodule FrontWeb.ProjectControllerTest do
 
       assert html_response(conn, 200)
     end
+
+    test "returns 200 with timeout message when workflow fetch times out", %{
+      conn: conn,
+      project: project
+    } do
+      with_mock Front.Models.Workflow, [:passthrough],
+        list_latest_workflows: fn _ -> {:error, :timeout} end do
+        conn =
+          conn
+          |> get("/projects/#{project.name}/workflows?force_cold_boot=true")
+
+        assert html_response(conn, 200) =~ "Loading workflows timed out"
+      end
+    end
+
+    test "returns 200 with fallback message when keyset workflow fetch fails", %{
+      conn: conn,
+      project: project,
+      organization: organization
+    } do
+      rpc_error = %GRPC.RPCError{status: 2, message: "Internal Server Error"}
+
+      Support.Stubs.Feature.setup_feature("project_page_all_pipelines",
+        state: :ENABLED,
+        quantity: 1
+      )
+
+      Support.Stubs.Feature.enable_feature(organization.id, :project_page_all_pipelines)
+
+      with_mock Front.Models.Workflow, [:passthrough],
+        list_keyset: fn _ -> {:error, rpc_error} end do
+        conn =
+          conn
+          |> get("/projects/#{project.name}/workflows?force_cold_boot=true&listing=all_pipelines")
+
+        assert html_response(conn, 200) =~ "load workflows right now"
+      end
+    end
   end
 
   describe "GET check_commit_job" do


### PR DESCRIPTION
## 📝 Description

Improves frontend resilience when workflow data retrieval fails due to backend timeout/internal/unexpected errors, preventing crashes and 500 responses. The page now degrades gracefully with a clear user-facing error state.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
