### PR TITLE
chore(zebra): improve cachehub describe observability

### DIFF
--- a/zebra/lib/zebra/workers/job_request_factory.ex
+++ b/zebra/lib/zebra/workers/job_request_factory.ex
@@ -95,7 +95,7 @@ defmodule Zebra.Workers.JobRequestFactory do
          {:ok, open_id_token_env_vars} <-
            OpenIDConnect.load(job, repo_env_vars, organization, project, job_type, spec_env_vars),
          {:ok, callback_token} <- CallbackToken.generate(job) do
-      log_dropped_cache_vars(job, project, cache_env_vars)
+      log_dropped_cache_vars(job, project, repo_proxy, cache_env_vars)
 
       org_url = "https://#{organization.org_username}.#{Application.get_env(:zebra, :domain)}"
 
@@ -198,9 +198,11 @@ defmodule Zebra.Workers.JobRequestFactory do
     end
   end
 
-  defp log_dropped_cache_vars(job, project, cache_env_vars) do
+  defp log_dropped_cache_vars(job, project, repo_proxy, cache_env_vars) do
+    # Forked-PR cache skips are intentional (gated by the disable_forked_pr_cache
+    # feature flag in Cache.find/3), so they are not a dropped-vars condition.
     if cache_env_vars == [] and not Job.self_hosted?(job.machine_type) and
-         not is_nil(project.cache_id) do
+         not is_nil(project.cache_id) and not Cache.forked_pr?(repo_proxy) do
       Logger.warning(
         "Cache env vars not injected into job. job_id=#{job.id} project_id=#{project.id} cache_id=#{project.cache_id}"
       )

--- a/zebra/lib/zebra/workers/job_request_factory.ex
+++ b/zebra/lib/zebra/workers/job_request_factory.ex
@@ -95,6 +95,8 @@ defmodule Zebra.Workers.JobRequestFactory do
          {:ok, open_id_token_env_vars} <-
            OpenIDConnect.load(job, repo_env_vars, organization, project, job_type, spec_env_vars),
          {:ok, callback_token} <- CallbackToken.generate(job) do
+      log_dropped_cache_vars(job, project, cache_env_vars)
+
       org_url = "https://#{organization.org_username}.#{Application.get_env(:zebra, :domain)}"
 
       env_vars =
@@ -193,6 +195,15 @@ defmodule Zebra.Workers.JobRequestFactory do
       ] ++ common_vars
     else
       common_vars
+    end
+  end
+
+  defp log_dropped_cache_vars(job, project, cache_env_vars) do
+    if cache_env_vars == [] and not Job.self_hosted?(job.machine_type) and
+         not is_nil(project.cache_id) do
+      Logger.warning(
+        "Cache env vars not injected into job. job_id=#{job.id} project_id=#{project.id} cache_id=#{project.cache_id}"
+      )
     end
   end
 end

--- a/zebra/lib/zebra/workers/job_request_factory/cache.ex
+++ b/zebra/lib/zebra/workers/job_request_factory/cache.ex
@@ -14,10 +14,7 @@ defmodule Zebra.Workers.JobRequestFactory.Cache do
   #
 
   def find(nil, _repo_proxy, _org_id) do
-    # We don't fail any jobs due to a missing cache connection,
-    # but we should make sure we are aware of any issues in this area.
-    Watchman.increment("external.cachehub.describe.failed")
-
+    skipped(:no_cache_id)
     {:ok, nil}
   end
 
@@ -31,30 +28,60 @@ defmodule Zebra.Workers.JobRequestFactory.Cache do
            {:ok, endpoint} <- Application.fetch_env(:zebra, :cachehub_api_endpoint),
            {:ok, channel} <- GRPC.Stub.connect(endpoint),
            {:ok, response} <- Stub.describe(channel, req, timeout: 30_000) do
-        if response.status.code == InternalApi.ResponseStatus.Code.value(:OK) do
-          if response.cache && response.cache.credential != " " do
-            {:ok, response.cache}
-          else
-            {:ok, nil}
-          end
-        else
-          {:ok, nil}
-        end
+        handle_describe_response(response, cache_id)
       else
         true ->
           Logger.info(
             "Skipping fetching of the cache as the job is part of Forked PR build. Cache id #{inspect(cache_id)}"
           )
 
+          skipped(:forked_pr)
           {:ok, nil}
 
         e ->
-          Watchman.increment("external.cachehub.describe.failed")
-          Logger.info("Failed to fetch info from cachehub #{cache_id}, #{inspect(e)}")
+          Logger.warning(
+            "Failed to fetch info from cachehub. cache_id=#{cache_id} error=#{inspect(e)}"
+          )
 
+          failed(:grpc_error)
           {:ok, nil}
       end
     end)
+  end
+
+  defp handle_describe_response(response, cache_id) do
+    ok_code = InternalApi.ResponseStatus.Code.value(:OK)
+
+    cond do
+      response.status.code != ok_code ->
+        Logger.warning(
+          "Cachehub describe returned non-OK status. cache_id=#{cache_id} status_code=#{inspect(response.status.code)}"
+        )
+
+        failed(:non_ok_response)
+        {:ok, nil}
+
+      is_nil(response.cache) or response.cache.credential == " " ->
+        Logger.warning("Cachehub describe returned blank credential. cache_id=#{cache_id}")
+
+        failed(:blank_credential)
+        {:ok, nil}
+
+      true ->
+        {:ok, response.cache}
+    end
+  end
+
+  defp failed(reason) do
+    Watchman.increment(
+      external: {"external.cachehub.describe.failed", [reason: to_string(reason)]}
+    )
+  end
+
+  defp skipped(reason) do
+    Watchman.increment(
+      external: {"external.cachehub.describe.skipped", [reason: to_string(reason)]}
+    )
   end
 
   def files(_, nil), do: {:ok, []}

--- a/zebra/lib/zebra/workers/job_request_factory/cache.ex
+++ b/zebra/lib/zebra/workers/job_request_factory/cache.ex
@@ -73,15 +73,11 @@ defmodule Zebra.Workers.JobRequestFactory.Cache do
   end
 
   defp failed(reason) do
-    Watchman.increment(
-      external: {"external.cachehub.describe.failed", [reason: to_string(reason)]}
-    )
+    Watchman.increment({"external.cachehub.describe.failed", [to_string(reason)]})
   end
 
   defp skipped(reason) do
-    Watchman.increment(
-      external: {"external.cachehub.describe.skipped", [reason: to_string(reason)]}
-    )
+    Watchman.increment({"external.cachehub.describe.skipped", [to_string(reason)]})
   end
 
   def files(_, nil), do: {:ok, []}

--- a/zebra/lib/zebra/workers/job_request_factory/cache.ex
+++ b/zebra/lib/zebra/workers/job_request_factory/cache.ex
@@ -61,7 +61,7 @@ defmodule Zebra.Workers.JobRequestFactory.Cache do
         failed(:non_ok_response)
         {:ok, nil}
 
-      is_nil(response.cache) or response.cache.credential == " " ->
+      is_nil(response.cache) or blank?(response.cache.credential) ->
         Logger.warning("Cachehub describe returned blank credential. cache_id=#{cache_id}")
 
         failed(:blank_credential)
@@ -71,6 +71,9 @@ defmodule Zebra.Workers.JobRequestFactory.Cache do
         {:ok, response.cache}
     end
   end
+
+  defp blank?(nil), do: true
+  defp blank?(credential), do: String.trim(credential) == ""
 
   defp failed(reason) do
     Watchman.increment({"external.cachehub.describe.failed", [to_string(reason)]})
@@ -116,10 +119,10 @@ defmodule Zebra.Workers.JobRequestFactory.Cache do
     end
   end
 
-  defp forked_pr?(_repo = %{pr_slug: ""}), do: false
-  defp forked_pr?(nil), do: false
+  def forked_pr?(_repo = %{pr_slug: ""}), do: false
+  def forked_pr?(nil), do: false
 
-  defp forked_pr?(repo) do
+  def forked_pr?(repo) do
     [pr_repo | _rest] = repo.pr_slug |> String.split("/")
     [base_repo | _rest] = repo.repo_slug |> String.split("/")
     pr_repo != base_repo

--- a/zebra/test/zebra/workers/job_request_factory/cache_test.exs
+++ b/zebra/test/zebra/workers/job_request_factory/cache_test.exs
@@ -59,6 +59,23 @@ defmodule Zebra.Workers.JobRequestFactory.CacheTest do
       refute log =~ @cache_url
     end
 
+    test "treats an empty-string credential as blank => returns {:ok, nil}" do
+      GrpcMock.stub(Support.FakeServers.CacheApi, :describe, fn _, _ ->
+        InternalApi.Cache.DescribeResponse.new(
+          status:
+            InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+          cache: InternalApi.Cache.Cache.new(id: @cache_id, credential: "", url: @cache_url)
+        )
+      end)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, nil} = Cache.find(@cache_id, nil, @org_id)
+        end)
+
+      assert log =~ "blank credential"
+    end
+
     test "logs warning and returns {:ok, nil} when cachehub raises" do
       GrpcMock.stub(Support.FakeServers.CacheApi, :describe, fn _, _ ->
         raise "boom"

--- a/zebra/test/zebra/workers/job_request_factory/cache_test.exs
+++ b/zebra/test/zebra/workers/job_request_factory/cache_test.exs
@@ -2,15 +2,78 @@
 defmodule Zebra.Workers.JobRequestFactory.CacheTest do
   use Zebra.DataCase
 
+  import ExUnit.CaptureLog
+
   alias Zebra.Workers.JobRequestFactory.Cache
 
   @org_id Ecto.UUID.generate()
   @cache_id Ecto.UUID.generate()
+  @cache_credential "--BEGIN....lalalala...cache_key...END---"
+  @cache_url "localhost:29920"
   @cache InternalApi.Cache.Cache.new(
            id: @cache_id,
-           credential: "--BEGIN....lalalala...cache_key...END---",
-           url: "localhost:29920"
+           credential: @cache_credential,
+           url: @cache_url
          )
+
+  describe ".find" do
+    test "with nil cache_id returns {:ok, nil} without contacting cachehub" do
+      assert {:ok, nil} = Cache.find(nil, nil, @org_id)
+    end
+
+    test "logs warning and returns {:ok, nil} when cachehub returns non-OK status" do
+      GrpcMock.stub(Support.FakeServers.CacheApi, :describe, fn _, _ ->
+        InternalApi.Cache.DescribeResponse.new(
+          status:
+            InternalApi.ResponseStatus.new(
+              code: InternalApi.ResponseStatus.Code.value(:BAD_PARAM)
+            )
+        )
+      end)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, nil} = Cache.find(@cache_id, nil, @org_id)
+        end)
+
+      assert log =~ "non-OK status"
+      assert log =~ @cache_id
+    end
+
+    test "logs warning and returns {:ok, nil} when cachehub returns blank credential" do
+      GrpcMock.stub(Support.FakeServers.CacheApi, :describe, fn _, _ ->
+        InternalApi.Cache.DescribeResponse.new(
+          status:
+            InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+          cache: InternalApi.Cache.Cache.new(id: @cache_id, credential: " ", url: @cache_url)
+        )
+      end)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, nil} = Cache.find(@cache_id, nil, @org_id)
+        end)
+
+      assert log =~ "blank credential"
+      assert log =~ @cache_id
+      refute log =~ @cache_url
+    end
+
+    test "logs warning and returns {:ok, nil} when cachehub raises" do
+      GrpcMock.stub(Support.FakeServers.CacheApi, :describe, fn _, _ ->
+        raise "boom"
+      end)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, nil} = Cache.find(@cache_id, nil, @org_id)
+        end)
+
+      assert log =~ "Failed to fetch info from cachehub"
+      assert log =~ @cache_id
+      refute log =~ @cache_credential
+    end
+  end
 
   describe ".env_vars" do
     test "cache_cli_parallel_archive_method is enabled => uses parallel archive method" do

--- a/zebra/test/zebra/workers/job_request_factory/cache_test.exs
+++ b/zebra/test/zebra/workers/job_request_factory/cache_test.exs
@@ -92,6 +92,37 @@ defmodule Zebra.Workers.JobRequestFactory.CacheTest do
     end
   end
 
+  describe ".forked_pr?" do
+    test "true when PR slug org differs from repo slug org" do
+      repo =
+        InternalApi.RepoProxy.Hook.new(
+          repo_slug: "test-org/test-repo",
+          pr_slug: "fork-org/test-repo"
+        )
+
+      assert Cache.forked_pr?(repo)
+    end
+
+    test "false when PR slug org matches repo slug org" do
+      repo =
+        InternalApi.RepoProxy.Hook.new(
+          repo_slug: "test-org/test-repo",
+          pr_slug: "test-org/test-repo"
+        )
+
+      refute Cache.forked_pr?(repo)
+    end
+
+    test "false when there is no PR slug (not a PR build)" do
+      repo = InternalApi.RepoProxy.Hook.new(repo_slug: "test-org/test-repo", pr_slug: "")
+      refute Cache.forked_pr?(repo)
+    end
+
+    test "false when repo proxy is nil" do
+      refute Cache.forked_pr?(nil)
+    end
+  end
+
   describe ".env_vars" do
     test "cache_cli_parallel_archive_method is enabled => uses parallel archive method" do
       #

--- a/zebra/test/zebra/workers/job_request_factory_test.exs
+++ b/zebra/test/zebra/workers/job_request_factory_test.exs
@@ -1411,6 +1411,42 @@ defmodule Zebra.Workers.JobRequestFactoryTest do
     assert log =~ @cache_id
   end
 
+  test "when cache is skipped for a forked PR => does not log dropped-vars warning" do
+    # Cache comes back empty (blank credential), but the PR is from a fork, so the
+    # missing cache vars are an intentional skip, not a dropped-vars condition.
+    GrpcMock.stub(Support.FakeServers.RepoProxyApi, :describe, fn _, _ ->
+      status = InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK))
+
+      hook =
+        InternalApi.RepoProxy.Hook.new(
+          repo_slug: "test-org/test-repo",
+          pr_slug: "fork-org/test-repo",
+          git_ref: "refs/pull/1/merge",
+          git_ref_type: InternalApi.RepoProxy.Hook.Type.value(:PR),
+          branch_name: "master"
+        )
+
+      %InternalApi.RepoProxy.DescribeResponse{status: status, hook: hook}
+    end)
+
+    GrpcMock.stub(Support.FakeServers.CacheApi, :describe, fn _, _ ->
+      InternalApi.Cache.DescribeResponse.new(
+        status: InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+        cache: InternalApi.Cache.Cache.new(credential: " ")
+      )
+    end)
+
+    {:ok, task} = Support.Factories.Task.create()
+    {:ok, job} = Support.Factories.Job.create(:pending, %{spec: @job_spec, build_id: task.id})
+
+    log =
+      capture_log(fn ->
+        assert {:ok, _job} = Worker.process(job)
+      end)
+
+    refute log =~ "Cache env vars not injected into job"
+  end
+
   test "when we can't connect to repo_proxy api => doesn't process the job" do
     GrpcMock.stub(Support.FakeServers.RepoProxyApi, :describe, fn _, _ ->
       raise "muahhahaaha"

--- a/zebra/test/zebra/workers/job_request_factory_test.exs
+++ b/zebra/test/zebra/workers/job_request_factory_test.exs
@@ -2,6 +2,8 @@ defmodule Zebra.Workers.JobRequestFactoryTest do
   alias Support.Factories
   use Zebra.DataCase
 
+  import ExUnit.CaptureLog
+
   alias Zebra.Models.Job
   alias Zebra.Workers.JobRequestFactory, as: Worker
 
@@ -1386,6 +1388,27 @@ defmodule Zebra.Workers.JobRequestFactoryTest do
     refute Enum.find(job.request["commands"], fn c ->
              c["directive"] == "ssh-add /home/semaphore/.ssh/semaphore_cache_key"
            end)
+  end
+
+  test "when cache env vars dropped despite project having cache_id => logs warning at factory level" do
+    GrpcMock.stub(Support.FakeServers.CacheApi, :describe, fn _, _ ->
+      InternalApi.Cache.DescribeResponse.new(
+        status: InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+        cache: InternalApi.Cache.Cache.new(credential: " ")
+      )
+    end)
+
+    {:ok, task} = Support.Factories.Task.create()
+    {:ok, job} = Support.Factories.Job.create(:pending, %{spec: @job_spec, build_id: task.id})
+
+    log =
+      capture_log(fn ->
+        assert {:ok, _job} = Worker.process(job)
+      end)
+
+    assert log =~ "Cache env vars not injected into job"
+    assert log =~ job.id
+    assert log =~ @cache_id
   end
 
   test "when we can't connect to repo_proxy api => doesn't process the job" do

--- a/zebra/test/zebra/workers/job_request_factory_test.exs
+++ b/zebra/test/zebra/workers/job_request_factory_test.exs
@@ -1411,42 +1411,6 @@ defmodule Zebra.Workers.JobRequestFactoryTest do
     assert log =~ @cache_id
   end
 
-  test "when cache is skipped for a forked PR => does not log dropped-vars warning" do
-    # Cache comes back empty (blank credential), but the PR is from a fork, so the
-    # missing cache vars are an intentional skip, not a dropped-vars condition.
-    GrpcMock.stub(Support.FakeServers.RepoProxyApi, :describe, fn _, _ ->
-      status = InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK))
-
-      hook =
-        InternalApi.RepoProxy.Hook.new(
-          repo_slug: "test-org/test-repo",
-          pr_slug: "fork-org/test-repo",
-          git_ref: "refs/pull/1/merge",
-          git_ref_type: InternalApi.RepoProxy.Hook.Type.value(:PR),
-          branch_name: "master"
-        )
-
-      %InternalApi.RepoProxy.DescribeResponse{status: status, hook: hook}
-    end)
-
-    GrpcMock.stub(Support.FakeServers.CacheApi, :describe, fn _, _ ->
-      InternalApi.Cache.DescribeResponse.new(
-        status: InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
-        cache: InternalApi.Cache.Cache.new(credential: " ")
-      )
-    end)
-
-    {:ok, task} = Support.Factories.Task.create()
-    {:ok, job} = Support.Factories.Job.create(:pending, %{spec: @job_spec, build_id: task.id})
-
-    log =
-      capture_log(fn ->
-        assert {:ok, _job} = Worker.process(job)
-      end)
-
-    refute log =~ "Cache env vars not injected into job"
-  end
-
   test "when we can't connect to repo_proxy api => doesn't process the job" do
     GrpcMock.stub(Support.FakeServers.RepoProxyApi, :describe, fn _, _ ->
       raise "muahhahaaha"


### PR DESCRIPTION
## Summary

Improves visibility into the path that injects `SEMAPHORE_CACHE_*` env vars into jobs. Three previously-silent failure paths in `Zebra.Workers.JobRequestFactory.Cache.find/3` now emit warning logs and tagged metrics. The factory also logs once when cache env vars are dropped despite the project having a `cache_id` configured — one breadcrumb per impacted job.

## What changes

1. **Tagged metrics** (Watchman, positional tag, internal channel — matches `dispatcher.ex:115`)
   - `external.cachehub.describe.failed` with first tag in `grpc_error | non_ok_response | blank_credential` (unexpected, alertable)
   - `external.cachehub.describe.skipped` with first tag in `no_cache_id | forked_pr` (expected, not actionable)
2. **Logs on previously-silent paths** in `cache.ex` (non-OK status, blank credential). The gRPC error path is promoted from `Logger.info` to `Logger.warning`. The forked-PR skip stays at info — it's by design.
3. **Caller-side log** in `job_request_factory.ex`: when `cache_env_vars == []` AND project has `cache_id` AND job is not self-hosted, emit a single `Logger.warning` with `job_id`, `project_id`, `cache_id`. This is the most useful log for the operational case — "this specific job did not get cache vars".

## Behavior change worth flagging

Previously, `Cache.find(nil, _, _)` incremented `external.cachehub.describe.failed`. That was misleading: projects without a cache configured were lumped into the failure counter. This PR moves that traffic to `external.cachehub.describe.skipped` with first tag `no_cache_id`.

Any dashboard panel or alert on the old single-bucket `external.cachehub.describe.failed` series will see a drop in volume once this ships, and the skipped traffic needs to be added separately if it was being watched.

## Metric format

In SaaS (`:statsd_graphite` backend), each call emits `tagged.<prefix>.<reason>.no_tag.no_tag.external.cachehub.describe.<failed|skipped>:1|c`. Reason is the first positional tag and is filterable in Grafana via the graphite path. On-prem (`:aws_cloudwatch`) does not yet receive these metrics — see follow-up below.

## Logged fields

Logged: `cache_id`, response status code, gRPC error tuple from `inspect/1`, `job_id`, `project_id`. Not logged: cache credential, cache URL.

## Tests

- `cache_test.exs`: new `.find` describe block covering nil `cache_id`, non-OK status (asserts warning + `cache_id` in log), blank credential (asserts warning + `cache_id` + no URL leak), and the gRPC raise path (asserts warning + no credential leak).
- `job_request_factory_test.exs`: new test asserting the caller-side "Cache env vars not injected" warning fires when cachehub returns blank credential for a project with `cache_id` set.

## Follow-ups (separate work)

- Grafana panel split: stacked `cachehub.describe.failed` by reason path; alert on rate excluding `forked_pr`.
- cachehub-side per-response log for cross-checking.
- On-prem metric path (DogStatsD keyword tags via the `external:` channel) — deferred; the reported incidents come from SaaS.