### PR TITLE
fix(plumber): Add timeout and retries for checkout command in init jobs

### DIFF
--- a/plumber/ppl/lib/ppl/ppl_sub_inits/stm_handler/compilation/definition.ex
+++ b/plumber/ppl/lib/ppl/ppl_sub_inits/stm_handler/compilation/definition.ex
@@ -128,7 +128,7 @@ defmodule Ppl.PplSubInits.STMHandler.Compilation.Definition do
   defp default_commands() do
     [
       ~s[export GIT_LFS_SKIP_SMUDGE=1],
-      ~s[checkout],
+      ~s[retry --times 3 "timeout 180 bash -lc 'source ~/.toolbox/toolbox; checkout'"],
       ~s[export INPUT_FILE="$SEMAPHORE_YAML_FILE_PATH"],
       ~s[export OUTPUT_FILE="${SEMAPHORE_YAML_FILE_PATH}.output.yml"],
       ~s[export LOGS_FILE="${SEMAPHORE_YAML_FILE_PATH}.logs.jsonl"],

--- a/plumber/ppl/lib/ppl/ppl_sub_inits/stm_handler/compilation/definition.ex
+++ b/plumber/ppl/lib/ppl/ppl_sub_inits/stm_handler/compilation/definition.ex
@@ -129,6 +129,7 @@ defmodule Ppl.PplSubInits.STMHandler.Compilation.Definition do
     [
       ~s[export GIT_LFS_SKIP_SMUDGE=1],
       ~s[retry --times 3 "timeout 180 bash -lc 'source ~/.toolbox/toolbox; checkout'"],
+      ~s[cd "$SEMAPHORE_GIT_DIR"],
       ~s[export INPUT_FILE="$SEMAPHORE_YAML_FILE_PATH"],
       ~s[export OUTPUT_FILE="${SEMAPHORE_YAML_FILE_PATH}.output.yml"],
       ~s[export LOGS_FILE="${SEMAPHORE_YAML_FILE_PATH}.logs.jsonl"],

--- a/plumber/ppl/test/ppl_sub_inits/stm_handler/compilation/definition_test.exs
+++ b/plumber/ppl/test/ppl_sub_inits/stm_handler/compilation/definition_test.exs
@@ -528,6 +528,7 @@ defmodule Ppl.PplSubInits.STMHandler.Compilation.Definition.Test do
     assert Map.get(job, "commands") == [
              "export GIT_LFS_SKIP_SMUDGE=1",
              "retry --times 3 \"timeout 180 bash -lc 'source ~/.toolbox/toolbox; checkout'\"",
+             "cd \"$SEMAPHORE_GIT_DIR\"",
              "export INPUT_FILE=\"$SEMAPHORE_YAML_FILE_PATH\"",
              "export OUTPUT_FILE=\"${SEMAPHORE_YAML_FILE_PATH}.output.yml\"",
              "export LOGS_FILE=\"${SEMAPHORE_YAML_FILE_PATH}.logs.jsonl\"",

--- a/plumber/ppl/test/ppl_sub_inits/stm_handler/compilation/definition_test.exs
+++ b/plumber/ppl/test/ppl_sub_inits/stm_handler/compilation/definition_test.exs
@@ -524,7 +524,18 @@ defmodule Ppl.PplSubInits.STMHandler.Compilation.Definition.Test do
     }
 
     assert {:ok, definition} = Definition.form_definition(ppl_req, :undefined, settings, :prod)
-    assert list = Map.get(definition, "jobs") |> Enum.at(0) |> Map.get("env_vars")
+    assert job = Map.get(definition, "jobs") |> Enum.at(0)
+    assert Map.get(job, "commands") == [
+             "export GIT_LFS_SKIP_SMUDGE=1",
+             "retry --times 3 \"timeout 180 bash -lc 'source ~/.toolbox/toolbox; checkout'\"",
+             "export INPUT_FILE=\"$SEMAPHORE_YAML_FILE_PATH\"",
+             "export OUTPUT_FILE=\"${SEMAPHORE_YAML_FILE_PATH}.output.yml\"",
+             "export LOGS_FILE=\"${SEMAPHORE_YAML_FILE_PATH}.logs.jsonl\"",
+             "cat $INPUT_FILE",
+             "echo \"Compiling $INPUT_FILE into $OUTPUT_FILE and storing logs to $LOGS_FILE\"",
+             "spc compile --input $INPUT_FILE --output $OUTPUT_FILE --logs $LOGS_FILE"
+           ]
+    assert list = Map.get(job, "env_vars")
     assert is_list(list)
     assert Enum.count(list) == 21
 


### PR DESCRIPTION
## 📝 Description

Adds timeout + retry pattern for checkout command in init jobs to handle GitHub connection network issues.

## ✅ Checklist
- [ ] I have tested this change
- [x] ~This change requires documentation update~
