### PR TITLE
fix(bitbucket): update API calls to use user workspaces endpoints

### DIFF
--- a/front/assets/js/project_onboarding/new/components/repository_selector.tsx
+++ b/front/assets/js/project_onboarding/new/components/repository_selector.tsx
@@ -23,6 +23,11 @@ interface ApiResponse {
   next_page_token?: string;
 }
 
+interface ApiErrorResponse {
+  error?: string;
+  message?: string;
+}
+
 interface RepositorySelectorProps {
   repositoriesUrl: string;
   githubInstallUrl?: string;
@@ -53,13 +58,50 @@ export const RepositorySelector = (props: RepositorySelectorProps) => {
     [repositories, searchQuery]
   );
 
+  const parseErrorMessage = (payload: unknown): string | null => {
+    if (!payload || typeof payload !== `object`) return null;
+
+    const message =
+      `message` in payload && typeof payload.message === `string` ? payload.message : null;
+    const code = `error` in payload && typeof payload.error === `string` ? payload.error : null;
+
+    if (message && code) return `${message} (${code})`;
+    if (message) return message;
+    if (code) return code;
+
+    return null;
+  };
+
   const loadRepositories = async (url: string) => {
     if (!url || isLoading) return;
     setIsLoading(true);
 
     try {
       const response = await fetch(url);
-      const json: ApiResponse = await response.json();
+      const contentType = response.headers.get(`content-type`) || ``;
+      const isJson = contentType.includes(`application/json`);
+
+      if (!isJson) {
+        const responseBody = await response.text();
+        const responsePreview = responseBody.replace(/\s+/g, ` `).trim().slice(0, 200);
+        const details = responsePreview ? `: ${responsePreview}` : ``;
+
+        throw new Error(`Failed to load repositories (HTTP ${response.status})${details}`);
+      }
+
+      const payload: ApiResponse | ApiErrorResponse = await response.json();
+
+      if (!response.ok) {
+        const message = parseErrorMessage(payload);
+        throw new Error(message || `Failed to load repositories (HTTP ${response.status})`);
+      }
+
+      const json = payload as ApiResponse;
+      if (!json || !Array.isArray(json.repos)) {
+        const message = parseErrorMessage(payload);
+        throw new Error(message || `Failed to load repositories: invalid response payload`);
+      }
+
       const repos = json.repos;
 
       setRepositories(prev => [...prev, ... repos]);
@@ -71,7 +113,8 @@ export const RepositorySelector = (props: RepositorySelectorProps) => {
         void loadRepositories(nextUrl);
       }
     } catch (error) {
-      Notice.error(`Error loading repositories: ${String(error)}`);
+      const message = error instanceof Error ? error.message : String(error);
+      Notice.error(`Error loading repositories: ${message}`);
     } finally {
       setIsLoading(false);
     }

--- a/front/lib/front/models/repository.ex
+++ b/front/lib/front/models/repository.ex
@@ -1,6 +1,11 @@
 defmodule Front.Models.Repository do
+  require Logger
+
   defstruct [:name, :description, :url, :owner_name, :owner_avatar, :addable]
 
+  @spec list_repositories(String.t(), String.t(), String.t(), boolean()) ::
+          {:ok, %{repos: list(), next_page_token: String.t()}}
+          | {:error, %{error: String.t(), message: String.t()}}
   def list_repositories(user_id, integration_type, page_token, open_source) do
     req =
       InternalApi.Repository.ListAccessibleRepositoriesRequest.new(
@@ -13,17 +18,29 @@ defmodule Front.Models.Repository do
     {:ok, channel} =
       GRPC.Stub.connect(Application.fetch_env!(:front, :repositoryhub_grpc_endpoint))
 
-    {:ok, res} =
-      InternalApi.Repository.RepositoryService.Stub.list_accessible_repositories(
-        channel,
-        req,
-        timeout: 30_000
-      )
+    case InternalApi.Repository.RepositoryService.Stub.list_accessible_repositories(
+           channel,
+           req,
+           timeout: 30_000
+         ) do
+      {:ok, res} ->
+        {:ok,
+         %{
+           repos: map_repos(res.repositories),
+           next_page_token: res.next_page_token
+         }}
 
-    %{
-      repos: map_repos(res.repositories),
-      next_page_token: res.next_page_token
-    }
+      {:error, error} ->
+        Logger.error(
+          "[Repository Model] list_accessible_repositories failed for user #{user_id}, integration #{integration_type}: #{inspect(error)}"
+        )
+
+        {:error,
+         %{
+           error: "repository_service_unavailable",
+           message: "Failed to load repositories. Please retry."
+         }}
+    end
   end
 
   defp map_integratin_type("github_oauth_token"),

--- a/front/lib/front_web/controllers/project_onboarding_controller.ex
+++ b/front/lib/front_web/controllers/project_onboarding_controller.ex
@@ -510,15 +510,20 @@ defmodule FrontWeb.ProjectOnboardingController do
     fetch_organization = Async.run(fn -> Models.Organization.find(org_id) end)
     {:ok, organization} = Async.await(fetch_organization)
 
-    repositories =
-      Models.Repository.list_repositories(
-        user_id,
-        integration_type,
-        page_token,
-        organization.open_source
-      )
+    case Models.Repository.list_repositories(
+           user_id,
+           integration_type,
+           page_token,
+           organization.open_source
+         ) do
+      {:ok, repositories} ->
+        json(conn, repositories)
 
-    json(conn, repositories)
+      {:error, error_response} ->
+        conn
+        |> put_status(:service_unavailable)
+        |> json(error_response)
+    end
   end
 
   def project_repository_status(conn, params) do

--- a/front/test/front_web/controllers/project_onboarding_controller_test.exs
+++ b/front/test/front_web/controllers/project_onboarding_controller_test.exs
@@ -87,4 +87,34 @@ defmodule FrontWeb.ProjectOnboardingControllerTest do
       assert json["error"] == "Error from projecthub"
     end
   end
+
+  describe "GET repositories" do
+    test "returns repositories payload on success", %{conn: conn} do
+      conn =
+        conn
+        |> get("/repositories?integration_type=bitbucket&page_token=")
+
+      body = json_response(conn, 200)
+
+      assert is_list(body["repos"])
+      assert Map.has_key?(body, "next_page_token")
+    end
+
+    test "returns structured JSON error on repository service failure", %{conn: conn} do
+      GrpcMock.stub(RepositoryMock, :list_accessible_repositories, fn _, _ ->
+        raise GRPC.RPCError, status: GRPC.Status.unavailable(), message: "Repository service down"
+      end)
+
+      conn =
+        conn
+        |> get("/repositories?integration_type=bitbucket&page_token=")
+
+      body = json_response(conn, 503)
+
+      assert body == %{
+               "error" => "repository_service_unavailable",
+               "message" => "Failed to load repositories. Please retry."
+             }
+    end
+  end
 end

--- a/github_hooks/lib/internal_api/repository_integrator/repository_integrator_server.rb
+++ b/github_hooks/lib/internal_api/repository_integrator/repository_integrator_server.rb
@@ -137,7 +137,14 @@ module InternalApi
 
         if rha.repo_host == "bitbucket"
           token, _ = ::Semaphore::Bitbucket::Token.user_token(rha)
-          rha.update!(:revoked => !::Semaphore::Bitbucket::Token.valid?(token))
+          validation_state = ::Semaphore::Bitbucket::Token.validation_state(token)
+
+          case validation_state
+          when :valid
+            rha.update!(:revoked => false)
+          when :invalid
+            rha.update!(:revoked => true)
+          end
         end
 
         rha

--- a/github_hooks/lib/semaphore/bitbucket/token.rb
+++ b/github_hooks/lib/semaphore/bitbucket/token.rb
@@ -3,7 +3,11 @@ module Semaphore::Bitbucket
     def self.valid?(token)
       return false unless token.present?
 
-      response = Excon.get("https://api.bitbucket.org/2.0/repositories?access_token=#{token}")
+      response =
+        Excon.get(
+          "https://api.bitbucket.org/2.0/user/workspaces?pagelen=1",
+          :headers => { "Authorization" => "Bearer #{token}" }
+        )
 
       response.status <= 299
     end

--- a/github_hooks/lib/semaphore/bitbucket/token.rb
+++ b/github_hooks/lib/semaphore/bitbucket/token.rb
@@ -1,7 +1,7 @@
 module Semaphore::Bitbucket
   class Token
-    def self.valid?(token)
-      return false unless token.present?
+    def self.validation_state(token)
+      return :invalid unless token.present?
 
       response =
         Excon.get(
@@ -9,7 +9,20 @@ module Semaphore::Bitbucket
           :headers => { "Authorization" => "Bearer #{token}" }
         )
 
-      response.status <= 299
+      case response.status
+      when 200..299
+        :valid
+      when 401, 403
+        :invalid
+      else
+        :transient
+      end
+    rescue Excon::Error
+      :transient
+    end
+
+    def self.valid?(token)
+      validation_state(token) == :valid
     end
 
     def self.user_token(repo_host_account)

--- a/github_hooks/spec/lib/internal_api/repository_integrator/repository_integrator_server_spec.rb
+++ b/github_hooks/spec/lib/internal_api/repository_integrator/repository_integrator_server_spec.rb
@@ -467,6 +467,46 @@ RSpec.describe InternalApi::RepositoryIntegrator::RepositoryIntegratorServer do
     end
   end
 
+  describe "#update_revoke_status" do
+    let(:bitbucket_account) { FactoryBot.create(:bitbucket_account, :revoked => revoked) }
+    let(:revoked) { false }
+
+    before do
+      allow(Semaphore::Bitbucket::Token).to receive(:user_token).with(bitbucket_account).and_return(["token", nil])
+      allow(Semaphore::Bitbucket::Token).to receive(:validation_state).with("token").and_return(validation_state)
+    end
+
+    context "when token is valid" do
+      let(:revoked) { true }
+      let(:validation_state) { :valid }
+
+      it "marks connection as not revoked" do
+        server.send(:update_revoke_status, bitbucket_account)
+        expect(bitbucket_account.reload.revoked).to eq(false)
+      end
+    end
+
+    context "when token is invalid" do
+      let(:revoked) { false }
+      let(:validation_state) { :invalid }
+
+      it "marks connection as revoked" do
+        server.send(:update_revoke_status, bitbucket_account)
+        expect(bitbucket_account.reload.revoked).to eq(true)
+      end
+    end
+
+    context "when token check is transient" do
+      let(:revoked) { false }
+      let(:validation_state) { :transient }
+
+      it "keeps the existing revoked status" do
+        server.send(:update_revoke_status, bitbucket_account)
+        expect(bitbucket_account.reload.revoked).to eq(false)
+      end
+    end
+  end
+
   describe "#github_installation_info" do
     before do
       Semaphore::GithubApp::Credentials.instance_variable_set(:@github_application_url, nil)

--- a/github_hooks/spec/lib/internal_api/repository_integrator/repository_integrator_server_spec.rb
+++ b/github_hooks/spec/lib/internal_api/repository_integrator/repository_integrator_server_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe InternalApi::RepositoryIntegrator::RepositoryIntegratorServer do
 
       it "marks connection as not revoked" do
         server.send(:update_revoke_status, bitbucket_account)
-        expect(bitbucket_account.reload.revoked).to eq(false)
+        expect(bitbucket_account.reload.revoked).to be(false)
       end
     end
 
@@ -492,7 +492,7 @@ RSpec.describe InternalApi::RepositoryIntegrator::RepositoryIntegratorServer do
 
       it "marks connection as revoked" do
         server.send(:update_revoke_status, bitbucket_account)
-        expect(bitbucket_account.reload.revoked).to eq(true)
+        expect(bitbucket_account.reload.revoked).to be(true)
       end
     end
 
@@ -502,7 +502,7 @@ RSpec.describe InternalApi::RepositoryIntegrator::RepositoryIntegratorServer do
 
       it "keeps the existing revoked status" do
         server.send(:update_revoke_status, bitbucket_account)
-        expect(bitbucket_account.reload.revoked).to eq(false)
+        expect(bitbucket_account.reload.revoked).to be(false)
       end
     end
   end

--- a/github_hooks/spec/lib/semaphore/bitbucket/token_spec.rb
+++ b/github_hooks/spec/lib/semaphore/bitbucket/token_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+RSpec.describe Semaphore::Bitbucket::Token do
+  describe ".validation_state" do
+    it "returns :invalid when token is blank" do
+      expect(described_class.validation_state(nil)).to eq(:invalid)
+      expect(described_class.validation_state("")).to eq(:invalid)
+    end
+
+    it "returns :valid for 2xx response" do
+      allow(Excon).to receive(:get).and_return(instance_double(Excon::Response, :status => 200))
+
+      expect(described_class.validation_state("token")).to eq(:valid)
+    end
+
+    it "returns :invalid for 401/403 response" do
+      allow(Excon).to receive(:get).and_return(instance_double(Excon::Response, :status => 401))
+      expect(described_class.validation_state("token")).to eq(:invalid)
+
+      allow(Excon).to receive(:get).and_return(instance_double(Excon::Response, :status => 403))
+      expect(described_class.validation_state("token")).to eq(:invalid)
+    end
+
+    it "returns :transient for non-auth failures" do
+      allow(Excon).to receive(:get).and_return(instance_double(Excon::Response, :status => 429))
+      expect(described_class.validation_state("token")).to eq(:transient)
+
+      allow(Excon).to receive(:get).and_return(instance_double(Excon::Response, :status => 503))
+      expect(described_class.validation_state("token")).to eq(:transient)
+    end
+
+    it "returns :transient when request raises Excon::Error" do
+      allow(Excon).to receive(:get).and_raise(Excon::Error.new("boom"))
+
+      expect(described_class.validation_state("token")).to eq(:transient)
+    end
+  end
+
+  describe ".valid?" do
+    it "returns true only for :valid validation state" do
+      allow(described_class).to receive(:validation_state).with("token").and_return(:valid)
+      expect(described_class.valid?("token")).to eq(true)
+
+      allow(described_class).to receive(:validation_state).with("token").and_return(:invalid)
+      expect(described_class.valid?("token")).to eq(false)
+
+      allow(described_class).to receive(:validation_state).with("token").and_return(:transient)
+      expect(described_class.valid?("token")).to eq(false)
+    end
+  end
+end

--- a/github_hooks/spec/lib/semaphore/bitbucket/token_spec.rb
+++ b/github_hooks/spec/lib/semaphore/bitbucket/token_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe Semaphore::Bitbucket::Token do
   describe ".valid?" do
     it "returns true only for :valid validation state" do
       allow(described_class).to receive(:validation_state).with("token").and_return(:valid)
-      expect(described_class.valid?("token")).to eq(true)
+      expect(described_class.valid?("token")).to be(true)
 
       allow(described_class).to receive(:validation_state).with("token").and_return(:invalid)
-      expect(described_class.valid?("token")).to eq(false)
+      expect(described_class.valid?("token")).to be(false)
 
       allow(described_class).to receive(:validation_state).with("token").and_return(:transient)
-      expect(described_class.valid?("token")).to eq(false)
+      expect(described_class.valid?("token")).to be(false)
     end
   end
 end

--- a/guard/lib/guard/api/bitbucket.ex
+++ b/guard/lib/guard/api/bitbucket.ex
@@ -45,13 +45,29 @@ defmodule Guard.Api.Bitbucket do
   def validate_token(token) do
     client = build_validate_token_client()
 
-    case Tesla.get(client, "/repositories", headers: [{"authorization", "Bearer #{token}"}]) do
+    case Tesla.get(
+           client,
+           "/user/workspaces",
+           query: [pagelen: 1],
+           headers: [{"authorization", "Bearer #{token}"}]
+         ) do
+      {:ok, res} when res.status in 200..299 ->
+        {:ok, true}
+
+      {:ok, res} when res.status in [401, 403] ->
+        {:ok, false}
+
+      {:ok, res} when res.status == 429 or res.status in 500..599 ->
+        Logger.warning("Transient Bitbucket token validation failure (HTTP #{res.status})")
+        {:error, :transient}
+
       {:ok, res} ->
-        {:ok, res.status in 200..299}
+        Logger.warning("Unexpected Bitbucket token validation response (HTTP #{res.status})")
+        {:error, :transient}
 
       {:error, error} ->
         Logger.error("Error validating Bitbucket token: #{inspect(error)}")
-        {:error, :network_error}
+        {:error, :transient}
     end
   end
 

--- a/guard/lib/guard/front_repo/repo_host_account.ex
+++ b/guard/lib/guard/front_repo/repo_host_account.ex
@@ -214,9 +214,11 @@ defmodule Guard.FrontRepo.RepoHostAccount do
   @spec update_repo_host_account(String.t(), repo_host, map(), Keyword.t()) ::
           {:ok, Guard.FrontRepo.RepoHostAccount.t()}
           | {:error, :invalid_data | Ecto.Changeset.t()}
-  def update_repo_host_account(user_id, _, %{github_uid: uid, login: login} = data, _opts)
+  def update_repo_host_account(user_id, _, %{github_uid: uid, login: login}, _opts)
       when is_nil(uid) or is_nil(login) do
-    Logger.error("Cannot update RepoHostAccount for #{user_id} with data #{inspect(data)}")
+    Logger.error(
+      "Cannot update RepoHostAccount for #{user_id}: missing required fields (login_present=#{not is_nil(login)}, uid_present=#{not is_nil(uid)})"
+    )
 
     {:error, :invalid_data}
   end
@@ -225,9 +227,7 @@ defmodule Guard.FrontRepo.RepoHostAccount do
     data = data |> adjust_scope(user_id)
     repo_host = repo_host |> Atom.to_string()
 
-    Logger.debug(
-      "Updating RepoHostAccount for #{user_id} with data #{inspect(data)} and opts #{inspect(opts)} #{inspect(repo_host)}"
-    )
+    Logger.debug("Updating RepoHostAccount for #{user_id} repo_host=#{repo_host}")
 
     case get_for_user_by_repo_host(user_id, repo_host) do
       {:ok, account} ->
@@ -332,14 +332,14 @@ defmodule Guard.FrontRepo.RepoHostAccount do
     case result do
       {:ok, account} ->
         Logger.info(
-          "Successfully updated RepoHostAccount for #{account.user_id} from #{inspect(account)} to #{inspect(data)}"
+          "Successfully updated RepoHostAccount for #{account.user_id} #{account.repo_host} login=#{account.login}"
         )
 
         {:ok, account}
 
       {:error, error} ->
         Logger.error(
-          "Failed to update RepoHostAccount for #{account.user_id} from #{inspect(account)} to #{inspect(data)} #{inspect(error)}"
+          "Failed to update RepoHostAccount for #{account.user_id} #{account.repo_host} login=#{account.login} errors=#{inspect(error)}"
         )
 
         {:error, error}
@@ -349,7 +349,7 @@ defmodule Guard.FrontRepo.RepoHostAccount do
   defp reset_account(account, data, reset: reset)
        when account.github_uid == data.github_uid or reset == false do
     Logger.debug(
-      "Skipping reset account for #{account.user_id} from #{inspect(account)} to #{inspect(data)}"
+      "Skipping reset account for #{account.user_id} #{account.repo_host} reset=#{reset}"
     )
 
     {:ok, account}
@@ -377,14 +377,14 @@ defmodule Guard.FrontRepo.RepoHostAccount do
     case result do
       {:ok, account} ->
         Logger.warning(
-          "Successfully reset RepoHostAccount for #{account.user_id} from #{inspect(account)} to #{inspect(data)}"
+          "Successfully reset RepoHostAccount for #{account.user_id} #{account.repo_host} login=#{account.login}"
         )
 
         {:ok, account}
 
       {:error, error} ->
         Logger.error(
-          "Failed to reset RepoHostAccount for #{account.user_id} from #{inspect(account)} to #{inspect(data)} #{inspect(error)}"
+          "Failed to reset RepoHostAccount for #{account.user_id} #{account.repo_host} login=#{account.login} errors=#{inspect(error)}"
         )
 
         {:error, error}

--- a/guard/lib/guard/grpc_servers/user_server.ex
+++ b/guard/lib/guard/grpc_servers/user_server.ex
@@ -417,6 +417,13 @@ defmodule Guard.GrpcServers.UserServer do
 
         FrontRepo.RepoHostAccount.update_revoke_status(repo_account, not is_valid)
 
+      {:error, :transient} ->
+        Logger.warning(
+          "Transient token validation failure for #{user.id}; keeping existing revoke status."
+        )
+
+        {:ok, repo_account}
+
       {:error, _} ->
         grpc_error!(:internal, "Error while validating token for #{user.id}.")
     end

--- a/guard/test/guard/api/bitbucket_test.exs
+++ b/guard/test/guard/api/bitbucket_test.exs
@@ -53,7 +53,7 @@ defmodule Guard.Api.BitbucketTest do
 
         %{
           method: :get,
-          url: "https://api.bitbucket.org/2.0/repositories"
+          url: "https://api.bitbucket.org/2.0/user/workspaces"
         } ->
           {:ok, %Tesla.Env{status: 404, body: %{}}}
       end)
@@ -65,6 +65,35 @@ defmodule Guard.Api.BitbucketTest do
         |> Guard.FrontRepo.get!(rha.id)
 
       assert updated_rha.token == "new_token"
+    end
+  end
+
+  describe "validate_token/1" do
+    test "returns valid for successful responses" do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.bitbucket.org/2.0/user/workspaces"} ->
+          {:ok, %Tesla.Env{status: 200, body: %{}}}
+      end)
+
+      assert {:ok, true} = Bitbucket.validate_token("valid_token")
+    end
+
+    test "returns invalid only for auth errors" do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.bitbucket.org/2.0/user/workspaces"} ->
+          {:ok, %Tesla.Env{status: 401, body: %{}}}
+      end)
+
+      assert {:ok, false} = Bitbucket.validate_token("expired_token")
+    end
+
+    test "returns transient error for provider-side failures" do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.bitbucket.org/2.0/user/workspaces"} ->
+          {:ok, %Tesla.Env{status: 503, body: %{}}}
+      end)
+
+      assert {:error, :transient} = Bitbucket.validate_token("token")
     end
   end
 end

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -1168,7 +1168,7 @@ defmodule Guard.GrpcServers.UserServerTest do
         case env do
           %{
             method: :get,
-            url: "https://api.bitbucket.org/2.0/repositories"
+            url: "https://api.bitbucket.org/2.0/user/workspaces"
           } ->
             {:ok, %Tesla.Env{status: 200, body: %{}}}
 
@@ -1222,6 +1222,102 @@ defmodule Guard.GrpcServers.UserServerTest do
                  uid: repo_host_account.github_uid
                }
              } == response
+    end
+
+    test "refresh_repository_provider marks bitbucket account revoked for 401 responses",
+         %{grpc_channel: channel} do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.bitbucket.org/2.0/user/workspaces"} ->
+          {:ok, %Tesla.Env{status: 401, body: %{}}}
+      end)
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+
+      {:ok, _} =
+        Support.Members.insert_user(
+          id: user.id,
+          email: user.email,
+          name: user.name
+        )
+
+      {:ok, repo_host_account} =
+        Support.Members.insert_repo_host_account(
+          login: "radwo",
+          name: "radwo",
+          repo_host: "bitbucket",
+          refresh_token: "example_refresh_token",
+          token_expires_at: Support.Members.valid_expires_at(),
+          user_id: user.id,
+          token: "token",
+          revoked: false,
+          permission_scope: "repo"
+        )
+
+      request =
+        User.RefreshRepositoryProviderRequest.new(
+          user_id: user.id,
+          type: User.RepositoryProvider.Type.value(:BITBUCKET)
+        )
+
+      {:ok, response} =
+        channel
+        |> Stub.refresh_repository_provider(request)
+
+      assert response.repository_provider.scope == User.RepositoryProvider.Scope.value(:NONE)
+
+      updated_account =
+        Guard.FrontRepo.get!(Guard.FrontRepo.RepoHostAccount, repo_host_account.id)
+
+      assert updated_account.revoked == true
+    end
+
+    test "refresh_repository_provider keeps revoke status unchanged for transient bitbucket failures",
+         %{grpc_channel: channel} do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.bitbucket.org/2.0/user/workspaces"} ->
+          {:ok, %Tesla.Env{status: 503, body: %{}}}
+      end)
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+
+      {:ok, _} =
+        Support.Members.insert_user(
+          id: user.id,
+          email: user.email,
+          name: user.name
+        )
+
+      {:ok, repo_host_account} =
+        Support.Members.insert_repo_host_account(
+          login: "radwo",
+          name: "radwo",
+          repo_host: "bitbucket",
+          refresh_token: "example_refresh_token",
+          token_expires_at: Support.Members.valid_expires_at(),
+          user_id: user.id,
+          token: "token",
+          revoked: false,
+          permission_scope: "repo"
+        )
+
+      request =
+        User.RefreshRepositoryProviderRequest.new(
+          user_id: user.id,
+          type: User.RepositoryProvider.Type.value(:BITBUCKET)
+        )
+
+      {:ok, response} =
+        channel
+        |> Stub.refresh_repository_provider(request)
+
+      assert response.repository_provider.scope == User.RepositoryProvider.Scope.value(:PRIVATE)
+
+      updated_account =
+        Guard.FrontRepo.get!(Guard.FrontRepo.RepoHostAccount, repo_host_account.id)
+
+      assert updated_account.revoked == false
     end
 
     test "refresh_repository_provider should refresh repository provider details for a valid user with gitlab",

--- a/repository_hub/lib/repository_hub/clients/bitbucket_client.ex
+++ b/repository_hub/lib/repository_hub/clients/bitbucket_client.ex
@@ -337,10 +337,19 @@ defmodule RepositoryHub.BitbucketClient do
   end
 
   defp append_workspace_permissions(workspace, acc, params, token) do
-    with {:ok, repository_permissions} <- wrap(acc),
-         {:ok, workspace_permissions} <- list_repositories_for_workspace(workspace, params, token) do
-      (repository_permissions ++ workspace_permissions)
-      |> wrap()
+    with {:ok, repository_permissions} <- wrap(acc) do
+      case list_repositories_for_workspace(workspace, params, token) do
+        {:ok, workspace_permissions} ->
+          (repository_permissions ++ workspace_permissions)
+          |> wrap()
+
+        {:error, reason} ->
+          "Skipping Bitbucket workspace #{workspace} due to error: #{inspect(reason)}"
+          |> log(level: :warning)
+
+          repository_permissions
+          |> wrap()
+      end
     end
   end
 
@@ -596,13 +605,13 @@ defmodule RepositoryHub.BitbucketClient do
 
   defp dedupe_repository_permissions(repository_permissions) do
     repository_permissions
-    |> Enum.with_index()
-    |> Enum.uniq_by(fn {permission, index} ->
-      get_in(permission, ["repository", "uuid"]) ||
-        get_in(permission, ["repository", "full_name"]) ||
-        {:missing_repository_identity, index}
+    |> Enum.reject(fn permission ->
+      nil_or_empty?(get_in(permission, ["repository", "uuid"])) and
+        nil_or_empty?(get_in(permission, ["repository", "full_name"]))
     end)
-    |> Enum.map(&elem(&1, 0))
+    |> Enum.uniq_by(fn permission ->
+      get_in(permission, ["repository", "uuid"]) || get_in(permission, ["repository", "full_name"])
+    end)
   end
 
   defp nil_or_empty?(nil), do: true

--- a/repository_hub/lib/repository_hub/clients/bitbucket_client.ex
+++ b/repository_hub/lib/repository_hub/clients/bitbucket_client.ex
@@ -9,6 +9,7 @@ defmodule RepositoryHub.BitbucketClient do
 
   @type request_options :: [token: String.t()]
   @type http_response :: {:ok, HTTPoison.Response.t() | HTTPoison.AsyncResponse.t()} | {:error, HTTPoison.Error.t()}
+  @max_pagination_pages 20
 
   @doc """
   https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commit-statuses/#api-repositories-workspace-repo-slug-commit-commit-statuses-build-post
@@ -310,20 +311,37 @@ defmodule RepositoryHub.BitbucketClient do
   end
 
   @doc """
-  https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-user-permissions-repositories-get
+  https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-user-workspaces-workspace-permissions-repositories-get
+
+  Bitbucket repository loading is currently aggregated across all user workspaces.
+  `params.page_token` is accepted for interface compatibility, but this path returns a
+  fully materialized repository set and does not emit a `"next"` token.
   """
   @impl true
   def list_repositories(params, opts \\ []) do
     token = fetch_token(opts)
 
-    "https://api.bitbucket.org/2.0/user/permissions/repositories"
-    |> paged_resource(params.page_token)
-    |> http_get(token, %{
-      pagelen: 100,
-      sort: "repository.created_on",
-      q: params.query
-    })
-    |> process_response()
+    list_user_workspaces(token)
+    |> unwrap(fn workspaces ->
+      workspaces
+      |> Enum.reduce(wrap([]), fn workspace, acc ->
+        append_workspace_permissions(workspace, acc, params, token)
+      end)
+    end)
+    |> unwrap(fn repository_permissions ->
+      %{
+        "values" => dedupe_repository_permissions(repository_permissions)
+      }
+      |> wrap()
+    end)
+  end
+
+  defp append_workspace_permissions(workspace, acc, params, token) do
+    with {:ok, repository_permissions} <- wrap(acc),
+         {:ok, workspace_permissions} <- list_repositories_for_workspace(workspace, params, token) do
+      (repository_permissions ++ workspace_permissions)
+      |> wrap()
+    end
   end
 
   @impl true
@@ -513,6 +531,83 @@ defmodule RepositoryHub.BitbucketClient do
       encoded_resource_url -> Base.decode64!(encoded_resource_url)
     end
   end
+
+  defp list_user_workspaces(token) do
+    "https://api.bitbucket.org/2.0/user/workspaces"
+    |> fetch_paginated_values(token, %{
+      pagelen: 100
+    })
+    |> unwrap(fn workspaces ->
+      workspaces
+      |> Enum.map(&get_in(&1, ["workspace", "slug"]))
+      |> Enum.reject(&nil_or_empty?/1)
+      |> Enum.uniq()
+      |> wrap()
+    end)
+  end
+
+  defp list_repositories_for_workspace(workspace, params, token) do
+    "https://api.bitbucket.org/2.0/user/workspaces/#{workspace}/permissions/repositories"
+    |> fetch_paginated_values(token, %{
+      pagelen: 100,
+      q: params.query
+    })
+  end
+
+  defp fetch_paginated_values(
+         url,
+         token,
+         query_params,
+         acc \\ [],
+         pages_left \\ @max_pagination_pages
+       )
+
+  defp fetch_paginated_values(_url, _token, _query_params, acc, 0) do
+    "Bitbucket pagination limit reached, returning partial results"
+    |> log(level: :warning)
+
+    acc
+    |> Enum.reverse()
+    |> List.flatten()
+    |> wrap()
+  end
+
+  defp fetch_paginated_values(url, token, query_params, acc, pages_left) do
+    url
+    |> http_get(token, query_params)
+    |> process_response()
+    |> unwrap(fn page ->
+      values = Map.get(page, "values", [])
+      next_url = Map.get(page, "next")
+      acc = [values | acc]
+
+      case next_url do
+        next_url when is_binary(next_url) and next_url != "" ->
+          fetch_paginated_values(next_url, token, %{}, acc, pages_left - 1)
+
+        _ ->
+          acc
+          |> Enum.reverse()
+          |> List.flatten()
+          |> wrap()
+      end
+    end)
+  end
+
+  defp dedupe_repository_permissions(repository_permissions) do
+    repository_permissions
+    |> Enum.with_index()
+    |> Enum.uniq_by(fn {permission, index} ->
+      get_in(permission, ["repository", "uuid"]) ||
+        get_in(permission, ["repository", "full_name"]) ||
+        {:missing_repository_identity, index}
+    end)
+    |> Enum.map(&elem(&1, 0))
+  end
+
+  defp nil_or_empty?(nil), do: true
+  defp nil_or_empty?(""), do: true
+  defp nil_or_empty?(_), do: false
 
   defp request_headers(token) do
     [{"Authorization", "Bearer #{token}"}, {"Content-Type", "application/json"}]

--- a/repository_hub/test/repository_hub/clients/bitbucket_client_test.exs
+++ b/repository_hub/test/repository_hub/clients/bitbucket_client_test.exs
@@ -44,11 +44,40 @@ defmodule RepositoryHub.BitbucketClientTest do
 
     test "list_repositories" do
       with_mock(HTTPoison, [],
-        get: fn _url, _body, _headers ->
+        get: fn url, _headers, _opts ->
+          body =
+            case url do
+              "https://api.bitbucket.org/2.0/user/workspaces" ->
+                Jason.encode!(%{
+                  "values" => [
+                    %{"workspace" => %{"slug" => "example-workspace"}}
+                  ]
+                })
+
+              "https://api.bitbucket.org/2.0/user/workspaces/example-workspace/permissions/repositories" ->
+                Jason.encode!(%{
+                  "values" => [
+                    %{
+                      "permission" => "admin",
+                      "repository" => %{
+                        "uuid" => "{repo-1}",
+                        "full_name" => "example-workspace/example-repo",
+                        "name" => "example-repo"
+                      }
+                    }
+                  ]
+                })
+
+              _ ->
+                Jason.encode!(%{"values" => []})
+            end
+
           response = %HTTPoison.Response{
             status_code: 200,
-            body: "{}",
-            headers: []
+            body: body,
+            headers: [],
+            request_url: url,
+            request: nil
           }
 
           {:ok, response}
@@ -56,7 +85,133 @@ defmodule RepositoryHub.BitbucketClientTest do
       ) do
         params = BitbucketClientFactory.list_repositories_params()
         response = BitbucketClient.list_repositories(params, token: "foobar")
-        assert {:ok, _result} = response
+        assert {:ok, %{"values" => values}} = response
+        assert length(values) == 1
+        assert get_in(hd(values), ["repository", "full_name"]) == "example-workspace/example-repo"
+      end
+    end
+
+    test "list_repositories returns partial results when pagination limit is reached" do
+      with_mock(HTTPoison, [],
+        get: fn url, _headers, _opts ->
+          body =
+            case url do
+              "https://api.bitbucket.org/2.0/user/workspaces" ->
+                Jason.encode!(%{
+                  "values" => [
+                    %{"workspace" => %{"slug" => "example-workspace"}}
+                  ]
+                })
+
+              _ ->
+                page =
+                  url
+                  |> URI.parse()
+                  |> Map.get(:query)
+                  |> case do
+                    nil ->
+                      1
+
+                    query ->
+                      query
+                      |> URI.decode_query()
+                      |> Map.get("page", "1")
+                      |> String.to_integer()
+                  end
+
+                page_values = [
+                  %{
+                    "permission" => "admin",
+                    "repository" => %{
+                      "uuid" => "{repo-#{page}}",
+                      "full_name" => "example-workspace/repo-#{page}",
+                      "name" => "repo-#{page}"
+                    }
+                  }
+                ]
+
+                page_response =
+                  if page < 25 do
+                    %{
+                      "values" => page_values,
+                      "next" =>
+                        "https://api.bitbucket.org/2.0/user/workspaces/example-workspace/permissions/repositories?page=#{page + 1}"
+                    }
+                  else
+                    %{"values" => page_values}
+                  end
+
+                Jason.encode!(page_response)
+            end
+
+          response = %HTTPoison.Response{
+            status_code: 200,
+            body: body,
+            headers: [],
+            request_url: url,
+            request: nil
+          }
+
+          {:ok, response}
+        end
+      ) do
+        params = BitbucketClientFactory.list_repositories_params(page_token: "", query: "")
+        response = BitbucketClient.list_repositories(params, token: "foobar")
+
+        assert {:ok, %{"values" => values}} = response
+        assert length(values) == 20
+        assert Enum.any?(values, &(get_in(&1, ["repository", "full_name"]) == "example-workspace/repo-1"))
+        assert Enum.any?(values, &(get_in(&1, ["repository", "full_name"]) == "example-workspace/repo-20"))
+        refute Enum.any?(values, &(get_in(&1, ["repository", "full_name"]) == "example-workspace/repo-21"))
+      end
+    end
+
+    test "list_repositories keeps entries without repository uuid/full_name when deduplicating" do
+      with_mock(HTTPoison, [],
+        get: fn url, _headers, _opts ->
+          body =
+            case url do
+              "https://api.bitbucket.org/2.0/user/workspaces" ->
+                Jason.encode!(%{
+                  "values" => [
+                    %{"workspace" => %{"slug" => "example-workspace"}}
+                  ]
+                })
+
+              "https://api.bitbucket.org/2.0/user/workspaces/example-workspace/permissions/repositories" ->
+                Jason.encode!(%{
+                  "values" => [
+                    %{
+                      "permission" => "admin",
+                      "repository" => %{"name" => "repo-1"}
+                    },
+                    %{
+                      "permission" => "admin",
+                      "repository" => %{"name" => "repo-2"}
+                    }
+                  ]
+                })
+
+              _ ->
+                Jason.encode!(%{"values" => []})
+            end
+
+          response = %HTTPoison.Response{
+            status_code: 200,
+            body: body,
+            headers: [],
+            request_url: url,
+            request: nil
+          }
+
+          {:ok, response}
+        end
+      ) do
+        params = BitbucketClientFactory.list_repositories_params(page_token: "", query: "")
+        response = BitbucketClient.list_repositories(params, token: "foobar")
+
+        assert {:ok, %{"values" => values}} = response
+        assert length(values) == 2
       end
     end
 

--- a/repository_hub/test/repository_hub/clients/bitbucket_client_test.exs
+++ b/repository_hub/test/repository_hub/clients/bitbucket_client_test.exs
@@ -166,7 +166,7 @@ defmodule RepositoryHub.BitbucketClientTest do
       end
     end
 
-    test "list_repositories keeps entries without repository uuid/full_name when deduplicating" do
+    test "list_repositories filters entries without repository identity when deduplicating" do
       with_mock(HTTPoison, [],
         get: fn url, _headers, _opts ->
           body =
@@ -181,6 +181,14 @@ defmodule RepositoryHub.BitbucketClientTest do
               "https://api.bitbucket.org/2.0/user/workspaces/example-workspace/permissions/repositories" ->
                 Jason.encode!(%{
                   "values" => [
+                    %{
+                      "permission" => "admin",
+                      "repository" => %{
+                        "uuid" => "{repo-1}",
+                        "full_name" => "example-workspace/repo-1",
+                        "name" => "repo-1"
+                      }
+                    },
                     %{
                       "permission" => "admin",
                       "repository" => %{"name" => "repo-1"}
@@ -211,7 +219,71 @@ defmodule RepositoryHub.BitbucketClientTest do
         response = BitbucketClient.list_repositories(params, token: "foobar")
 
         assert {:ok, %{"values" => values}} = response
-        assert length(values) == 2
+        assert length(values) == 1
+        assert get_in(hd(values), ["repository", "full_name"]) == "example-workspace/repo-1"
+      end
+    end
+
+    test "list_repositories skips failed workspace and keeps successful workspace results" do
+      with_mock(HTTPoison, [],
+        get: fn url, _headers, _opts ->
+          response =
+            case url do
+              "https://api.bitbucket.org/2.0/user/workspaces" ->
+                %HTTPoison.Response{
+                  status_code: 200,
+                  body:
+                    Jason.encode!(%{
+                      "values" => [
+                        %{"workspace" => %{"slug" => "workspace-1"}},
+                        %{"workspace" => %{"slug" => "workspace-2"}}
+                      ]
+                    }),
+                  headers: [],
+                  request_url: url,
+                  request: nil
+                }
+
+              "https://api.bitbucket.org/2.0/user/workspaces/workspace-1/permissions/repositories" ->
+                %HTTPoison.Response{
+                  status_code: 200,
+                  body:
+                    Jason.encode!(%{
+                      "values" => [
+                        %{
+                          "permission" => "admin",
+                          "repository" => %{
+                            "uuid" => "{repo-1}",
+                            "full_name" => "workspace-1/repo-1",
+                            "name" => "repo-1"
+                          }
+                        }
+                      ]
+                    }),
+                  headers: [],
+                  request_url: url,
+                  request: nil
+                }
+
+              "https://api.bitbucket.org/2.0/user/workspaces/workspace-2/permissions/repositories" ->
+                %HTTPoison.Response{
+                  status_code: 503,
+                  body: "service unavailable",
+                  headers: [],
+                  request_url: url,
+                  request: nil
+                }
+            end
+
+          {:ok, response}
+        end
+      ) do
+        params = BitbucketClientFactory.list_repositories_params(page_token: "", query: "")
+        response = BitbucketClient.list_repositories(params, token: "foobar")
+
+        assert {:ok, %{"values" => values}} = response
+        assert length(values) == 1
+        assert get_in(hd(values), ["repository", "full_name"]) == "workspace-1/repo-1"
       end
     end
 


### PR DESCRIPTION
## 📝 Description

Improves Bitbucket onboarding and reconnect stability by updating repository discovery and token validation flows to current workspace-scoped API patterns and Bearer authentication.

- Aligns repository listing and token validation with workspace-scoped Bitbucket API usage.
- Refines token-state handling to distinguish invalid credentials from transient provider errors, preventing false `revoked` updates.
- Ensures reconnect flow persists `revoked=false` after successful validation.
- Improves repository-loading error handling with structured JSON responses.
 
## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
