### PR TITLE
docs(ai): add sem-ai CLI page + AI-assisted GHA migration callout

### DIFF
--- a/docs/docs/getting-started/migration/github-actions.md
+++ b/docs/docs/getting-started/migration/github-actions.md
@@ -15,6 +15,12 @@ GitHub Actions uses a YAML-based syntax to define pipelines and actions. With Se
 
 Semaphore provides [top-of-market machines](../../reference/machine-types) for faster build times, along with extra features like fully customizable [Role Based Access Control](../../using-semaphore/rbac), [parameterized promotions](../../using-semaphore/promotions#parameters), and [SSH debugging](../../using-semaphore/jobs#ssh-into-agent).
 
+:::tip AI-assisted migration
+
+The [`sem-ai` CLI](../../using-semaphore/ai/sem-ai) ships a Claude Code / Codex plugin that can translate `.github/workflows/*` into a Semaphore pipeline for you. After installing the plugin, run `/sem-ai:gha-to-semaphore` from the repo and the agent inventories your workflows, drafts `.semaphore/semaphore.yml`, validates it with `sem-ai yaml validate`, and opens a PR. Use the rest of this page as the reference for what each construct maps to — and to review the agent's output.
+
+:::
+
 ## GitHub Actions vs Semaphore
 
 This section describes how to implement common GitHub Actions functionalities on Semaphore.

--- a/docs/docs/using-semaphore/ai/sem-ai.md
+++ b/docs/docs/using-semaphore/ai/sem-ai.md
@@ -106,7 +106,7 @@ From inside Claude Code or Codex:
 /plugin install sem-ai@semaphoreio
 ```
 
-The marketplace is published with `autoUpdate: true`, so the host refreshes the catalog at session start and pulls new skill versions automatically. To force an immediate refresh:
+Claude Code refreshes the marketplace catalog at session start, so updates land automatically next time you open a session. To force an immediate refresh:
 
 ```text
 /plugin marketplace update semaphoreio
@@ -167,7 +167,7 @@ Flags:
 
 - `--name <name>` — project name. Defaults to the basename of the current working directory.
 - `--repo-url <url>` — repository URL. Auto-detected from the `origin` remote when omitted.
-- `--github-integration <type>` — one of `github_token` (default), `github_app`, `github_oauth_token`, `bitbucket`, `gitlab`.
+- `--github-integration <type>` — `github_token` (default) or `github_app`.
 - `--remote <name>` — which git remote to read the URL from. Defaults to `origin`.
 - `--skip-yaml` — skip writing `.semaphore/semaphore.yml`.
 

--- a/docs/docs/using-semaphore/ai/sem-ai.md
+++ b/docs/docs/using-semaphore/ai/sem-ai.md
@@ -101,14 +101,14 @@ The plugin bundles Semaphore skills, an embedded MCP server, and a SessionStart 
 
 From inside Claude Code or Codex:
 
-```
+```text
 /plugin marketplace add semaphoreio/sem-ai
 /plugin install sem-ai@semaphoreio
 ```
 
 The marketplace is published with `autoUpdate: true`, so the host refreshes the catalog at session start and pulls new skill versions automatically. To force an immediate refresh:
 
-```
+```text
 /plugin marketplace update semaphoreio
 /reload-plugins
 ```

--- a/docs/docs/using-semaphore/ai/sem-ai.md
+++ b/docs/docs/using-semaphore/ai/sem-ai.md
@@ -39,6 +39,18 @@ sem-ai connect <your-org>.semaphoreci.com YOUR_API_TOKEN
 
 `sem-ai` writes credentials to `~/.sem.yaml`, the same file used by the legacy [`sem` CLI](https://github.com/semaphoreci/cli), so existing contexts and tokens are reused.
 
+:::tip Prefer a service account token for CI/automation
+
+For shared CI/CD usage, scheduled jobs, and any setup where the token survives a single developer leaving the project, use a per-project [service account](../service-accounts) token instead of a personal API token:
+
+- **Rotation** — service-account tokens are decoupled from a human user. You can rotate the token (or revoke a compromised one) without touching anyone's login session, and without losing access when the original creator leaves the org.
+- **Managed access** — service accounts created with the org-level Member role do not get any project access by default. Add the service account to each project's People page that the agent is allowed to touch, and `sem-ai` calls outside that scope return `404 Not Found`. This makes "what can this token reach" auditable in one place.
+- **Fine-grained permissions** — if your plan includes [RBAC](../rbac), assign a project role that matches what the agent actually needs (e.g. read-only for a status / diagnose bot, contributor for a deploy bot). Avoid handing it Admin "just in case".
+
+Service accounts are an opt-in org feature — contact `support@semaphore.io` if it is not yet enabled for your organization.
+
+:::
+
 Verify with:
 
 ```shell

--- a/docs/docs/using-semaphore/ai/sem-ai.md
+++ b/docs/docs/using-semaphore/ai/sem-ai.md
@@ -20,7 +20,7 @@ Agents driving Semaphore from a developer's machine need three things that a rem
 ### What it helps with
 
 - **Bootstrap a project on Semaphore from a single prompt** — `/sem-ai:init` covers translating an existing `.github/workflows/*` or drafting a greenfield `.semaphore/semaphore.yml`, applying Semaphore-side defaults (machine type, `checkout` in prologue, `sem-version` for languages, cache keyed on lockfile, `test-results publish` in epilogue, …).
-- **Debug a failing pipeline without leaving the terminal** — `sem-ai diagnose` composes workflow → pipeline → failed jobs → logs → parsed JUnit into one call; `sem-ai test summary` parses published reports in under a second instead of patching reporters to print to stdout.
+- **Debug a failing pipeline without leaving the terminal** — `sem-ai diagnose` composes workflow → pipeline → failed jobs → logs → parsed test results into one call; `sem-ai test summary` parses published JUnit reports in under a second instead of patching reporters to print to stdout.
 - **Operate full CI/CD from an agent** — manage projects, secrets, notifications, deploy targets, scheduled tasks, and promotions; validate YAML before pushing; run commands against a real Semaphore agent via `sem-ai testbox` to iterate on CI fixes before committing.
 
 ### sem-ai vs the hosted MCP Server
@@ -47,7 +47,7 @@ Full command reference: [sem-ai Command Line](../../reference/sem-ai-cli). Sourc
 curl -fsSL https://raw.githubusercontent.com/semaphoreio/sem-ai/main/install.sh | sh
 ```
 
-The installer fetches the latest release for macOS or Linux (amd64 or arm64) and places the binary on your `PATH`. Re-running the same command upgrades to the newest release (and fast-paths if you are already on it).
+The installer fetches the latest release for macOS or Linux (amd64 or arm64). It installs to `~/.local/bin` when that directory is already on your `PATH`; otherwise it installs to `~/.semaphore-ai/bin` and prints a note asking you to add that directory to your `PATH`. Re-running the same command upgrades to the newest release (and fast-paths if you are already on it).
 
 To opt out of background update checks:
 
@@ -57,7 +57,7 @@ export SEM_AI_NO_UPDATE_CHECK=1
 
 ## Connect to your organization
 
-Get an API token from `https://<your-org>.semaphoreci.com/account` and run:
+Get an API token from `https://me.semaphoreci.com/account` and run:
 
 ```shell
 sem-ai connect <your-org>.semaphoreci.com YOUR_API_TOKEN
@@ -87,7 +87,7 @@ sem-ai health --project my-app
 # Validate a pipeline YAML before pushing
 sem-ai yaml validate --file .semaphore/semaphore.yml
 
-# Stream a workflow until it completes
+# Poll a workflow until it completes (default 30s interval)
 sem-ai watch <workflow-id>
 ```
 
@@ -106,14 +106,14 @@ From inside Claude Code or Codex:
 /plugin install sem-ai@semaphoreio
 ```
 
-Claude Code refreshes the marketplace catalog at session start, so updates land automatically next time you open a session. To force an immediate refresh:
+A third-party marketplace like this one does not auto-update by default — Claude Code refreshes its catalog only when you ask. To pull the latest skills:
 
 ```text
 /plugin marketplace update semaphoreio
 /reload-plugins
 ```
 
-There is no `/plugin update <plugin>` command — refresh the marketplace and let auto-update apply, or `uninstall` followed by `install` for a forced re-install.
+To keep it current automatically, enable auto-update for this marketplace from the plugin manager (`/plugin` → **Marketplaces** → **semaphoreio** → **Enable auto-update**); the catalog then refreshes between sessions on its own. You can also update an installed plugin directly with `/plugin update`, or `uninstall` followed by `install` for a forced re-install.
 
 The plugin requires the `sem-ai` binary to be on `PATH`. If you install the plugin before the binary, the SessionStart hook prints a one-line install hint in chat.
 
@@ -165,7 +165,7 @@ sem-ai project create \
 
 Flags:
 
-- `--name <name>` — project name. Defaults to the basename of the current working directory.
+- `--name <name>` — project name. Defaults to the repository name derived from the repo URL (e.g. `org/repo.git` → `repo`).
 - `--repo-url <url>` — repository URL. Auto-detected from the `origin` remote when omitted.
 - `--github-integration <type>` — `github_token` (default) or `github_app`.
 - `--remote <name>` — which git remote to read the URL from. Defaults to `origin`.

--- a/docs/docs/using-semaphore/ai/sem-ai.md
+++ b/docs/docs/using-semaphore/ai/sem-ai.md
@@ -1,0 +1,179 @@
+---
+description: Drive Semaphore from an AI agent with the sem-ai CLI and Claude Code / Codex plugin
+sidebar_position: 5
+---
+
+# sem-ai CLI
+
+This page explains how to install and use `sem-ai`, an agent-first CLI for Semaphore. It pairs with the official Claude Code / Codex plugin that ships Semaphore skills and an embedded MCP server.
+
+## Overview
+
+`sem-ai` is a single binary that wraps the Semaphore APIs in a shape AI agents work well with: structured JSON output by default, self-describing commands, and compound operations that chain workflow → pipeline → failed jobs → logs → parsed test results into one call.
+
+When installed locally, `sem-ai` runs its own MCP server (`sem-ai mcp`). You do **not** need the organization-level [hosted MCP Server](./mcp-server) feature enabled to use it — `sem-ai` talks to the public Semaphore API directly with your personal API token. Use the hosted MCP Server when you want a managed, OAuth-friendly remote endpoint; use `sem-ai` when you want a local CLI plus agent tooling that any team member can install today.
+
+Source and full command reference: [github.com/semaphoreio/sem-ai](https://github.com/semaphoreio/sem-ai).
+
+## Install
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/semaphoreio/sem-ai/main/install.sh | sh
+```
+
+The installer fetches the latest release for macOS or Linux (amd64 or arm64) and places the binary on your `PATH`. Re-running the same command upgrades to the newest release (and fast-paths if you are already on it).
+
+To opt out of background update checks:
+
+```shell
+export SEM_AI_NO_UPDATE_CHECK=1
+```
+
+## Connect to your organization
+
+Get an API token from `https://<your-org>.semaphoreci.com/account` and run:
+
+```shell
+sem-ai connect <your-org>.semaphoreci.com YOUR_API_TOKEN
+```
+
+`sem-ai` writes credentials to `~/.sem.yaml`, the same file used by the legacy [`sem` CLI](https://github.com/semaphoreci/cli), so existing contexts and tokens are reused.
+
+Verify with:
+
+```shell
+sem-ai status --project <project> --branch main
+```
+
+## Quick start
+
+A few representative commands — every command also supports `--examples` for inline usage:
+
+```shell
+# Diagnose a failing branch — composes workflow → pipeline → failed jobs → logs → tests
+sem-ai diagnose --project my-app --branch main
+
+# Project health overview
+sem-ai health --project my-app
+
+# Validate a pipeline YAML before pushing
+sem-ai yaml validate --file .semaphore/semaphore.yml
+
+# Stream a workflow until it completes
+sem-ai watch <workflow-id>
+```
+
+`sem-ai discover` returns the full capability map.
+
+## Claude Code / Codex plugin
+
+The plugin bundles Semaphore skills, an embedded MCP server, and a SessionStart hook that surfaces update notices in chat. Skills follow the [Agent Skills](https://agentskills.io) standard so the same bundle works in Claude Code, Codex, and any compliant host.
+
+### Install the plugin
+
+From inside Claude Code or Codex:
+
+```
+/plugin marketplace add semaphoreio/sem-ai
+/plugin install sem-ai@semaphoreio
+```
+
+The marketplace is published with `autoUpdate: true`, so the host refreshes the catalog at session start and pulls new skill versions automatically. To force an immediate refresh:
+
+```
+/plugin marketplace update semaphoreio
+/reload-plugins
+```
+
+There is no `/plugin update <plugin>` command — refresh the marketplace and let auto-update apply, or `uninstall` followed by `install` for a forced re-install.
+
+The plugin requires the `sem-ai` binary to be on `PATH`. If you install the plugin before the binary, the SessionStart hook prints a one-line install hint in chat.
+
+### Slash-command entry points
+
+User-invocable skills can be triggered directly with a namespaced slash command — useful when the activation keyword in a skill's description does not match your prompt verbatim:
+
+| Slash command | What it does |
+|---|---|
+| `/sem-ai:init` | Initialize Semaphore CI/CD for the current repo. Detects state — GitHub Actions workflows present, greenfield, or `.semaphore/` already there — applies Semaphore-side defaults (`f1-standard-2` + `ubuntu2404` agent, `checkout` in `global_job_config.prologue`, `sem-version` for language pinning, `cache` keyed on `$(checksum <lockfile>)`, `test-results publish` in `epilogue.always.commands`, explicit `dependencies:` on every block, `auto_cancel` on non-`main`/`master`), validates with `sem-ai yaml validate`, wires required secrets, and opens a PR. |
+| `/sem-ai:gha-to-semaphore` | Translate-only — same procedure as the `init` translate path, scoped to converting `.github/workflows/*` into a Semaphore pipeline. See also the [GitHub Actions migration page](../../getting-started/migration/github-actions). |
+
+Other skills load automatically when their description keywords match the user's prompt. The slash commands above are explicit triggers for the most common entry points.
+
+### What ships in the plugin
+
+Skills the plugin loads into your agent:
+
+| Skill | Purpose |
+|---|---|
+| `semaphore-ci` | Manage Semaphore CI/CD via `sem-ai` — status, failures, test results, deployments, secrets, notifications |
+| `semaphore-blocks` | Pipeline structure — blocks, tasks, jobs, dependencies, parallelism cost-benefit, `auto_cancel` |
+| `semaphore-promotions` | Promotion concepts, parameterized deploys, deployment-target gating |
+| `semaphore-test-results` | Publishing JUnit reports — epilogue rule, per-framework JUnit config |
+| `semaphore-toolbox` | Preinstalled toolbox CLIs — `cache`, `artifact`, `retry`, `sem-version`, `sem-service`, `checkout` |
+| `gha-to-semaphore` | Translate GitHub Actions workflows to Semaphore pipelines |
+| `init` | Orchestrator for `/sem-ai:init` |
+| `testbox` | Run CI commands against local changes in a real Semaphore environment |
+| `probe-agent-environment` | Discover what is preinstalled on a Semaphore agent via a short-lived testbox |
+| `test-intelligence` | Pull and analyze test results, detect flaky tests |
+| `debug-pipeline` | Step-by-step CI failure diagnosis |
+| `deploy` | Deploy via Semaphore promotions |
+| `manage-infra` | Manage secrets, notifications, agent types, scheduled tasks, artifacts |
+| `project-health` | Pass rates, recent failures, deployment trends |
+| `sem-ai-bootstrap` | Diagnose sem-ai plugin issues (binary missing, MCP not registering, …) |
+
+### Embedded MCP server
+
+The plugin registers `sem-ai mcp` as an MCP server inside the host, so every `sem-ai` command becomes a native tool the agent can call without a shell round-trip.
+
+To register `sem-ai mcp` manually in any MCP-aware client, add to `.mcp.json` in your project:
+
+```json
+{
+  "mcpServers": {
+    "semaphore": {
+      "command": "sem-ai",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+This is local: the MCP server runs on the same machine as the agent, using your `sem-ai connect` credentials. Long-running commands (`watch`, `promote-and-wait`) are excluded from the MCP surface to prevent blocking the agent.
+
+## Bootstrap a project from the CLI
+
+`sem-ai project create` registers a new Semaphore project and, when run from a git working directory, writes a starter `.semaphore/semaphore.yml`:
+
+```shell
+sem-ai project create \
+  --name my-app \
+  --github-integration github_token
+```
+
+Flags:
+
+- `--name <name>` — project name. Defaults to the basename of the current working directory.
+- `--repo-url <url>` — repository URL. Auto-detected from the `origin` remote when omitted.
+- `--github-integration <type>` — one of `github_token` (default), `github_app`, `github_oauth_token`, `bitbucket`, `gitlab`.
+- `--remote <name>` — which git remote to read the URL from. Defaults to `origin`.
+- `--skip-yaml` — skip writing `.semaphore/semaphore.yml`.
+
+For an AI-driven flow that wires secrets and translates GitHub Actions if present, use `/sem-ai:init` from the plugin instead.
+
+## Updates
+
+A `SessionStart` hook checks GitHub for new releases at most once every 6 hours and surfaces an upgrade banner in chat when one is available. To force a check from a shell:
+
+```shell
+sem-ai version --check
+```
+
+Upgrade by re-running the install script.
+
+## See also
+
+- [MCP Server](./mcp-server) — Semaphore-hosted remote MCP endpoint (organization feature)
+- [GitHub Actions migration](../../getting-started/migration/github-actions) — uses `/sem-ai:gha-to-semaphore` as the recommended path
+- [Self-Healing CI](./self-healing-ci) — automated build-fix workflows
+- [Toolbox reference](../../reference/toolbox) — the CLIs the `semaphore-toolbox` skill teaches the agent about

--- a/docs/docs/using-semaphore/ai/sem-ai.md
+++ b/docs/docs/using-semaphore/ai/sem-ai.md
@@ -13,7 +13,7 @@ This page explains how to install and use `sem-ai`, an agent-first CLI for Semap
 
 When installed locally, `sem-ai` runs its own MCP server (`sem-ai mcp`). You do **not** need the organization-level [hosted MCP Server](./mcp-server) feature enabled to use it — `sem-ai` talks to the public Semaphore API directly with your personal API token. Use the hosted MCP Server when you want a managed, OAuth-friendly remote endpoint; use `sem-ai` when you want a local CLI plus agent tooling that any team member can install today.
 
-Source and full command reference: [github.com/semaphoreio/sem-ai](https://github.com/semaphoreio/sem-ai).
+Full command reference: [sem-ai Command Line](../../reference/sem-ai-cli). Source: [github.com/semaphoreio/sem-ai](https://github.com/semaphoreio/sem-ai).
 
 ## Install
 
@@ -39,17 +39,7 @@ sem-ai connect <your-org>.semaphoreci.com YOUR_API_TOKEN
 
 `sem-ai` writes credentials to `~/.sem.yaml`, the same file used by the legacy [`sem` CLI](https://github.com/semaphoreci/cli), so existing contexts and tokens are reused.
 
-:::tip Prefer a service account token for CI/automation
-
-For shared CI/CD usage, scheduled jobs, and any setup where the token survives a single developer leaving the project, use a per-project [service account](../service-accounts) token instead of a personal API token:
-
-- **Rotation** — service-account tokens are decoupled from a human user. You can rotate the token (or revoke a compromised one) without touching anyone's login session, and without losing access when the original creator leaves the org.
-- **Managed access** — service accounts created with the org-level Member role do not get any project access by default. Add the service account to each project's People page that the agent is allowed to touch, and `sem-ai` calls outside that scope return `404 Not Found`. This makes "what can this token reach" auditable in one place.
-- **Fine-grained permissions** — if your plan includes [RBAC](../rbac), assign a project role that matches what the agent actually needs (e.g. read-only for a status / diagnose bot, contributor for a deploy bot). Avoid handing it Admin "just in case".
-
-Service accounts are an opt-in org feature — contact `support@semaphore.io` if it is not yet enabled for your organization.
-
-:::
+For shared or headless setups — a chatops bot, an internal dashboard, or a non-Semaphore CI job that calls the Semaphore API — use a [service account](../service-accounts) token instead, so access and rotation are not tied to any single user.
 
 Verify with:
 

--- a/docs/docs/using-semaphore/ai/sem-ai.md
+++ b/docs/docs/using-semaphore/ai/sem-ai.md
@@ -11,7 +11,33 @@ This page explains how to install and use `sem-ai`, an agent-first CLI for Semap
 
 `sem-ai` is a single binary that wraps the Semaphore APIs in a shape AI agents work well with: structured JSON output by default, self-describing commands, and compound operations that chain workflow → pipeline → failed jobs → logs → parsed test results into one call.
 
-When installed locally, `sem-ai` runs its own MCP server (`sem-ai mcp`). You do **not** need the organization-level [hosted MCP Server](./mcp-server) feature enabled to use it — `sem-ai` talks to the public Semaphore API directly with your personal API token. Use the hosted MCP Server when you want a managed, OAuth-friendly remote endpoint; use `sem-ai` when you want a local CLI plus agent tooling that any team member can install today.
+### Why it exists
+
+Agents driving Semaphore from a developer's machine need three things that a remote MCP server cannot provide on its own: a full write-surface to manage projects, secrets, deploy targets, and YAML; in-context **skills** that teach the agent Semaphore's conventions (block dependencies, the `epilogue` rule for test reports, toolbox CLIs, sharding cost-benefit, …) so it does not invent wrong defaults; and a deterministic entry point for repetitive set-up tasks like translating GitHub Actions or bootstrapping a fresh project.
+
+`sem-ai` packages all three: the CLI exposes the full Semaphore API surface, the Claude Code / Codex plugin ships [Agent Skills](https://agentskills.io) covering each Semaphore concept, and the `/sem-ai:init` slash command orchestrates project bootstrap end to end (detect repo state → translate or draft → validate → wire secrets → open a PR).
+
+### What it helps with
+
+- **Bootstrap a project on Semaphore from a single prompt** — `/sem-ai:init` covers translating an existing `.github/workflows/*` or drafting a greenfield `.semaphore/semaphore.yml`, applying Semaphore-side defaults (machine type, `checkout` in prologue, `sem-version` for languages, cache keyed on lockfile, `test-results publish` in epilogue, …).
+- **Debug a failing pipeline without leaving the terminal** — `sem-ai diagnose` composes workflow → pipeline → failed jobs → logs → parsed JUnit into one call; `sem-ai test summary` parses published reports in under a second instead of patching reporters to print to stdout.
+- **Operate full CI/CD from an agent** — manage projects, secrets, notifications, deploy targets, scheduled tasks, and promotions; validate YAML before pushing; run commands against a real Semaphore agent via `sem-ai testbox` to iterate on CI fixes before committing.
+
+### sem-ai vs the hosted MCP Server
+
+Both let AI agents talk to Semaphore. They are complementary, and you can use them at the same time. Use this table to pick.
+
+| | [Hosted MCP Server](./mcp-server) | sem-ai |
+|---|---|---|
+| **Where it runs** | Semaphore-managed endpoint at `mcp.semaphoreci.com` | Local binary on the developer's machine |
+| **Setup** | Opt-in per org — contact `support@semaphore.io` | Install the binary; no feature flag required |
+| **Auth** | OAuth 2.1 (browser) or personal API token | Personal API token (or [service account](../service-accounts) for shared/headless setups) |
+| **Scope** | A focused MCP tool set: orgs, projects, workflows, pipelines, jobs, logs, test results, doc lookup, workflow run/rerun | The full Semaphore API surface — projects, secrets, deploy targets, notifications, scheduled tasks, agents, artifacts, YAML validation, testbox, plus the same read/diagnose tools |
+| **Skills** | Tool descriptions only | 15 [Agent Skills](https://agentskills.io) covering blocks, promotions, toolbox CLIs, test-results, GHA translation, debugging, deploys, manage-infra, testbox, etc |
+| **Slash commands** | None | `/sem-ai:init` (bootstrap a project), `/sem-ai:gha-to-semaphore` (translate workflows) |
+| **Best for** | Any MCP-aware agent that should reach into Semaphore from the web — Claude desktop, Cursor, VS Code, internal copilots — without each user installing a CLI | Driving Semaphore from a terminal-attached agent (Claude Code, Codex), bootstrapping CI on new projects, fixing failing pipelines on a developer laptop, automating Semaphore from non-Semaphore CI |
+
+In short: the hosted MCP Server is the remote, managed access path; `sem-ai` is the local, fully-featured agent toolkit that ships with opinionated Semaphore knowledge.
 
 Full command reference: [sem-ai Command Line](../../reference/sem-ai-cli). Source: [github.com/semaphoreio/sem-ai](https://github.com/semaphoreio/sem-ai).
 

--- a/docs/docs/using-semaphore/ai/sem-ai.md
+++ b/docs/docs/using-semaphore/ai/sem-ai.md
@@ -5,25 +5,25 @@ sidebar_position: 5
 
 # sem-ai CLI
 
-This page explains how to install and use `sem-ai`, an agent-first CLI for Semaphore. It pairs with the official Claude Code / Codex plugin that ships Semaphore skills and an embedded MCP server.
+`sem-ai` is an agent-first command line tool for Semaphore, paired with an optional Claude Code / Codex plugin. This page explains the pieces, how to install them, and when to reach for each.
 
 ## Overview
 
-`sem-ai` is a single binary that wraps the Semaphore APIs in a shape AI agents work well with: structured JSON output by default, self-describing commands, and compound operations that chain workflow → pipeline → failed jobs → logs → parsed test results into one call.
+`sem-ai` is **one binary** with **two artifacts and three ways to use it**:
 
-### Why it exists
+1. **CLI binary** — direct terminal and API access. Structured JSON output by default, self-describing commands, and compound operations that chain workflow → pipeline → failed jobs → logs → parsed test results into a single call (`diagnose`, `status`, `health`, `yaml validate`, `project create`, …).
+2. **Embedded MCP server** — the same binary, run as `sem-ai mcp`, exposes every command as a native tool to any MCP-aware agent. This is a mode of the binary, not a separate download.
+3. **Claude Code / Codex plugin** — an optional bundle that installs Semaphore [Agent Skills](https://agentskills.io), namespaced slash commands (`/sem-ai:init`, `/sem-ai:gha-to-semaphore`), and a `SessionStart` update hook — and registers the embedded MCP server with the host automatically.
 
-Agents driving Semaphore from a developer's machine need three things that a remote MCP server cannot provide on its own: a full write-surface to manage projects, secrets, deploy targets, and YAML; in-context **skills** that teach the agent Semaphore's conventions (block dependencies, the `epilogue` rule for test reports, toolbox CLIs, sharding cost-benefit, …) so it does not invent wrong defaults; and a deterministic entry point for repetitive set-up tasks like translating GitHub Actions or bootstrapping a fresh project.
+The CLI works on its own for terminal and API workflows; **you do not need the plugin**. The plugin is what gives an AI agent Semaphore skills, slash-command entry points, and automatic MCP registration.
 
-`sem-ai` packages all three: the CLI exposes the full Semaphore API surface, the Claude Code / Codex plugin ships [Agent Skills](https://agentskills.io) covering each Semaphore concept, and the `/sem-ai:init` slash command orchestrates project bootstrap end to end (detect repo state → translate or draft → validate → wire secrets → open a PR).
+### What you can do with it
 
-### What it helps with
-
-- **Bootstrap a project on Semaphore from a single prompt** — `/sem-ai:init` covers translating an existing `.github/workflows/*` or drafting a greenfield `.semaphore/semaphore.yml`, applying Semaphore-side defaults (machine type, `checkout` in prologue, `sem-version` for languages, cache keyed on lockfile, `test-results publish` in epilogue, …).
+- **Bootstrap a project on Semaphore from a single prompt** — `/sem-ai:init` translates an existing `.github/workflows/*` or drafts a greenfield `.semaphore/semaphore.yml`, applying Semaphore-side defaults (machine type, `checkout` in prologue, `sem-version` for languages, cache keyed on lockfile, `test-results publish` in epilogue, …).
 - **Debug a failing pipeline without leaving the terminal** — `sem-ai diagnose` composes workflow → pipeline → failed jobs → logs → parsed test results into one call; `sem-ai test summary` parses published JUnit reports in under a second instead of patching reporters to print to stdout.
 - **Operate full CI/CD from an agent** — manage projects, secrets, notifications, deploy targets, scheduled tasks, and promotions; validate YAML before pushing; run commands against a real Semaphore agent via `sem-ai testbox` to iterate on CI fixes before committing.
 
-### sem-ai vs the hosted MCP Server
+## When to use sem-ai vs the hosted MCP Server
 
 Both let AI agents talk to Semaphore. They are complementary, and you can use them at the same time. Use this table to pick.
 
@@ -39,23 +39,19 @@ Both let AI agents talk to Semaphore. They are complementary, and you can use th
 
 In short: the hosted MCP Server is the remote, managed access path; `sem-ai` is the local, fully-featured agent toolkit that ships with opinionated Semaphore knowledge.
 
-Full command reference: [sem-ai Command Line](../../reference/sem-ai-cli). Source: [github.com/semaphoreio/sem-ai](https://github.com/semaphoreio/sem-ai).
+## Install and set up
 
-## Install
+The flow is: install the CLI binary → connect to your organization → (optionally) install the plugin.
+
+### 1. Install the CLI binary
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/semaphoreio/sem-ai/main/install.sh | sh
 ```
 
-The installer fetches the latest release for macOS or Linux (amd64 or arm64). It installs to `~/.local/bin` when that directory is already on your `PATH`; otherwise it installs to `~/.semaphore-ai/bin` and prints a note asking you to add that directory to your `PATH`. Re-running the same command upgrades to the newest release (and fast-paths if you are already on it).
+The installer fetches the latest release for macOS or Linux (amd64 or arm64). It installs to `~/.local/bin` when that directory is already on your `PATH`; otherwise it installs to `~/.semaphore-ai/bin` and prints a note asking you to add that directory to your `PATH`.
 
-To opt out of background update checks:
-
-```shell
-export SEM_AI_NO_UPDATE_CHECK=1
-```
-
-## Connect to your organization
+### 2. Connect to your organization
 
 Get an API token from `https://me.semaphoreci.com/account` and run:
 
@@ -73,7 +69,27 @@ Verify with:
 sem-ai status --project <project> --branch main
 ```
 
-## Quick start
+At this point the CLI is fully usable on its own. Install the plugin only if you want the agent ergonomics described below.
+
+### 3. (Optional) Install the Claude Code / Codex plugin
+
+The plugin requires the `sem-ai` binary to be on your `PATH` — install it first (step 1). If you install the plugin before the binary, the `SessionStart` hook prints a one-line install hint in chat.
+
+From inside Claude Code or Codex:
+
+```text
+/plugin marketplace add semaphoreio/sem-ai
+/plugin install sem-ai@semaphoreio
+```
+
+### Staying up to date
+
+There are two independent things to keep current:
+
+- **The CLI binary.** Re-run the install script to upgrade — it fast-paths if you are already on the latest release. A background check notifies you when a newer release exists; force a check from a shell with `sem-ai version --check`, or opt out with `export SEM_AI_NO_UPDATE_CHECK=1`. Inside the plugin, a `SessionStart` hook surfaces the same upgrade banner in chat (at most once every 6 hours).
+- **The plugin skills.** These come from the marketplace catalog, not the binary. A third-party marketplace like this one does not auto-update by default — refresh it on demand with `/plugin marketplace update semaphoreio` followed by `/reload-plugins`. To keep it current automatically, enable auto-update for the marketplace (`/plugin` → **Marketplaces** → **semaphoreio** → **Enable auto-update**). You can also update an installed plugin directly with `/plugin update`, or `uninstall` then `install` for a forced re-install.
+
+## Common CLI commands
 
 A few representative commands — every command also supports `--examples` for inline usage:
 
@@ -91,33 +107,24 @@ sem-ai yaml validate --file .semaphore/semaphore.yml
 sem-ai watch <workflow-id>
 ```
 
-`sem-ai discover` returns the full capability map.
+`sem-ai discover` returns the full capability map. For the complete command list, see the [sem-ai Command Line reference](../../reference/sem-ai-cli).
 
-## Claude Code / Codex plugin
+## Plugin capabilities
 
-The plugin bundles Semaphore skills, an embedded MCP server, and a SessionStart hook that surfaces update notices in chat. Skills follow the [Agent Skills](https://agentskills.io) standard so the same bundle works in Claude Code, Codex, and any compliant host.
+The plugin bundles four things and works in Claude Code, Codex, and any [Agent Skills](https://agentskills.io)-compliant host:
 
-### Install the plugin
+- **Skills** — in-context Semaphore knowledge the agent loads on demand.
+- **Slash commands** — explicit entry points for the most common workflows.
+- **Embedded MCP server** — automatic registration of `sem-ai mcp` with the host.
+- **`SessionStart` hook** — surfaces CLI upgrade banners (see [Staying up to date](#staying-up-to-date)).
 
-From inside Claude Code or Codex:
+### Skills
 
-```text
-/plugin marketplace add semaphoreio/sem-ai
-/plugin install sem-ai@semaphoreio
-```
+Each skill teaches the agent one Semaphore concept (blocks, promotions, toolbox CLIs, test-results, GHA translation, testbox, deploys, manage-infra, …) and loads automatically when its description keywords match the user's prompt.
 
-A third-party marketplace like this one does not auto-update by default — Claude Code refreshes its catalog only when you ask. To pull the latest skills:
+For the canonical inventory and per-skill documentation, browse [`assets/plugin/skills/`](https://github.com/semaphoreio/sem-ai/tree/main/assets/plugin/skills) in the sem-ai repository — that directory is the source of truth and updates as new skills land.
 
-```text
-/plugin marketplace update semaphoreio
-/reload-plugins
-```
-
-To keep it current automatically, enable auto-update for this marketplace from the plugin manager (`/plugin` → **Marketplaces** → **semaphoreio** → **Enable auto-update**); the catalog then refreshes between sessions on its own. You can also update an installed plugin directly with `/plugin update`, or `uninstall` followed by `install` for a forced re-install.
-
-The plugin requires the `sem-ai` binary to be on `PATH`. If you install the plugin before the binary, the SessionStart hook prints a one-line install hint in chat.
-
-### Slash-command entry points
+### Slash commands
 
 User-invocable skills can be triggered directly with a namespaced slash command — useful when the activation keyword in a skill's description does not match your prompt verbatim:
 
@@ -127,12 +134,6 @@ User-invocable skills can be triggered directly with a namespaced slash command 
 | `/sem-ai:gha-to-semaphore` | Translate-only — same procedure as the `init` translate path, scoped to converting `.github/workflows/*` into a Semaphore pipeline. See also the [GitHub Actions migration page](../../getting-started/migration/github-actions). |
 
 Other skills load automatically when their description keywords match the user's prompt. The slash commands above are explicit triggers for the most common entry points.
-
-### What ships in the plugin
-
-Each skill teaches the agent one Semaphore concept (blocks, promotions, toolbox CLIs, test-results, GHA translation, testbox, deploys, manage-infra, …) and loads automatically when its description keywords match the user's prompt.
-
-For the canonical inventory and per-skill documentation, browse [`assets/plugin/skills/`](https://github.com/semaphoreio/sem-ai/tree/main/assets/plugin/skills) in the sem-ai repository — that directory is the source of truth and updates as new skills land.
 
 ### Embedded MCP server
 
@@ -153,9 +154,9 @@ To register `sem-ai mcp` manually in any MCP-aware client, add to `.mcp.json` in
 
 This is local: the MCP server runs on the same machine as the agent, using your `sem-ai connect` credentials. Long-running commands (`watch`, `promote-and-wait`) are excluded from the MCP surface to prevent blocking the agent.
 
-## Bootstrap a project from the CLI
+## Create a project from the CLI
 
-`sem-ai project create` registers a new Semaphore project and, when run from a git working directory, writes a starter `.semaphore/semaphore.yml`:
+If you prefer the CLI over the agent flow, `sem-ai project create` registers a new Semaphore project and, when run from a git working directory, writes a starter `.semaphore/semaphore.yml`:
 
 ```shell
 sem-ai project create \
@@ -173,19 +174,11 @@ Flags:
 
 For an AI-driven flow that wires secrets and translates GitHub Actions if present, use `/sem-ai:init` from the plugin instead.
 
-## Updates
-
-A `SessionStart` hook checks GitHub for new releases at most once every 6 hours and surfaces an upgrade banner in chat when one is available. To force a check from a shell:
-
-```shell
-sem-ai version --check
-```
-
-Upgrade by re-running the install script.
-
 ## See also
 
 - [MCP Server](./mcp-server) — Semaphore-hosted remote MCP endpoint (organization feature)
 - [GitHub Actions migration](../../getting-started/migration/github-actions) — uses `/sem-ai:gha-to-semaphore` as the recommended path
 - [Self-Healing CI](./self-healing-ci) — automated build-fix workflows
 - [Toolbox reference](../../reference/toolbox) — the CLIs the `semaphore-toolbox` skill teaches the agent about
+- [sem-ai Command Line reference](../../reference/sem-ai-cli) — full CLI command reference
+- Source: [github.com/semaphoreio/sem-ai](https://github.com/semaphoreio/sem-ai)

--- a/docs/docs/using-semaphore/ai/sem-ai.md
+++ b/docs/docs/using-semaphore/ai/sem-ai.md
@@ -31,10 +31,10 @@ Both let AI agents talk to Semaphore. They are complementary, and you can use th
 |---|---|---|
 | **Where it runs** | Semaphore-managed endpoint at `mcp.semaphoreci.com` | Local binary on the developer's machine |
 | **Setup** | Opt-in per org — contact `support@semaphore.io` | Install the binary; no feature flag required |
-| **Auth** | OAuth 2.1 (browser) or personal API token | Personal API token (or [service account](../service-accounts) for shared/headless setups) |
+| **Auth** | OAuth 2.1 (browser), personal API token, or [service account](../service-accounts) API token | Personal API token (or [service account](../service-accounts) token for shared/headless setups) |
 | **Scope** | A focused MCP tool set: orgs, projects, workflows, pipelines, jobs, logs, test results, doc lookup, workflow run/rerun | The full Semaphore API surface — projects, secrets, deploy targets, notifications, scheduled tasks, agents, artifacts, YAML validation, testbox, plus the same read/diagnose tools |
-| **Skills** | Tool descriptions only | 15 [Agent Skills](https://agentskills.io) covering blocks, promotions, toolbox CLIs, test-results, GHA translation, debugging, deploys, manage-infra, testbox, etc |
-| **Slash commands** | None | `/sem-ai:init` (bootstrap a project), `/sem-ai:gha-to-semaphore` (translate workflows) |
+| **Skills** | Tool descriptions only | [Agent Skills](https://agentskills.io) covering blocks, promotions, toolbox CLIs, test-results, GHA translation, debugging, deploys, manage-infra, testbox, etc |
+| **Slash commands** | `/semaphore:mcp_setup` (auto-discover project and organization IDs — see [usage examples](./mcp-usage-examples)) | `/sem-ai:init` (bootstrap a project), `/sem-ai:gha-to-semaphore` (translate workflows) |
 | **Best for** | Any MCP-aware agent that should reach into Semaphore from the web — Claude desktop, Cursor, VS Code, internal copilots — without each user installing a CLI | Driving Semaphore from a terminal-attached agent (Claude Code, Codex), bootstrapping CI on new projects, fixing failing pipelines on a developer laptop, automating Semaphore from non-Semaphore CI |
 
 In short: the hosted MCP Server is the remote, managed access path; `sem-ai` is the local, fully-featured agent toolkit that ships with opinionated Semaphore knowledge.
@@ -130,25 +130,9 @@ Other skills load automatically when their description keywords match the user's
 
 ### What ships in the plugin
 
-Skills the plugin loads into your agent:
+Each skill teaches the agent one Semaphore concept (blocks, promotions, toolbox CLIs, test-results, GHA translation, testbox, deploys, manage-infra, …) and loads automatically when its description keywords match the user's prompt.
 
-| Skill | Purpose |
-|---|---|
-| `semaphore-ci` | Manage Semaphore CI/CD via `sem-ai` — status, failures, test results, deployments, secrets, notifications |
-| `semaphore-blocks` | Pipeline structure — blocks, tasks, jobs, dependencies, parallelism cost-benefit, `auto_cancel` |
-| `semaphore-promotions` | Promotion concepts, parameterized deploys, deployment-target gating |
-| `semaphore-test-results` | Publishing JUnit reports — epilogue rule, per-framework JUnit config |
-| `semaphore-toolbox` | Preinstalled toolbox CLIs — `cache`, `artifact`, `retry`, `sem-version`, `sem-service`, `checkout` |
-| `gha-to-semaphore` | Translate GitHub Actions workflows to Semaphore pipelines |
-| `init` | Orchestrator for `/sem-ai:init` |
-| `testbox` | Run CI commands against local changes in a real Semaphore environment |
-| `probe-agent-environment` | Discover what is preinstalled on a Semaphore agent via a short-lived testbox |
-| `test-intelligence` | Pull and analyze test results, detect flaky tests |
-| `debug-pipeline` | Step-by-step CI failure diagnosis |
-| `deploy` | Deploy via Semaphore promotions |
-| `manage-infra` | Manage secrets, notifications, agent types, scheduled tasks, artifacts |
-| `project-health` | Pass rates, recent failures, deployment trends |
-| `sem-ai-bootstrap` | Diagnose sem-ai plugin issues (binary missing, MCP not registering, …) |
+For the canonical inventory and per-skill documentation, browse [`assets/plugin/skills/`](https://github.com/semaphoreio/sem-ai/tree/main/assets/plugin/skills) in the sem-ai repository — that directory is the source of truth and updates as new skills land.
 
 ### Embedded MCP server
 


### PR DESCRIPTION
## Summary

- New `docs/docs/using-semaphore/ai/sem-ai.md` page in the AI-Driven Development section. Covers what sem-ai is, why it exists, what it helps with, a side-by-side comparison with the [hosted MCP Server](https://docs.semaphore.io/using-semaphore/ai/mcp-server), install (`install.sh`), `sem-ai connect`, the Claude Code / Codex plugin (slash commands, embedded MCP), and `sem-ai project create`.
- AI-assisted migration callout on `docs/docs/getting-started/migration/github-actions.md` pointing readers at `/sem-ai:gha-to-semaphore`.

## Comparison table

| | Hosted MCP Server | sem-ai |
|---|---|---|
| Where it runs | Semaphore-managed endpoint | Local binary on developer's machine |
| Setup | Opt-in per org | Install the binary; no feature flag |
| Auth | OAuth 2.1, personal API token, or service account | Personal API token (or service account for shared/headless) |
| Scope | Focused MCP tool set | Full Semaphore API surface |
| Skills | Tool descriptions only | Agent Skills bundle |
| Slash commands | `/semaphore:mcp_setup` | `/sem-ai:init`, `/sem-ai:gha-to-semaphore` |
| Best for | Web/IDE agents reaching into Semaphore | Terminal-attached agents, CI bootstrap, on-laptop fixes |

## Anti-drift note

The page does **not** enumerate individual skills inline — it links to [`assets/plugin/skills/`](https://github.com/semaphoreio/sem-ai/tree/main/assets/plugin/skills) in the sem-ai repository so the docs cannot drift out of sync as new skills land. The skill directory is the canonical inventory.

## Other things the page clarifies

- `sem-ai` does **not** require the org-level hosted MCP Server feature flag — it talks to the public Semaphore API directly using a user's token.
- On a developer machine a personal API token is the right default; service-account tokens are for shared or headless setups (bots, dashboards, non-Semaphore CI hitting the Semaphore API).
- Full command reference points at the in-tree [`reference/sem-ai-cli`](https://github.com/semaphoreio/semaphore/blob/main/docs/docs/reference/sem-ai-cli.md) (added in #1023).

## Test plan

- [x] `npm run build` in `docs/` with `onBrokenLinks: 'throw'` — clean; all internal cross-links resolve
- [x] `markdownlint-cli2 docs/using-semaphore/ai/sem-ai.md` — clean (after MD040 fence-language fix)
- [x] Sidebar: AI section is autogenerated; `sidebar_position: 5` places `sem-ai` after `copilot-agent-cloud` (4)


🤖 Generated with [Claude Code](https://claude.com/claude-code)
