### PR TITLE
toil(security-toolbox): adds support for --ignore-file in mix audit

### DIFF
--- a/security-toolbox/dependencies
+++ b/security-toolbox/dependencies
@@ -45,6 +45,10 @@ if File.exist?(policy_file) and args[:ignore_policy].nil?
   args[:ignore_policy] = policy_file
 end
 
+if File.exist?(".mix-audit.txt") and args[:language] == "elixir"
+  args[:ignore_file] = ".mix-audit.txt"
+end
+
 case args[:language]
 when "go", "js"
   require_relative "#{__dir__}/policies/dependencies/trivy_fs"

--- a/security-toolbox/policies/dependencies/mix_audit.rb
+++ b/security-toolbox/policies/dependencies/mix_audit.rb
@@ -4,6 +4,7 @@ class Policy::MixAudit < Policy
   def initialize(args)
     super(args)
     @ignore_packages = args[:ignore_packages] || nil
+    @ignore_file = args[:ignore_file] || nil
   end
 
   def test
@@ -13,6 +14,10 @@ class Policy::MixAudit < Policy
 
     if @ignore_packages != nil
       command << "--ignore-package-names #{@ignore_packages}"
+    end
+
+    if @ignore_file != nil
+      command << "--ignore-file #{@ignore_file}"
     end
 
     @output = `#{command.join(" ")}`


### PR DESCRIPTION
## 📝 Description

mix audit supports [--ignore-file](https://github.com/mirego/mix_audit#options)￼, but it does not provide a default ignore file, and any specified file must already exist.

This PR introduces support for a optional .mix-audit.txt ignore file for our Elixir projects.

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
