### PR TITLE
fix(ee/rbac): issues when readiing saml user

### DIFF
--- a/ee/rbac/lib/rbac/okta/saml/api.ex
+++ b/ee/rbac/lib/rbac/okta/saml/api.ex
@@ -123,7 +123,8 @@ defmodule Rbac.Okta.Saml.Api do
     {:ok, email, attributes} = PayloadParser.parse(integration, params, consume_uri, metadata_uri)
 
     with {:ok, scim_saml_user} <- find_scim_or_saml_user(integration, email),
-         {:ok, scim_saml_user} <- maybe_provision_existing_saml_jit_user(integration, scim_saml_user),
+         {:ok, scim_saml_user} <-
+           maybe_provision_existing_saml_jit_user(integration, scim_saml_user),
          {:ok, user} <- find_user(scim_saml_user),
          {:ok, user} <- FrontRepo.User.set_remember_timestamp(user) do
       Watchman.increment("saml_login.success")

--- a/ee/rbac/lib/rbac/okta/saml/api.ex
+++ b/ee/rbac/lib/rbac/okta/saml/api.ex
@@ -123,6 +123,7 @@ defmodule Rbac.Okta.Saml.Api do
     {:ok, email, attributes} = PayloadParser.parse(integration, params, consume_uri, metadata_uri)
 
     with {:ok, scim_saml_user} <- find_scim_or_saml_user(integration, email),
+         {:ok, scim_saml_user} <- maybe_provision_existing_saml_jit_user(integration, scim_saml_user),
          {:ok, user} <- find_user(scim_saml_user),
          {:ok, user} <- FrontRepo.User.set_remember_timestamp(user) do
       Watchman.increment("saml_login.success")
@@ -209,6 +210,22 @@ defmodule Rbac.Okta.Saml.Api do
     else
       {:ok, user} -> {:ok, user}
     end
+  end
+
+  defp maybe_provision_existing_saml_jit_user(
+         %{jit_provisioning_enabled: true},
+         %Rbac.Repo.SamlJitUser{} = saml_jit_user
+       ) do
+    if saml_jit_user.user_id == nil or
+         !Rbac.RoleManagement.user_part_of_org?(saml_jit_user.user_id, saml_jit_user.org_id) do
+      Rbac.Okta.Saml.JitProvisioner.AddUser.run(saml_jit_user)
+    else
+      {:ok, saml_jit_user}
+    end
+  end
+
+  defp maybe_provision_existing_saml_jit_user(_integration, scim_saml_user) do
+    {:ok, scim_saml_user}
   end
 
   defp expires_at_unix(integration) do

--- a/ee/rbac/lib/rbac/okta/saml/api.ex
+++ b/ee/rbac/lib/rbac/okta/saml/api.ex
@@ -124,7 +124,7 @@ defmodule Rbac.Okta.Saml.Api do
 
     with {:ok, scim_saml_user} <- find_scim_or_saml_user(integration, email),
          {:ok, scim_saml_user} <-
-           maybe_provision_existing_saml_jit_user(integration, scim_saml_user),
+           maybe_provision_existing_saml_jit_user(integration, scim_saml_user, attributes),
          {:ok, user} <- find_user(scim_saml_user),
          {:ok, user} <- FrontRepo.User.set_remember_timestamp(user) do
       Watchman.increment("saml_login.success")
@@ -215,17 +215,19 @@ defmodule Rbac.Okta.Saml.Api do
 
   defp maybe_provision_existing_saml_jit_user(
          %{jit_provisioning_enabled: true},
-         %Rbac.Repo.SamlJitUser{} = saml_jit_user
+         %Rbac.Repo.SamlJitUser{} = saml_jit_user,
+         attributes
        ) do
     if saml_jit_user.user_id == nil or
          !Rbac.RoleManagement.user_part_of_org?(saml_jit_user.user_id, saml_jit_user.org_id) do
+      {:ok, saml_jit_user} = Rbac.Repo.SamlJitUser.update_attributes(saml_jit_user, attributes)
       Rbac.Okta.Saml.JitProvisioner.AddUser.run(saml_jit_user)
     else
       {:ok, saml_jit_user}
     end
   end
 
-  defp maybe_provision_existing_saml_jit_user(_integration, scim_saml_user) do
+  defp maybe_provision_existing_saml_jit_user(_integration, scim_saml_user, _attributes) do
     {:ok, scim_saml_user}
   end
 

--- a/ee/rbac/lib/rbac/okta/saml/jit_provisioner/add_user.ex
+++ b/ee/rbac/lib/rbac/okta/saml/jit_provisioner/add_user.ex
@@ -1,13 +1,18 @@
 # credo:disable-for-this-file
 defmodule Rbac.Okta.Saml.JitProvisioner.AddUser do
   @moduledoc """
-  Procedure for creating a Semaphore user based on the received
-  okta user payload.
+  Procedure for provisioning (or re-provisioning) a Semaphore user based on
+  the received okta/SAML JIT payload.
 
-  The assumed state of the system:
-  - We have an okta_user record in the database
-  - The okta_user.state is :pending
-  - The okta_user.user_id is nil
+  `run/1` is idempotent and safe to re-enter for an already-provisioned user
+  (the SAML re-add path: a JIT user who was removed from the org logging in
+  again). It does not assume `state == :pending` or `user_id == nil`:
+
+  - `find_or_create_user/2` reuses an existing user when one is found.
+  - `assign_role/3` is a no-op when the user is already part of the org.
+  - `assign_groups/2` skips a group when the user is already a member or an
+    `:add_user` request for that group is already in-flight, so rapid
+    duplicate logins do not enqueue duplicate `GroupManagementRequest` rows.
   """
 
   require Logger
@@ -144,7 +149,16 @@ defmodule Rbac.Okta.Saml.JitProvisioner.AddUser do
 
   defp assign_groups(user_id, group_ids) when is_list(group_ids) do
     Enum.each(group_ids, fn group_id ->
-      Rbac.Repo.GroupManagementRequest.create_new_request(user_id, group_id, :add_user, nil)
+      cond do
+        Rbac.Repo.UserGroupBinding.member?(user_id, group_id) ->
+          :ok
+
+        Rbac.Repo.GroupManagementRequest.open_add_user_request_exists?(user_id, group_id) ->
+          :ok
+
+        true ->
+          Rbac.Repo.GroupManagementRequest.create_new_request(user_id, group_id, :add_user, nil)
+      end
     end)
 
     :ok

--- a/ee/rbac/lib/rbac/repo/group_management_request.ex
+++ b/ee/rbac/lib/rbac/repo/group_management_request.ex
@@ -48,6 +48,21 @@ defmodule Rbac.Repo.GroupManagementRequest do
     |> insert()
   end
 
+  @doc """
+  Returns true when an `:add_user` request for this user/group is already
+  in-flight (`:pending` or `:processing`). Used to keep re-add provisioning
+  idempotent so rapid duplicate logins do not enqueue duplicate requests.
+  """
+  def open_add_user_request_exists?(user_id, group_id) do
+    __MODULE__
+    |> where(
+      [r],
+      r.user_id == ^user_id and r.group_id == ^group_id and r.action == ^:add_user and
+        r.state in ^[:pending, :processing]
+    )
+    |> Rbac.Repo.exists?()
+  end
+
   def finish_processing(%__MODULE__{} = req) do
     req = fetch(req)
 

--- a/ee/rbac/lib/rbac/repo/saml_jit_user.ex
+++ b/ee/rbac/lib/rbac/repo/saml_jit_user.ex
@@ -81,6 +81,10 @@ defmodule Rbac.Repo.SamlJitUser do
     changeset(user, %{state: :processed}) |> Rbac.Repo.update()
   end
 
+  def update_attributes(%__MODULE__{} = user, attributes) do
+    changeset(user, %{attributes: attributes}) |> Rbac.Repo.update()
+  end
+
   defp new(integration, email, attributes) do
     %__MODULE__{
       integration_id: integration.id,

--- a/ee/rbac/lib/rbac/repo/user_group_binding.ex
+++ b/ee/rbac/lib/rbac/repo/user_group_binding.ex
@@ -10,6 +10,13 @@ defmodule Rbac.Repo.UserGroupBinding do
     belongs_to(:group, Group, primary_key: true)
   end
 
+  @spec member?(String.t(), String.t()) :: boolean()
+  def member?(user_id, group_id) do
+    __MODULE__
+    |> where([ugb], ugb.user_id == ^user_id and ugb.group_id == ^group_id)
+    |> Rbac.Repo.exists?()
+  end
+
   @spec fetch_group_members(String.t()) :: [RbacUser.t()]
   def fetch_group_members(group_id) do
     __MODULE__

--- a/ee/rbac/test/rbac/okta/saml/api_test.exs
+++ b/ee/rbac/test/rbac/okta/saml/api_test.exs
@@ -156,6 +156,57 @@ defmodule Rbac.Okta.Saml.Api.Test do
       end
     end
 
+    test "rapid re-add logins do not enqueue duplicate group add requests", ctx do
+      import Ecto.Query
+      alias Rbac.Events.UserJoinedOrganization
+
+      enable_jit_provisioning(ctx.integration)
+
+      {:ok, group1} = Support.Factories.Group.insert(organization_id: @org_id)
+      {:ok, member} = Rbac.Repo.RbacRole.get_role_by_name("Member", "org_scope", @org_id)
+
+      Support.Factories.IdpGroupMapping.insert(
+        organization_id: @org_id,
+        default_role_id: member.id,
+        group_mapping: [%{idp_group_id: "g1", semaphore_group_id: group1.id}]
+      )
+
+      with_mocks [{UserJoinedOrganization, [], [publish: fn _, _ -> :ok end]}] do
+        {:ok, saml_jit_user} =
+          Rbac.Repo.SamlJitUser.create(ctx.integration, "denis@example.com", %{"member" => ["g1"]})
+
+        # Initial provision queues exactly one :add_user request for the group.
+        {:ok, saml_jit_user} = Rbac.Okta.Saml.JitProvisioner.AddUser.run(saml_jit_user)
+
+        {:ok, rbi} =
+          Rbac.RoleBindingIdentification.new(
+            user_id: saml_jit_user.user_id,
+            org_id: @org_id,
+            project_id: :is_nil
+          )
+
+        {:ok, nil} = Rbac.RoleManagement.retract_roles(rbi)
+        refute Rbac.RoleManagement.user_part_of_org?(saml_jit_user.user_id, @org_id)
+
+        # Two rapid re-add logins must not pile on additional :add_user requests.
+        {:ok, r1} =
+          post("/okta/auth", saml_payload("denis@example.com", :okta, [{"member", "g1"}]))
+
+        {:ok, r2} =
+          post("/okta/auth", saml_payload("denis@example.com", :okta, [{"member", "g1"}]))
+
+        assert r1.status_code == 302
+        assert r2.status_code == 302
+
+        add_user_requests =
+          Rbac.Repo.GroupManagementRequest
+          |> where([r], r.user_id == ^saml_jit_user.user_id and r.action == :add_user)
+          |> Rbac.Repo.aggregate(:count)
+
+        assert add_user_requests == 1
+      end
+    end
+
     test "valid SAML, okta user exists, but semaphore user does not", ctx do
       assert {:ok, _} = create_okta_user(ctx.integration, "denis@example.com")
 

--- a/ee/rbac/test/rbac/okta/saml/api_test.exs
+++ b/ee/rbac/test/rbac/okta/saml/api_test.exs
@@ -66,6 +66,39 @@ defmodule Rbac.Okta.Saml.Api.Test do
       assert location == {"location", "https://me.localhost/account/welcome/okta"}
     end
 
+    test "valid SAML re-adds an existing JIT user who is no longer part of the organization", ctx do
+      alias Rbac.Events.UserJoinedOrganization
+
+      enable_jit_provisioning(ctx.integration)
+
+      with_mocks [{UserJoinedOrganization, [], [publish: fn _, _ -> :ok end]}] do
+        {:ok, saml_jit_user} =
+          Rbac.Repo.SamlJitUser.create(ctx.integration, "denis@example.com", %{
+            "firstName" => ["Denis"],
+            "lastName" => ["Tapia"]
+          })
+
+        {:ok, saml_jit_user} = Rbac.Okta.Saml.JitProvisioner.AddUser.run(saml_jit_user)
+
+        {:ok, rbi} =
+          Rbac.RoleBindingIdentification.new(
+            user_id: saml_jit_user.user_id,
+            org_id: @org_id,
+            project_id: :is_nil
+          )
+
+        {:ok, nil} = Rbac.RoleManagement.retract_roles(rbi)
+
+        refute Rbac.RoleManagement.user_part_of_org?(saml_jit_user.user_id, @org_id)
+
+        {:ok, response} = post("/okta/auth", saml_payload("denis@example.com"))
+
+        assert response.status_code == 302
+        assert Rbac.RoleManagement.user_part_of_org?(saml_jit_user.user_id, @org_id)
+        assert_called_exactly(UserJoinedOrganization.publish(saml_jit_user.user_id, @org_id), 2)
+      end
+    end
+
     test "valid SAML, okta user exists, but semaphore user does not", ctx do
       assert {:ok, _} = create_okta_user(ctx.integration, "denis@example.com")
 

--- a/ee/rbac/test/rbac/okta/saml/api_test.exs
+++ b/ee/rbac/test/rbac/okta/saml/api_test.exs
@@ -66,7 +66,8 @@ defmodule Rbac.Okta.Saml.Api.Test do
       assert location == {"location", "https://me.localhost/account/welcome/okta"}
     end
 
-    test "valid SAML re-adds an existing JIT user who is no longer part of the organization", ctx do
+    test "valid SAML re-adds an existing JIT user who is no longer part of the organization",
+         ctx do
       alias Rbac.Events.UserJoinedOrganization
 
       enable_jit_provisioning(ctx.integration)

--- a/ee/rbac/test/rbac/okta/saml/api_test.exs
+++ b/ee/rbac/test/rbac/okta/saml/api_test.exs
@@ -100,6 +100,62 @@ defmodule Rbac.Okta.Saml.Api.Test do
       end
     end
 
+    test "valid SAML re-provisions a removed JIT user using current assertion claims, not stale stored ones",
+         ctx do
+      alias Rbac.Events.UserJoinedOrganization
+
+      enable_jit_provisioning(ctx.integration)
+
+      {:ok, admin} = Rbac.Repo.RbacRole.get_role_by_name("Admin", "org_scope", @org_id)
+      {:ok, member} = Rbac.Repo.RbacRole.get_role_by_name("Member", "org_scope", @org_id)
+
+      Support.Factories.IdpGroupMapping.insert(
+        organization_id: @org_id,
+        default_role_id: member.id,
+        role_mapping: [%{idp_role_id: "admins", semaphore_role_id: admin.id}]
+      )
+
+      with_mocks [{UserJoinedOrganization, [], [publish: fn _, _ -> :ok end]}] do
+        # First login: IdP grants an elevated role that maps to Admin.
+        {:ok, saml_jit_user} =
+          Rbac.Repo.SamlJitUser.create(ctx.integration, "denis@example.com", %{
+            "role" => ["admins"]
+          })
+
+        {:ok, saml_jit_user} = Rbac.Okta.Saml.JitProvisioner.AddUser.run(saml_jit_user)
+
+        assert_org_role(saml_jit_user.user_id, @org_id, "Admin")
+
+        # The user is removed from the organization.
+        {:ok, rbi} =
+          Rbac.RoleBindingIdentification.new(
+            user_id: saml_jit_user.user_id,
+            org_id: @org_id,
+            project_id: :is_nil
+          )
+
+        {:ok, nil} = Rbac.RoleManagement.retract_roles(rbi)
+        refute Rbac.RoleManagement.user_part_of_org?(saml_jit_user.user_id, @org_id)
+
+        # Re-login after the IdP downgraded the user (role no longer maps to Admin).
+        {:ok, response} =
+          post("/okta/auth", saml_payload("denis@example.com", :okta, [{"role", "members"}]))
+
+        assert response.status_code == 302
+        assert Rbac.RoleManagement.user_part_of_org?(saml_jit_user.user_id, @org_id)
+
+        # The re-added user gets the CURRENT (downgraded) role, never the stale elevated one.
+        assert_org_role(saml_jit_user.user_id, @org_id, "Member")
+        refute_org_role(saml_jit_user.user_id, @org_id, "Admin")
+
+        # Stored attributes were refreshed from the current assertion before re-provisioning.
+        {:ok, refreshed} =
+          Rbac.Repo.SamlJitUser.find_by_email(ctx.integration, "denis@example.com")
+
+        assert refreshed.attributes == %{"role" => ["members"]}
+      end
+    end
+
     test "valid SAML, okta user exists, but semaphore user does not", ctx do
       assert {:ok, _} = create_okta_user(ctx.integration, "denis@example.com")
 
@@ -329,7 +385,7 @@ defmodule Rbac.Okta.Saml.Api.Test do
     HTTPoison.post("#{@host}#{path}", body, @headers ++ headers, opts)
   end
 
-  defp saml_payload(email, issuer \\ :okta) do
+  defp saml_payload(email, issuer \\ :okta, attributes \\ []) do
     domain = Application.get_env(:rbac, :base_domain)
 
     Support.Okta.Saml.PayloadBuilder.build(
@@ -337,10 +393,31 @@ defmodule Rbac.Okta.Saml.Api.Test do
         recipient: "https://#{@org_username}.#{domain}/okta/auth",
         audience: "https://#{@org_username}.#{domain}",
         issuer: @okta_issuer,
-        email: email
+        email: email,
+        attributes: attributes
       },
       issuer
     )
+  end
+
+  defp assert_org_role(user_id, org_id, role_name),
+    do: assert(org_role_assigned?(user_id, org_id, role_name))
+
+  defp refute_org_role(user_id, org_id, role_name),
+    do: refute(org_role_assigned?(user_id, org_id, role_name))
+
+  defp org_role_assigned?(user_id, org_id, role_name) do
+    import Ecto.Query
+
+    {:ok, role} = Rbac.Repo.RbacRole.get_role_by_name(role_name, "org_scope", org_id)
+
+    Rbac.Repo.SubjectRoleBinding
+    |> where(
+      [s],
+      s.subject_id == ^user_id and s.org_id == ^org_id and s.role_id == ^role.id and
+        is_nil(s.project_id)
+    )
+    |> Rbac.Repo.exists?()
   end
 
   defp reload_okta_user(okta_user_id) do

--- a/ee/rbac/test/rbac/okta/saml/provisioner/add_user_test.exs
+++ b/ee/rbac/test/rbac/okta/saml/provisioner/add_user_test.exs
@@ -86,6 +86,42 @@ defmodule Rbac.Okta.Saml.Provisioner.AddUser.Test do
 
       assert Repo.GroupManagementRequest |> Repo.aggregate(:count) == 2
     end
+
+    test "is re-entrant: a second run does not enqueue duplicate group add requests" do
+      import Ecto.Query
+
+      {:ok, jit_user} =
+        Factories.SamlJitUser.insert(
+          org_id: @org_id,
+          attributes: %{"member" => ["g1", "g2"]}
+        )
+
+      {:ok, group1} = Factories.Group.insert(organization_id: @org_id)
+      {:ok, group2} = Factories.Group.insert(organization_id: @org_id)
+      {:ok, member} = Repo.RbacRole.get_role_by_name("Member", "org_scope", jit_user.org_id)
+
+      Factories.IdpGroupMapping.insert(
+        organization_id: jit_user.org_id,
+        default_role_id: member.id,
+        group_mapping: [
+          %{idp_group_id: "g1", semaphore_group_id: group1.id},
+          %{idp_group_id: "g2", semaphore_group_id: group2.id}
+        ]
+      )
+
+      {:ok, jit_user} = AddUser.run(jit_user)
+
+      # Rapid second login before the async processor catches up: the pending
+      # :add_user requests already exist, so the second run must not duplicate them.
+      {:ok, _jit_user} = AddUser.run(jit_user)
+
+      add_user_requests =
+        Repo.GroupManagementRequest
+        |> where([r], r.user_id == ^jit_user.user_id and r.action == :add_user)
+        |> Repo.aggregate(:count)
+
+      assert add_user_requests == 2
+    end
   end
 
   defp assert_user_created(jit_user) do


### PR DESCRIPTION
## 📝 Description

Fix SAML JIT re-provisioning for users who were previously removed from an organization.

When a SamlJitUser record already existed, login skipped provisioning and never re-checked org membership. This change re-runs JIT provisioning for existing SAML users when they are no longer part of the org, so they are added back correctly on login.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~
