### PR TITLE
feat(guard): add RefreshGithubProfile 

### DIFF
--- a/ee/rbac/lib/rbac/services/user_updater.ex
+++ b/ee/rbac/lib/rbac/services/user_updater.ex
@@ -27,13 +27,13 @@ defmodule Rbac.Services.UserUpdater do
       {:ok, rbi} = Rbac.RoleBindingIdentification.new(user_id: event.user_id)
       Rbac.RoleManagement.assign_project_roles_to_repo_collaborators(rbi)
 
-      # Propagate any repo host login changes (e.g. GitHub username rename) into
-      # cached collaborator rows so per-project listings/exports stay in sync.
-      Rbac.SyncUsernames.propagate(event.user_id)
-
       if Rbac.OIDC.enabled?() do
         handle_oidc_sync(event.user_id)
       end
+
+      # Propagate any repo host login changes (e.g. GitHub username rename) into
+      # cached collaborator rows so per-project listings/exports stay in sync.
+      Rbac.SyncUsernames.propagate(event.user_id)
 
       log(event.user_id, "Processing finished")
     end)

--- a/ee/rbac/lib/rbac/services/user_updater.ex
+++ b/ee/rbac/lib/rbac/services/user_updater.ex
@@ -27,6 +27,10 @@ defmodule Rbac.Services.UserUpdater do
       {:ok, rbi} = Rbac.RoleBindingIdentification.new(user_id: event.user_id)
       Rbac.RoleManagement.assign_project_roles_to_repo_collaborators(rbi)
 
+      # Propagate any repo host login changes (e.g. GitHub username rename) into
+      # cached collaborator rows so per-project listings/exports stay in sync.
+      Rbac.SyncUsernames.propagate(event.user_id)
+
       if Rbac.OIDC.enabled?() do
         handle_oidc_sync(event.user_id)
       end

--- a/ee/rbac/lib/rbac/sync_usernames.ex
+++ b/ee/rbac/lib/rbac/sync_usernames.ex
@@ -1,0 +1,83 @@
+defmodule Rbac.SyncUsernames do
+  @moduledoc """
+  Propagates repo host login (a.k.a. nickname/username) changes from the
+  authoritative `repo_host_accounts` table (Front DB, owned by Guard) into the
+  per-project `collaborators` cache that RBAC maintains.
+
+  Triggered from `Rbac.Services.UserUpdater` on every `user_updated` event.
+  Only rows whose `github_uid` matches the user's repo host account UID **and**
+  whose stored `github_username` is out of date are updated, so this is a
+  cheap no-op for the common case where the user did not actually rename.
+  """
+
+  require Logger
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Rbac.Repo
+  alias Rbac.Repo.Collaborator
+
+  @doc """
+  Loads the user's current repo host accounts and updates any `collaborators`
+  rows whose stored `github_username` is stale (matching by `github_uid`).
+
+  Returns `{:ok, n}` where `n` is the total number of collaborator rows that
+  were updated across all providers, or `{:error, reason}` if the user lookup
+  fails.
+  """
+  @spec propagate(String.t()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def propagate(user_id) when is_binary(user_id) do
+    case Rbac.Store.User.Front.fetch_user_with_repo_account_details(user_id) do
+      nil ->
+        Logger.warning("[SyncUsernames] User #{user_id} not found - skipping")
+        {:error, :user_not_found}
+
+      user ->
+        total =
+          user.providers
+          |> Enum.reduce(0, fn provider, acc ->
+            acc + update_for_provider(user_id, provider)
+          end)
+
+        if total > 0 do
+          Logger.info("[SyncUsernames] Updated #{total} collaborator row(s) for user #{user_id}")
+        end
+
+        Watchman.submit("rbac.sync_usernames.rows_updated", total, :gauge)
+
+        {:ok, total}
+    end
+  end
+
+  defp update_for_provider(user_id, provider) do
+    uid = Map.get(provider, "uid")
+    login = Map.get(provider, "login")
+    provider_name = Map.get(provider, "provider")
+
+    cond do
+      is_nil(uid) or uid == "" ->
+        0
+
+      is_nil(login) or login == "" ->
+        0
+
+      true ->
+        {count, _} =
+          from(c in Collaborator,
+            where: c.github_uid == ^uid and c.github_username != ^login
+          )
+          |> Repo.update_all(set: [github_username: login, updated_at: now()])
+
+        if count > 0 do
+          Logger.info(
+            "[SyncUsernames] user=#{user_id} provider=#{provider_name} uid=#{uid} " <>
+              "new_login=#{login} rows_updated=#{count}"
+          )
+        end
+
+        count
+    end
+  end
+
+  defp now, do: NaiveDateTime.utc_now()
+end

--- a/ee/rbac/lib/rbac/sync_usernames.ex
+++ b/ee/rbac/lib/rbac/sync_usernames.ex
@@ -1,13 +1,12 @@
 defmodule Rbac.SyncUsernames do
   @moduledoc """
-  Propagates repo host login (a.k.a. nickname/username) changes from the
+  Propagates repo host login changes from the
   authoritative `repo_host_accounts` table (Front DB, owned by Guard) into the
   per-project `collaborators` cache that RBAC maintains.
 
   Triggered from `Rbac.Services.UserUpdater` on every `user_updated` event.
   Only rows whose `github_uid` matches the user's repo host account UID **and**
-  whose stored `github_username` is out of date are updated, so this is a
-  cheap no-op for the common case where the user did not actually rename.
+  whose stored `github_username` is out of date are updated.
   """
 
   require Logger
@@ -21,9 +20,8 @@ defmodule Rbac.SyncUsernames do
   Loads the user's current repo host accounts and updates any `collaborators`
   rows whose stored `github_username` is stale (matching by `github_uid`).
 
-  Returns `{:ok, n}` where `n` is the total number of collaborator rows that
-  were updated across all providers, or `{:error, reason}` if the user lookup
-  fails.
+  Returns `{:ok, updated_collaborators_count}` if successful,
+  or `{:error, reason}` if the user lookup fails.
   """
   @spec propagate(String.t()) :: {:ok, non_neg_integer()} | {:error, term()}
   def propagate(user_id) when is_binary(user_id) do
@@ -49,34 +47,35 @@ defmodule Rbac.SyncUsernames do
     end
   end
 
+  # only handle GitHub provider for now.
+  defp update_for_provider(
+         _user_id,
+         %{"provider" => provider_name, "uid" => uid, "login" => login}
+       )
+       when provider_name != "github"
+       when is_nil(login) or login == ""
+       when is_nil(uid) or uid == "",
+       do: 0
+
   defp update_for_provider(user_id, provider) do
     uid = Map.get(provider, "uid")
     login = Map.get(provider, "login")
     provider_name = Map.get(provider, "provider")
 
-    cond do
-      is_nil(uid) or uid == "" ->
-        0
+    {count, _} =
+      from(c in Collaborator,
+        where: c.github_uid == ^uid and c.github_username != ^login
+      )
+      |> Repo.update_all(set: [github_username: login, updated_at: now()])
 
-      is_nil(login) or login == "" ->
-        0
-
-      true ->
-        {count, _} =
-          from(c in Collaborator,
-            where: c.github_uid == ^uid and c.github_username != ^login
-          )
-          |> Repo.update_all(set: [github_username: login, updated_at: now()])
-
-        if count > 0 do
-          Logger.info(
-            "[SyncUsernames] user=#{user_id} provider=#{provider_name} uid=#{uid} " <>
-              "new_login=#{login} rows_updated=#{count}"
-          )
-        end
-
-        count
+    if count > 0 do
+      Logger.info(
+        "[SyncUsernames] user=#{user_id} provider=#{provider_name} uid=#{uid} " <>
+          "new_login=#{login} rows_updated=#{count}"
+      )
     end
+
+    count
   end
 
   defp now, do: NaiveDateTime.utc_now()

--- a/ee/rbac/lib/rbac/sync_usernames.ex
+++ b/ee/rbac/lib/rbac/sync_usernames.ex
@@ -14,7 +14,7 @@ defmodule Rbac.SyncUsernames do
   import Ecto.Query, only: [from: 2]
 
   alias Rbac.Repo
-  alias Rbac.Repo.Collaborator
+  alias Rbac.Repo.{Collaborator, Project}
 
   @doc """
   Loads the user's current repo host accounts and updates any `collaborators`
@@ -64,7 +64,12 @@ defmodule Rbac.SyncUsernames do
 
     {count, _} =
       from(c in Collaborator,
-        where: c.github_uid == ^uid and c.github_username != ^login
+        join: p in Project,
+        on: p.project_id == c.project_id,
+        where:
+          c.github_uid == ^uid and
+            c.github_username != ^login and
+            p.provider == ^provider_name
       )
       |> Repo.update_all(set: [github_username: login, updated_at: now()])
 

--- a/ee/rbac/test/rbac/sync_usernames_test.exs
+++ b/ee/rbac/test/rbac/sync_usernames_test.exs
@@ -104,5 +104,63 @@ defmodule Rbac.SyncUsernamesTest do
       assert {:error, :user_not_found} =
                Rbac.SyncUsernames.propagate(Ecto.UUID.generate())
     end
+
+    test "does not touch any rows when the user only has a non-github provider" do
+      user_id = Ecto.UUID.generate()
+      uid = "bb-99"
+      project_id = Ecto.UUID.generate()
+
+      {:ok, _} = Support.Factories.FrontUser.insert(id: user_id, email: "user@example.com")
+      {:ok, _} = Support.Factories.RbacUser.insert(user_id, "User", "user@example.com")
+
+      {:ok, _} =
+        Support.Members.insert_repo_host_account(
+          login: "user-renamed",
+          name: "user-renamed",
+          github_uid: uid,
+          user_id: user_id,
+          repo_host: "bitbucket"
+        )
+
+      {:ok, collab} =
+        Support.Collaborators.insert(
+          project_id: project_id,
+          github_username: "user-old",
+          github_uid: uid
+        )
+
+      assert {:ok, 0} = Rbac.SyncUsernames.propagate(user_id)
+
+      assert %Collaborator{github_username: "user-old"} = Repo.get!(Collaborator, collab.id)
+    end
+
+    test "does not touch any rows when the provider has a blank login" do
+      user_id = Ecto.UUID.generate()
+      uid = "184065"
+      project_id = Ecto.UUID.generate()
+
+      {:ok, _} = Support.Factories.FrontUser.insert(id: user_id, email: "user@example.com")
+      {:ok, _} = Support.Factories.RbacUser.insert(user_id, "User", "user@example.com")
+
+      {:ok, _} =
+        Support.Members.insert_repo_host_account(
+          login: "",
+          name: "",
+          github_uid: uid,
+          user_id: user_id,
+          repo_host: "github"
+        )
+
+      {:ok, collab} =
+        Support.Collaborators.insert(
+          project_id: project_id,
+          github_username: "user-old",
+          github_uid: uid
+        )
+
+      assert {:ok, 0} = Rbac.SyncUsernames.propagate(user_id)
+
+      assert %Collaborator{github_username: "user-old"} = Repo.get!(Collaborator, collab.id)
+    end
   end
 end

--- a/ee/rbac/test/rbac/sync_usernames_test.exs
+++ b/ee/rbac/test/rbac/sync_usernames_test.exs
@@ -1,0 +1,108 @@
+defmodule Rbac.SyncUsernamesTest do
+  use Rbac.RepoCase
+
+  alias Rbac.Repo
+  alias Rbac.Repo.Collaborator
+
+  setup do
+    Support.Rbac.Store.clear!()
+
+    :ok
+  end
+
+  describe ".propagate/1" do
+    test "updates stale github_username on collaborator rows that match by github_uid" do
+      user_id = Ecto.UUID.generate()
+      uid = "184065"
+      project_id = Ecto.UUID.generate()
+
+      {:ok, _} = Support.Factories.FrontUser.insert(id: user_id, email: "user@example.com")
+      {:ok, _} = Support.Factories.RbacUser.insert(user_id, "User", "user@example.com")
+
+      {:ok, _} =
+        Support.Members.insert_repo_host_account(
+          login: "user-renamed",
+          name: "user-renamed",
+          github_uid: uid,
+          user_id: user_id,
+          repo_host: "github"
+        )
+
+      {:ok, stale} =
+        Support.Collaborators.insert(
+          project_id: project_id,
+          github_username: "user-old",
+          github_uid: uid
+        )
+
+      assert {:ok, 1} = Rbac.SyncUsernames.propagate(user_id)
+
+      assert %Collaborator{github_username: "user-renamed"} = Repo.get!(Collaborator, stale.id)
+    end
+
+    test "is a no-op when the stored username already matches" do
+      user_id = Ecto.UUID.generate()
+      uid = "184065"
+      project_id = Ecto.UUID.generate()
+
+      {:ok, _} = Support.Factories.FrontUser.insert(id: user_id, email: "user@example.com")
+      {:ok, _} = Support.Factories.RbacUser.insert(user_id, "User", "user@example.com")
+
+      {:ok, _} =
+        Support.Members.insert_repo_host_account(
+          login: "user-current",
+          name: "user-current",
+          github_uid: uid,
+          user_id: user_id,
+          repo_host: "github"
+        )
+
+      {:ok, untouched} =
+        Support.Collaborators.insert(
+          project_id: project_id,
+          github_username: "user-current",
+          github_uid: uid
+        )
+
+      assert {:ok, 0} = Rbac.SyncUsernames.propagate(user_id)
+
+      assert %Collaborator{github_username: "user-current"} =
+               Repo.get!(Collaborator, untouched.id)
+    end
+
+    test "does not touch collaborator rows that belong to a different uid" do
+      user_id = Ecto.UUID.generate()
+      uid = "184065"
+      other_uid = "999999"
+      project_id = Ecto.UUID.generate()
+
+      {:ok, _} = Support.Factories.FrontUser.insert(id: user_id, email: "user@example.com")
+      {:ok, _} = Support.Factories.RbacUser.insert(user_id, "User", "user@example.com")
+
+      {:ok, _} =
+        Support.Members.insert_repo_host_account(
+          login: "user-renamed",
+          name: "user-renamed",
+          github_uid: uid,
+          user_id: user_id,
+          repo_host: "github"
+        )
+
+      {:ok, other} =
+        Support.Collaborators.insert(
+          project_id: project_id,
+          github_username: "someone-else",
+          github_uid: other_uid
+        )
+
+      assert {:ok, 0} = Rbac.SyncUsernames.propagate(user_id)
+
+      assert %Collaborator{github_username: "someone-else"} = Repo.get!(Collaborator, other.id)
+    end
+
+    test "returns {:error, :user_not_found} when the user does not exist" do
+      assert {:error, :user_not_found} =
+               Rbac.SyncUsernames.propagate(Ecto.UUID.generate())
+    end
+  end
+end

--- a/ee/rbac/test/rbac/sync_usernames_test.exs
+++ b/ee/rbac/test/rbac/sync_usernames_test.exs
@@ -28,6 +28,8 @@ defmodule Rbac.SyncUsernamesTest do
           repo_host: "github"
         )
 
+      {:ok, _} = Support.Factories.Project.insert(id: project_id, provider: "github")
+
       {:ok, stale} =
         Support.Collaborators.insert(
           project_id: project_id,
@@ -56,6 +58,8 @@ defmodule Rbac.SyncUsernamesTest do
           user_id: user_id,
           repo_host: "github"
         )
+
+      {:ok, _} = Support.Factories.Project.insert(id: project_id, provider: "github")
 
       {:ok, untouched} =
         Support.Collaborators.insert(
@@ -87,6 +91,8 @@ defmodule Rbac.SyncUsernamesTest do
           user_id: user_id,
           repo_host: "github"
         )
+
+      {:ok, _} = Support.Factories.Project.insert(id: project_id, provider: "github")
 
       {:ok, other} =
         Support.Collaborators.insert(
@@ -122,6 +128,8 @@ defmodule Rbac.SyncUsernamesTest do
           repo_host: "bitbucket"
         )
 
+      {:ok, _} = Support.Factories.Project.insert(id: project_id, provider: "bitbucket")
+
       {:ok, collab} =
         Support.Collaborators.insert(
           project_id: project_id,
@@ -151,6 +159,8 @@ defmodule Rbac.SyncUsernamesTest do
           repo_host: "github"
         )
 
+      {:ok, _} = Support.Factories.Project.insert(id: project_id, provider: "github")
+
       {:ok, collab} =
         Support.Collaborators.insert(
           project_id: project_id,
@@ -161,6 +171,47 @@ defmodule Rbac.SyncUsernamesTest do
       assert {:ok, 0} = Rbac.SyncUsernames.propagate(user_id)
 
       assert %Collaborator{github_username: "user-old"} = Repo.get!(Collaborator, collab.id)
+    end
+
+    test "ignores rows whose project belongs to a different provider" do
+      user_id = Ecto.UUID.generate()
+      uid = "184065"
+      gh_project_id = Ecto.UUID.generate()
+      bb_project_id = Ecto.UUID.generate()
+
+      {:ok, _} = Support.Factories.FrontUser.insert(id: user_id, email: "user@example.com")
+      {:ok, _} = Support.Factories.RbacUser.insert(user_id, "User", "user@example.com")
+
+      {:ok, _} =
+        Support.Members.insert_repo_host_account(
+          login: "user-renamed",
+          name: "user-renamed",
+          github_uid: uid,
+          user_id: user_id,
+          repo_host: "github"
+        )
+
+      {:ok, _} = Support.Factories.Project.insert(id: gh_project_id, provider: "github")
+      {:ok, _} = Support.Factories.Project.insert(id: bb_project_id, provider: "bitbucket")
+
+      {:ok, gh_row} =
+        Support.Collaborators.insert(
+          project_id: gh_project_id,
+          github_username: "user-old",
+          github_uid: uid
+        )
+
+      {:ok, bb_row} =
+        Support.Collaborators.insert(
+          project_id: bb_project_id,
+          github_username: "user-old-bb",
+          github_uid: uid
+        )
+
+      assert {:ok, 1} = Rbac.SyncUsernames.propagate(user_id)
+
+      assert %Collaborator{github_username: "user-renamed"} = Repo.get!(Collaborator, gh_row.id)
+      assert %Collaborator{github_username: "user-old-bb"} = Repo.get!(Collaborator, bb_row.id)
     end
   end
 end

--- a/guard/.mix-audit.txt
+++ b/guard/.mix-audit.txt
@@ -18,3 +18,22 @@ GHSA-hv23-4qp7-8c8r
 
 # postgrex 0.20.0 — channel-name SQL injection in Notifications.listen/3 (not used by guard)
 GHSA-r73h-97w8-m54h
+
+# plug 1.16.1 — multipart header parsing DoS. Guard's only Plug.Parsers
+# config (lib/guard/id/api.ex) lists [:urlencoded, :json] — :multipart is
+# not registered. No Plug.Upload / read_part_headers calls anywhere in
+# guard/lib. Not exploitable. To be bumped to 1.16.3 in a follow-up PR.
+GHSA-468c-vq7p-gh64
+
+# cowboy 2.9.0 — multipart header parsing DoS. No guard handler calls
+# cowboy_req:read_part. HTTP listeners on 4003/4004 only parse
+# urlencoded/json; gRPC on 50051 uses length-prefixed protobuf over HTTP/2.
+# Not exploitable. To be bumped to 2.15.0 in a follow-up PR (needs grpc
+# 0.5.0-beta.1 compat check, override: true already in mix.exs).
+GHSA-jfc2-q6qh-g5x8
+
+# cowlib 2.11.0 — SPDY decompression bomb in cow_spdy:inflate/2. SPDY is
+# a dead protocol; cowboy 2.x speaks HTTP/1.1 + HTTP/2, never SPDY.
+# cow_spdy is unreachable from guard's request paths. Not exploitable.
+# To be bumped to 2.16.1 in a follow-up PR (within :gun's ~> 2.11 range).
+GHSA-84f2-rp86-235p

--- a/guard/lib/guard/api/github.ex
+++ b/guard/lib/guard/api/github.ex
@@ -11,12 +11,27 @@ defmodule Guard.Api.Github do
   plug(Tesla.Middleware.BaseUrl, "https://api.github.com")
   plug(Tesla.Middleware.JSON)
 
-  def user(id) do
-    case get("/user/" <> id) do
+  @doc """
+  Fetch a GitHub user by numeric UID.
+
+  When a non-nil/non-empty `token` is provided, the request is sent
+  authenticated (uses the per-user OAuth quota: 5000 req/hr). Otherwise the
+  unauthenticated client is used (60 req/hr per source IP).
+  """
+  def user(id, token \\ nil) do
+    opts =
+      if is_binary(token) and token != "", do: [headers: authorization_headers(token)], else: []
+
+    case get("/user/" <> id, opts) do
       {:ok, res} ->
         cond do
           res.status in 200..299 ->
-            {:ok, %{id: res.body["id"] |> Integer.to_string(), login: res.body["login"]}}
+            {:ok,
+             %{
+               id: res.body["id"] |> Integer.to_string(),
+               login: res.body["login"],
+               name: res.body["name"]
+             }}
 
           res.status == 404 ->
             Logger.debug("Error fetching user: #{inspect(res.body)}")
@@ -24,13 +39,13 @@ defmodule Guard.Api.Github do
             {:error, :not_found}
 
           true ->
-            Logger.debug("Error fetching user: #{inspect(res.body)}")
+            Logger.debug("Error fetching user (HTTP #{res.status}): #{inspect(res.body)}")
 
-            {:error, "#{res.body["message"]}. #{res.body["documentation_url"]}"}
+            {:error, {:http, res.status}}
         end
 
       {:error, error} ->
-        {:error, error}
+        {:error, {:transport, error}}
     end
   end
 
@@ -90,30 +105,36 @@ defmodule Guard.Api.Github do
     ])
   end
 
-  def validate_token(""), do: false
+  def validate_token(""), do: {:ok, false}
 
   def validate_token(token) do
     case get("", headers: authorization_headers(token)) do
-      {:ok, res} ->
-        is_valid = res.status in 200..299
+      {:ok, %{status: status}} when status in 200..299 ->
+        {:ok, true}
 
-        unless is_valid do
-          Logger.error(
-            "Token validation failed. status: #{res.status} body: #{inspect(res.body)}"
-          )
-        end
+      {:ok, %{status: status}} when status in [401, 403] ->
+        {:ok, false}
 
-        {:ok, is_valid}
+      {:ok, %{status: status}} when status == 429 or status in 500..599 ->
+        Logger.warning("Transient GitHub token validation failure (HTTP #{status})")
+        {:error, :transient}
+
+      {:ok, %{status: status, body: body}} ->
+        Logger.warning(
+          "Unexpected GitHub token validation response (HTTP #{status}): #{inspect(body)}"
+        )
+
+        {:error, :transient}
 
       {:error, error} ->
-        Logger.error("Error validating token: #{inspect(error)}")
-        {:error, :network_error}
+        Logger.error("Error validating GitHub token: #{inspect(error)}")
+        {:error, :transient}
     end
   end
 
   defp authorization_headers(token) do
     [
-      {"Authorization", "token #{token}"}
+      {"Authorization", "Bearer #{token}"}
     ]
   end
 end

--- a/guard/lib/guard/api/github.ex
+++ b/guard/lib/guard/api/github.ex
@@ -60,6 +60,7 @@ defmodule Guard.Api.Github do
   def user_token(repo_host_account) do
     case validate_token(repo_host_account.token) do
       {:ok, true} -> {:ok, {repo_host_account.token, nil}}
+      {:error, :transient} -> {:ok, {repo_host_account.token, nil}}
       _ -> handle_fetch_token(repo_host_account)
     end
   end
@@ -112,10 +113,10 @@ defmodule Guard.Api.Github do
       {:ok, %{status: status}} when status in 200..299 ->
         {:ok, true}
 
-      {:ok, %{status: status}} when status in [401, 403] ->
+      {:ok, %{status: 401}} ->
         {:ok, false}
 
-      {:ok, %{status: status}} when status == 429 or status in 500..599 ->
+      {:ok, %{status: status}} when status == 403 or status == 429 or status in 500..599 ->
         Logger.warning("Transient GitHub token validation failure (HTTP #{status})")
         {:error, :transient}
 

--- a/guard/lib/guard/front_repo/repo_host_account.ex
+++ b/guard/lib/guard/front_repo/repo_host_account.ex
@@ -361,7 +361,15 @@ defmodule Guard.FrontRepo.RepoHostAccount do
     {:ok, account}
   end
 
+  @required_on_write [:github_uid, :login, :name, :permission_scope]
+
   defp update_account(data, account) do
+    # Validate only the required-schema keys the caller is actually writing.
+    # The full @required_on_write list is checked at create/reset time; on a
+    # partial update (e.g., flipping :revoked) we must not refuse the write
+    # because an *untouched* legacy field happens to be nil.
+    required_now = Map.keys(data) |> Enum.filter(&(&1 in @required_on_write))
+
     result =
       account
       |> Ecto.Changeset.cast(
@@ -377,7 +385,7 @@ defmodule Guard.FrontRepo.RepoHostAccount do
           :permission_scope
         ]
       )
-      |> Ecto.Changeset.validate_required([:github_uid, :login, :name, :permission_scope])
+      |> Ecto.Changeset.validate_required(required_now)
       |> FrontRepo.update()
 
     case result do

--- a/guard/lib/guard/front_repo/repo_host_account.ex
+++ b/guard/lib/guard/front_repo/repo_host_account.ex
@@ -210,28 +210,20 @@ defmodule Guard.FrontRepo.RepoHostAccount do
   """
   @spec update_profile(t(), map()) :: {:ok, t()} | {:error, Ecto.Changeset.t() | :stale}
   def update_profile(%__MODULE__{} = rha, attrs) when is_map(attrs) do
-    changeset =
-      rha
-      |> Ecto.Changeset.cast(attrs, [:login, :name])
-      |> then(&Ecto.Changeset.validate_required(&1, Map.keys(&1.changes)))
-
-    cond do
-      not changeset.valid? ->
-        FrontRepo.update(changeset)
-
-      changeset.changes == %{} ->
-        {:ok, rha}
-
-      true ->
-        try do
-          changeset
-          |> Ecto.Changeset.optimistic_lock(:updated_at, &bump_updated_at/1)
-          |> FrontRepo.update()
-        rescue
-          Ecto.StaleEntryError -> {:error, :stale}
-        end
-    end
+    rha
+    |> Ecto.Changeset.cast(attrs, [:login, :name])
+    |> then(&Ecto.Changeset.validate_required(&1, Map.keys(&1.changes)))
+    |> maybe_lock_on_updated_at()
+    |> FrontRepo.update()
+  rescue
+    Ecto.StaleEntryError -> {:error, :stale}
   end
+
+  defp maybe_lock_on_updated_at(%Ecto.Changeset{changes: changes} = cs) when changes == %{},
+    do: cs
+
+  defp maybe_lock_on_updated_at(cs),
+    do: Ecto.Changeset.optimistic_lock(cs, :updated_at, &bump_updated_at/1)
 
   # Force monotonic increment so the optimistic lock works even when two
   # writes land in the same wall-clock second. The `:utc_datetime` schema

--- a/guard/lib/guard/front_repo/repo_host_account.ex
+++ b/guard/lib/guard/front_repo/repo_host_account.ex
@@ -203,13 +203,48 @@ defmodule Guard.FrontRepo.RepoHostAccount do
   any supplied key must carry a non-blank value or the changeset fails with
   a `:required` error. Callers that want "drop nil/blank as no-opinion"
   semantics must filter before calling.
+
+  Guards against concurrent writers via an optimistic lock on `:updated_at`.
+  When another writer commits between this caller's read and write, returns
+  `{:error, :stale}` instead of overwriting with the stale snapshot's view.
   """
-  @spec update_profile(t(), map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  @spec update_profile(t(), map()) :: {:ok, t()} | {:error, Ecto.Changeset.t() | :stale}
   def update_profile(%__MODULE__{} = rha, attrs) when is_map(attrs) do
-    rha
-    |> Ecto.Changeset.cast(attrs, [:login, :name])
-    |> then(&Ecto.Changeset.validate_required(&1, Map.keys(&1.changes)))
-    |> FrontRepo.update()
+    changeset =
+      rha
+      |> Ecto.Changeset.cast(attrs, [:login, :name])
+      |> then(&Ecto.Changeset.validate_required(&1, Map.keys(&1.changes)))
+
+    cond do
+      not changeset.valid? ->
+        FrontRepo.update(changeset)
+
+      changeset.changes == %{} ->
+        {:ok, rha}
+
+      true ->
+        try do
+          changeset
+          |> Ecto.Changeset.optimistic_lock(:updated_at, &bump_updated_at/1)
+          |> FrontRepo.update()
+        rescue
+          Ecto.StaleEntryError -> {:error, :stale}
+        end
+    end
+  end
+
+  # Force monotonic increment so the optimistic lock works even when two
+  # writes land in the same wall-clock second. The `:utc_datetime` schema
+  # type stores second precision, so plain `now()` can match the stale
+  # snapshot's `updated_at` and let a second writer through.
+  defp bump_updated_at(current) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    if DateTime.compare(now, current) == :gt do
+      now
+    else
+      DateTime.add(current, 1, :second)
+    end
   end
 
   @spec get_uid_by_login(String.t(), String.t()) :: {:ok, String.t()} | {:error, :not_found}

--- a/guard/lib/guard/front_repo/repo_host_account.ex
+++ b/guard/lib/guard/front_repo/repo_host_account.ex
@@ -37,6 +37,8 @@ defmodule Guard.FrontRepo.RepoHostAccount do
 
   @primary_key {:id, :binary_id, autogenerate: true}
 
+  @derive {Inspect, except: [:token, :refresh_token]}
+
   schema "repo_host_accounts" do
     field(:login, :string)
     field(:github_uid, :string)
@@ -194,6 +196,20 @@ defmodule Guard.FrontRepo.RepoHostAccount do
     }
 
     update_account(params, rha)
+  end
+
+  @doc """
+  Write `:login` and/or `:name` only; other keys dropped. Strict writer:
+  any supplied key must carry a non-blank value or the changeset fails with
+  a `:required` error. Callers that want "drop nil/blank as no-opinion"
+  semantics must filter before calling.
+  """
+  @spec update_profile(t(), map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def update_profile(%__MODULE__{} = rha, attrs) when is_map(attrs) do
+    rha
+    |> Ecto.Changeset.cast(attrs, [:login, :name])
+    |> then(&Ecto.Changeset.validate_required(&1, Map.keys(&1.changes)))
+    |> FrontRepo.update()
   end
 
   @spec get_uid_by_login(String.t(), String.t()) :: {:ok, String.t()} | {:error, :not_found}

--- a/guard/lib/guard/grpc_servers/user_server.ex
+++ b/guard/lib/guard/grpc_servers/user_server.ex
@@ -379,7 +379,10 @@ defmodule Guard.GrpcServers.UserServer do
   defp handle_update_repo_status(user, account) do
     {token, _expires_at} = get_token(account, user_id: user.id)
 
-    account_update_result = handle_validate_token(user, account, token)
+    account_update_result =
+      user
+      |> handle_validate_token(account, token)
+      |> Guard.User.GithubProfileSync.sync(user.id, token)
 
     repository_provider =
       case account_update_result do

--- a/guard/lib/guard/user/github_profile_sync.ex
+++ b/guard/lib/guard/user/github_profile_sync.ex
@@ -1,0 +1,101 @@
+defmodule Guard.User.GithubProfileSync do
+  @moduledoc """
+  Sync GitHub `:login` and `:name` onto a `RepoHostAccount` after token
+  validation. Best-effort: returns its input tuple unchanged on any
+  non-github, revoked, or fetch-failure path.
+  """
+
+  require Logger
+
+  alias Guard.FrontRepo
+
+  @profile_fields [:login, :name]
+  @user_exchange "user_exchange"
+  @updated_routing_key "updated"
+  @failure_metric "guard.github_profile_sync.failure"
+  @success_metric "guard.github_profile_sync.success"
+
+  @doc """
+  Sync the GitHub profile for the account contained in `result`.
+
+  `result` is the value produced by token validation:
+  `{:ok, %RepoHostAccount{}}`, `{:error, term()}`, or any other tuple.
+  Anything other than `{:ok, %{repo_host: "github", revoked: false}}` is
+  returned untouched.
+  """
+  @spec sync(any(), String.t(), String.t() | nil) :: any()
+  def sync({:ok, %{repo_host: "github", revoked: false} = account}, user_id, token) do
+    case Guard.Api.Github.user(account.github_uid, token) do
+      {:ok, profile} ->
+        apply_diff(account, profile, user_id)
+
+      {:error, reason} ->
+        log_fetch_failure(user_id, reason)
+        {:ok, account}
+    end
+  end
+
+  def sync(result, _user_id, _token), do: result
+
+  # 404 — GitHub account genuinely deleted upstream. Expected, no signal needed.
+  defp log_fetch_failure(_user_id, :not_found), do: :ok
+
+  # Auth / rate-limit failures are operationally distinct:
+  # 401 — token revoked between validate_token and user/{uid} fetch
+  # 403 — org-restricted token or secondary rate limit
+  # 429 — primary rate limit
+  # Tag each separately so alerts can route on the dimension.
+  defp log_fetch_failure(user_id, {:http, status} = reason) when status in [401, 403, 429] do
+    Logger.warning("GitHub profile sync auth/limit failure for #{user_id}: #{inspect(reason)}")
+
+    Watchman.increment({@failure_metric, ["http_#{status}"]})
+  end
+
+  defp log_fetch_failure(user_id, {:http, status} = reason) when status >= 500 do
+    Logger.warning(
+      "Skipping GitHub profile sync for #{user_id}: profile fetch failed (#{inspect(reason)})"
+    )
+
+    Watchman.increment({@failure_metric, ["http_5xx"]})
+  end
+
+  # Transport errors and any other unknown shape — silent by policy.
+  defp log_fetch_failure(_user_id, _reason), do: :ok
+
+  defp apply_diff(account, profile, user_id) do
+    # `update_profile` is a strict writer: nil/"" → `:required` error. GitHub
+    # may return `name: null` for users with no display name set; here we
+    # treat that as "no opinion" rather than "clear the field". Filter blanks
+    # at this boundary so the schema stays a strict writer.
+    attrs =
+      profile
+      |> Map.take(@profile_fields)
+      |> Map.reject(fn {_k, v} -> v in [nil, ""] end)
+
+    case FrontRepo.RepoHostAccount.update_profile(account, attrs) do
+      {:ok, ^account} ->
+        Watchman.increment({@success_metric, ["no_change"]})
+        {:ok, account}
+
+      {:ok, updated} ->
+        Guard.Events.UserUpdated.publish(user_id, @user_exchange, @updated_routing_key)
+        Watchman.increment({@success_metric, ["changed"]})
+        {:ok, updated}
+
+      {:error, error} ->
+        Logger.error(
+          "Failed to sync GitHub profile for #{user_id}: #{format_update_error(error)}"
+        )
+
+        Watchman.increment({@failure_metric, ["changeset"]})
+        {:ok, account}
+    end
+  end
+
+  # Logs only changeset errors (field + message), never the underlying
+  # `:data` struct — which carries the user's OAuth `:token` / `:refresh_token`.
+  defp format_update_error(%Ecto.Changeset{errors: errors}),
+    do: Enum.map_join(errors, ",", fn {field, {msg, _opts}} -> "#{field}:#{msg}" end)
+
+  defp format_update_error(other), do: inspect(other)
+end

--- a/guard/lib/guard/user/github_profile_sync.ex
+++ b/guard/lib/guard/user/github_profile_sync.ex
@@ -82,6 +82,14 @@ defmodule Guard.User.GithubProfileSync do
         Watchman.increment({@success_metric, ["changed"]})
         {:ok, updated}
 
+      {:error, :stale} ->
+        Logger.info(
+          "Skipping GitHub profile publish for #{user_id}: concurrent writer already updated the row"
+        )
+
+        Watchman.increment({@success_metric, ["concurrent_skip"]})
+        {:ok, account}
+
       {:error, error} ->
         Logger.error(
           "Failed to sync GitHub profile for #{user_id}: #{format_update_error(error)}"

--- a/guard/test/guard/api/github_test.exs
+++ b/guard/test/guard/api/github_test.exs
@@ -60,4 +60,154 @@ defmodule Guard.Api.GithubTest do
       assert updated_rha.token == "new_token"
     end
   end
+
+  describe "validate_token/1" do
+    test "2xx returns {:ok, true}" do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 200, body: %{}}}
+      end)
+
+      assert {:ok, true} = Github.validate_token("token")
+    end
+
+    for status <- [401, 403] do
+      test "#{status} returns {:ok, false}" do
+        status = unquote(status)
+
+        Tesla.Mock.mock_global(fn
+          %{method: :get, url: "https://api.github.com"} ->
+            {:ok, %Tesla.Env{status: status, body: %{"message" => "denied"}}}
+        end)
+
+        assert {:ok, false} = Github.validate_token("token")
+      end
+    end
+
+    for status <- [429, 500, 502, 503] do
+      test "#{status} returns {:error, :transient}" do
+        status = unquote(status)
+
+        Tesla.Mock.mock_global(fn
+          %{method: :get, url: "https://api.github.com"} ->
+            {:ok, %Tesla.Env{status: status, body: %{"message" => "boom"}}}
+        end)
+
+        assert {:error, :transient} = Github.validate_token("token")
+      end
+    end
+
+    test "unexpected 4xx returns {:error, :transient}" do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 418, body: %{}}}
+      end)
+
+      assert {:error, :transient} = Github.validate_token("token")
+    end
+
+    test "network error returns {:error, :transient}" do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:error, :timeout}
+      end)
+
+      assert {:error, :transient} = Github.validate_token("token")
+    end
+
+    test "empty token returns {:ok, false} without issuing HTTP request" do
+      Tesla.Mock.mock_global(fn _ ->
+        raise "unexpected HTTP call for validate_token(\"\")"
+      end)
+
+      assert {:ok, false} = Github.validate_token("")
+    end
+
+    test "sends Authorization: Bearer <token> header" do
+      Tesla.Mock.mock_global(fn %{method: :get, url: "https://api.github.com", headers: headers} ->
+        assert {"Authorization", "Bearer my-secret-token"} =
+                 List.keyfind(headers, "Authorization", 0)
+
+        {:ok, %Tesla.Env{status: 200, body: %{}}}
+      end)
+
+      assert {:ok, true} = Github.validate_token("my-secret-token")
+    end
+  end
+
+  describe "user/2" do
+    test "sends Authorization: Bearer <token> header when token is supplied" do
+      Tesla.Mock.mock_global(fn %{
+                                  method: :get,
+                                  url: "https://api.github.com/user/583231",
+                                  headers: headers
+                                } ->
+        assert {"Authorization", "Bearer my-secret-token"} =
+                 List.keyfind(headers, "Authorization", 0)
+
+        Tesla.Mock.json(%{"id" => 583_231, "login" => "octocat", "name" => "The Octocat"})
+      end)
+
+      assert {:ok, %{id: "583231", login: "octocat", name: "The Octocat"}} =
+               Github.user("583231", "my-secret-token")
+    end
+
+    test "sends NO Authorization header when token is nil" do
+      Tesla.Mock.mock_global(fn %{
+                                  method: :get,
+                                  url: "https://api.github.com/user/583231",
+                                  headers: headers
+                                } ->
+        refute List.keyfind(headers, "Authorization", 0)
+        Tesla.Mock.json(%{"id" => 583_231, "login" => "octocat", "name" => "The Octocat"})
+      end)
+
+      assert {:ok, _} = Github.user("583231", nil)
+    end
+
+    test "sends NO Authorization header when token is empty string" do
+      Tesla.Mock.mock_global(fn %{
+                                  method: :get,
+                                  url: "https://api.github.com/user/583231",
+                                  headers: headers
+                                } ->
+        refute List.keyfind(headers, "Authorization", 0)
+        Tesla.Mock.json(%{"id" => 583_231, "login" => "octocat", "name" => "The Octocat"})
+      end)
+
+      assert {:ok, _} = Github.user("583231", "")
+    end
+
+    test "returns :name from the response body" do
+      Tesla.Mock.mock_global(fn %{method: :get, url: "https://api.github.com/user/583231"} ->
+        Tesla.Mock.json(%{"id" => 583_231, "login" => "octocat", "name" => "The Octocat"})
+      end)
+
+      assert {:ok, %{name: "The Octocat"}} = Github.user("583231", "tok")
+    end
+
+    test "404 returns {:error, :not_found}" do
+      Tesla.Mock.mock_global(fn %{method: :get, url: "https://api.github.com/user/583231"} ->
+        {:ok, %Tesla.Env{status: 404, body: %{"message" => "Not Found"}}}
+      end)
+
+      assert {:error, :not_found} = Github.user("583231", "tok")
+    end
+
+    test "5xx returns {:error, {:http, status}}" do
+      Tesla.Mock.mock_global(fn %{method: :get, url: "https://api.github.com/user/583231"} ->
+        {:ok, %Tesla.Env{status: 500, body: %{"message" => "boom"}}}
+      end)
+
+      assert {:error, {:http, 500}} = Github.user("583231", "tok")
+    end
+
+    test "transport error returns {:error, {:transport, reason}}" do
+      Tesla.Mock.mock_global(fn %{method: :get, url: "https://api.github.com/user/583231"} ->
+        {:error, :timeout}
+      end)
+
+      assert {:error, {:transport, :timeout}} = Github.user("583231", "tok")
+    end
+  end
 end

--- a/guard/test/guard/api/github_test.exs
+++ b/guard/test/guard/api/github_test.exs
@@ -59,6 +59,49 @@ defmodule Guard.Api.GithubTest do
 
       assert updated_rha.token == "new_token"
     end
+
+    test "returns current token on transient validate failure without refresh attempt",
+         %{repo_host_account: rha} do
+      rha = %{rha | refresh_token: nil}
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 500, body: %{"message" => "boom"}}}
+
+        %{method: :post, url: "https://github.com/login/oauth/access_token"} ->
+          raise "must not attempt refresh on transient validate failure"
+      end)
+
+      assert {:ok, {"token", nil}} = Github.user_token(rha)
+    end
+
+    test "returns current token on transient validate failure even with refresh_token",
+         %{repo_host_account: rha} do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 503, body: %{}}}
+
+        %{method: :post, url: "https://github.com/login/oauth/access_token"} ->
+          raise "must not attempt refresh on transient validate failure"
+      end)
+
+      assert {:ok, {"token", nil}} = Github.user_token(rha)
+    end
+
+    test "returns :revoked when token is rejected and refresh_token is missing",
+         %{repo_host_account: rha} do
+      rha = %{rha | refresh_token: nil}
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 401, body: %{}}}
+
+        %{method: :post, url: "https://github.com/login/oauth/access_token"} ->
+          raise "must not attempt refresh without refresh_token"
+      end)
+
+      assert {:error, :revoked} = Github.user_token(rha)
+    end
   end
 
   describe "validate_token/1" do
@@ -71,20 +114,16 @@ defmodule Guard.Api.GithubTest do
       assert {:ok, true} = Github.validate_token("token")
     end
 
-    for status <- [401, 403] do
-      test "#{status} returns {:ok, false}" do
-        status = unquote(status)
+    test "401 returns {:ok, false}" do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 401, body: %{"message" => "denied"}}}
+      end)
 
-        Tesla.Mock.mock_global(fn
-          %{method: :get, url: "https://api.github.com"} ->
-            {:ok, %Tesla.Env{status: status, body: %{"message" => "denied"}}}
-        end)
-
-        assert {:ok, false} = Github.validate_token("token")
-      end
+      assert {:ok, false} = Github.validate_token("token")
     end
 
-    for status <- [429, 500, 502, 503] do
+    for status <- [403, 429, 500, 502, 503] do
       test "#{status} returns {:error, :transient}" do
         status = unquote(status)
 

--- a/guard/test/guard/front_repo/repo_host_account_test.exs
+++ b/guard/test/guard/front_repo/repo_host_account_test.exs
@@ -86,6 +86,31 @@ defmodule Guard.FrontRepo.RepoHostAccountTest do
     end
   end
 
+  describe "update_revoke_status/2" do
+    setup do
+      {user, rha} = Support.Members.insert_user_with_github_account()
+      {:ok, user: user, rha: rha}
+    end
+
+    test "succeeds on a legacy row where :name is nil (only writes :revoked)", %{rha: rha} do
+      {:ok, legacy_rha} =
+        rha
+        |> Ecto.Changeset.change(%{name: nil})
+        |> FrontRepo.update(force: true)
+
+      assert legacy_rha.name == nil
+      assert legacy_rha.revoked == false
+
+      assert {:ok, updated} = RepoHostAccount.update_revoke_status(legacy_rha, true)
+      assert updated.revoked == true
+      assert updated.name == nil
+
+      {:ok, reloaded} = RepoHostAccount.get_for_github_user(rha.user_id)
+      assert reloaded.revoked == true
+      assert reloaded.name == nil
+    end
+  end
+
   describe "Inspect implementation" do
     test "redacts :token and :refresh_token from inspect output" do
       rha = %RepoHostAccount{

--- a/guard/test/guard/front_repo/repo_host_account_test.exs
+++ b/guard/test/guard/front_repo/repo_host_account_test.exs
@@ -68,6 +68,22 @@ defmodule Guard.FrontRepo.RepoHostAccountTest do
 
       assert {"can't be blank", _} = errors[:name]
     end
+
+    test "returns {:error, :stale} when another writer updated the row first", %{rha: rha} do
+      # Simulate concurrent writer T1 via the same locked writer so the
+      # optimistic-lock bump fires (avoid Repo autogen-on-same-second pitfall).
+      {:ok, winner} = RepoHostAccount.update_profile(rha, %{login: "concurrent-winner"})
+
+      assert winner.updated_at != rha.updated_at
+
+      # T2 attempts a write with its stale snapshot — optimistic lock on
+      # :updated_at must reject and leave the persisted row untouched.
+      assert {:error, :stale} = RepoHostAccount.update_profile(rha, %{login: "stale-loser"})
+
+      {:ok, reloaded} = RepoHostAccount.get_for_github_user(rha.user_id)
+      assert reloaded.login == "concurrent-winner"
+      assert reloaded.updated_at == winner.updated_at
+    end
   end
 
   describe "Inspect implementation" do

--- a/guard/test/guard/front_repo/repo_host_account_test.exs
+++ b/guard/test/guard/front_repo/repo_host_account_test.exs
@@ -1,0 +1,88 @@
+defmodule Guard.FrontRepo.RepoHostAccountTest do
+  use Guard.RepoCase, async: false
+
+  alias Guard.FrontRepo
+  alias Guard.FrontRepo.RepoHostAccount
+
+  describe "update_profile/2" do
+    setup do
+      {user, rha} = Support.Members.insert_user_with_github_account()
+      {:ok, user: user, rha: rha}
+    end
+
+    test "no-op on empty diff", %{rha: rha} do
+      assert {:ok, ^rha} = RepoHostAccount.update_profile(rha, %{})
+    end
+
+    test "ignores keys outside [:login, :name]", %{rha: rha} do
+      {:ok, updated} =
+        RepoHostAccount.update_profile(rha, %{
+          token: "leaked",
+          permission_scope: "admin",
+          revoked: true
+        })
+
+      assert updated.token == "token"
+      assert updated.permission_scope == "repo"
+      assert updated.revoked == false
+    end
+
+    test "persists login change", %{rha: rha} do
+      {:ok, updated} = RepoHostAccount.update_profile(rha, %{login: "new-login"})
+      assert updated.login == "new-login"
+      assert updated.name == "The Octocat"
+    end
+
+    test "persists name change", %{rha: rha} do
+      {:ok, updated} = RepoHostAccount.update_profile(rha, %{name: "Octo Cat"})
+      assert updated.login == "octocat"
+      assert updated.name == "Octo Cat"
+    end
+
+    test "persists login change when stored name is nil (legacy row)", %{rha: rha} do
+      {:ok, legacy_rha} =
+        rha
+        |> Ecto.Changeset.change(%{name: nil})
+        |> FrontRepo.update(force: true)
+
+      assert legacy_rha.name == nil
+
+      {:ok, updated} = RepoHostAccount.update_profile(legacy_rha, %{login: "new-login"})
+
+      assert updated.login == "new-login"
+      assert updated.name == nil
+
+      {:ok, reloaded} = RepoHostAccount.get_for_github_user(rha.user_id)
+      assert reloaded.login == "new-login"
+      assert reloaded.name == nil
+    end
+
+    test "rejects blank values with a :required changeset error (strict writer)", %{rha: rha} do
+      assert {:error, %Ecto.Changeset{valid?: false, errors: errors}} =
+               RepoHostAccount.update_profile(rha, %{login: ""})
+
+      assert {"can't be blank", _} = errors[:login]
+
+      assert {:error, %Ecto.Changeset{valid?: false, errors: errors}} =
+               RepoHostAccount.update_profile(rha, %{name: nil})
+
+      assert {"can't be blank", _} = errors[:name]
+    end
+  end
+
+  describe "Inspect implementation" do
+    test "redacts :token and :refresh_token from inspect output" do
+      rha = %RepoHostAccount{
+        login: "octocat",
+        token: "ghp_super_secret_oauth_token",
+        refresh_token: "ghr_super_secret_refresh_token"
+      }
+
+      rendered = inspect(rha)
+
+      refute rendered =~ "ghp_super_secret_oauth_token"
+      refute rendered =~ "ghr_super_secret_refresh_token"
+      assert rendered =~ "octocat"
+    end
+  end
+end

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -1567,6 +1567,43 @@ defmodule Guard.GrpcServers.UserServerTest do
       assert reloaded.updated_at == original_updated_at
     end
 
+    test "refresh_repository_provider succeeds on a legacy github account with name == nil",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      # Before narrowing update_account's validate_required, a row with
+      # name == nil would error out in update_revoke_status with a
+      # :required changeset error → grpc_error!(:internal). The new sync
+      # could backfill name, but never got the chance because the revoke
+      # write failed first.
+      {:ok, legacy_rha} =
+        rha
+        |> Ecto.Changeset.change(%{name: nil})
+        |> Guard.FrontRepo.update(force: true)
+
+      assert legacy_rha.name == nil
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          json(%{"login" => rha.login})
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => rha.login, "name" => "Backfilled Name"})
+      end)
+
+      request =
+        User.RefreshRepositoryProviderRequest.new(
+          user_id: user.id,
+          type: User.RepositoryProvider.Type.value(:GITHUB)
+        )
+
+      {:ok, _response} = channel |> Stub.refresh_repository_provider(request)
+
+      {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+      assert reloaded.revoked == false
+      # GithubProfileSync should have backfilled the name now that the
+      # revoke write no longer blocks the flow on a nil legacy field.
+      assert reloaded.name == "Backfilled Name"
+    end
+
     test "refresh_repository_provider should refresh repository provider details for a valid user with bitbucket",
          %{
            grpc_channel: channel

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -1503,6 +1503,70 @@ defmodule Guard.GrpcServers.UserServerTest do
       assert reloaded.updated_at == original_updated_at
     end
 
+    test "refresh_repository_provider preserves revoke status when first validate_token returns 5xx and no refresh_token",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      # Guards against revoking a healthy account when the FIRST validate_token
+      # call (inside user_token/1) hits a transient failure. Fixture rha has no
+      # refresh_token; without the :transient short-circuit, user_token would
+      # fall through to handle_fetch_token → {:error, :revoked} → account
+      # revoked.
+      original_updated_at = rha.updated_at
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 500, body: %{"message" => "boom"}}}
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => rha.login, "name" => rha.name})
+
+        %{method: :post, url: "https://github.com/login/oauth/access_token"} ->
+          raise "must not attempt refresh when validate is transient"
+      end)
+
+      request =
+        User.RefreshRepositoryProviderRequest.new(
+          user_id: user.id,
+          type: User.RepositoryProvider.Type.value(:GITHUB)
+        )
+
+      {:ok, _response} = channel |> Stub.refresh_repository_provider(request)
+
+      {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+      assert reloaded.revoked == false
+      assert reloaded.updated_at == original_updated_at
+    end
+
+    test "refresh_repository_provider preserves revoke status when first validate_token returns 403 and no refresh_token",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      # 403 from GET https://api.github.com/ is overwhelmingly secondary
+      # rate-limit, not "token revoked". It must be treated as transient and
+      # leave the account untouched.
+      original_updated_at = rha.updated_at
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 403, body: %{"message" => "rate limited"}}}
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => rha.login, "name" => rha.name})
+
+        %{method: :post, url: "https://github.com/login/oauth/access_token"} ->
+          raise "must not attempt refresh on 403"
+      end)
+
+      request =
+        User.RefreshRepositoryProviderRequest.new(
+          user_id: user.id,
+          type: User.RepositoryProvider.Type.value(:GITHUB)
+        )
+
+      {:ok, _response} = channel |> Stub.refresh_repository_provider(request)
+
+      {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+      assert reloaded.revoked == false
+      assert reloaded.updated_at == original_updated_at
+    end
+
     test "refresh_repository_provider should refresh repository provider details for a valid user with bitbucket",
          %{
            grpc_channel: channel

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -1132,11 +1132,11 @@ defmodule Guard.GrpcServers.UserServerTest do
            user: user
          } do
       Tesla.Mock.mock_global(fn
-        %{
-          method: :get,
-          url: "https://api.github.com"
-        } ->
+        %{method: :get, url: "https://api.github.com"} ->
           json(%{"valid" => "valid"})
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => "radwo", "name" => "radwo"})
       end)
 
       request =
@@ -1158,6 +1158,349 @@ defmodule Guard.GrpcServers.UserServerTest do
                  uid: "184065"
                }
              } == response
+    end
+
+    test "refresh_repository_provider syncs the github login when it changed upstream",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      new_login = "#{rha.login}-renamed"
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          json(%{"valid" => "valid"})
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => new_login, "name" => rha.name})
+      end)
+
+      with_mock Guard.Events.UserUpdated, publish: fn _u, _e, _r -> :ok end do
+        request =
+          User.RefreshRepositoryProviderRequest.new(
+            user_id: user.id,
+            type: User.RepositoryProvider.Type.value(:GITHUB)
+          )
+
+        {:ok, response} = channel |> Stub.refresh_repository_provider(request)
+
+        assert response.repository_provider.login == new_login
+
+        {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+        assert reloaded.login == new_login
+        assert reloaded.name == rha.name
+        assert reloaded.revoked == false
+
+        assert called(Guard.Events.UserUpdated.publish(user.id, "user_exchange", "updated"))
+      end
+    end
+
+    test "refresh_repository_provider syncs the github display name when it changed upstream",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      new_name = "#{rha.name} (renamed)"
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          json(%{"valid" => "valid"})
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => rha.login, "name" => new_name})
+      end)
+
+      with_mock Guard.Events.UserUpdated, publish: fn _u, _e, _r -> :ok end do
+        request =
+          User.RefreshRepositoryProviderRequest.new(
+            user_id: user.id,
+            type: User.RepositoryProvider.Type.value(:GITHUB)
+          )
+
+        {:ok, _response} = channel |> Stub.refresh_repository_provider(request)
+
+        {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+        assert reloaded.login == rha.login
+        assert reloaded.name == new_name
+
+        assert called(Guard.Events.UserUpdated.publish(user.id, "user_exchange", "updated"))
+      end
+    end
+
+    test "refresh_repository_provider syncs login and name together when both changed",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      new_login = "#{rha.login}-v2"
+      new_name = "#{rha.name} v2"
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          json(%{"valid" => "valid"})
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => new_login, "name" => new_name})
+      end)
+
+      with_mock Guard.Events.UserUpdated, publish: fn _u, _e, _r -> :ok end do
+        request =
+          User.RefreshRepositoryProviderRequest.new(
+            user_id: user.id,
+            type: User.RepositoryProvider.Type.value(:GITHUB)
+          )
+
+        {:ok, _response} = channel |> Stub.refresh_repository_provider(request)
+
+        {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+        assert reloaded.login == new_login
+        assert reloaded.name == new_name
+
+        assert called(Guard.Events.UserUpdated.publish(user.id, "user_exchange", "updated"))
+      end
+    end
+
+    test "refresh_repository_provider is a no-op when github reports the same profile",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          json(%{"valid" => "valid"})
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => rha.login, "name" => rha.name})
+      end)
+
+      with_mock Guard.Events.UserUpdated, publish: fn _u, _e, _r -> :ok end do
+        original_updated_at = rha.updated_at
+
+        request =
+          User.RefreshRepositoryProviderRequest.new(
+            user_id: user.id,
+            type: User.RepositoryProvider.Type.value(:GITHUB)
+          )
+
+        {:ok, response} = channel |> Stub.refresh_repository_provider(request)
+
+        assert response.repository_provider.login == rha.login
+
+        {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+        assert reloaded.login == rha.login
+        assert reloaded.name == rha.name
+        # update_revoke_status was a no-op (status unchanged) so updated_at stays put.
+        assert reloaded.updated_at == original_updated_at
+
+        refute called(Guard.Events.UserUpdated.publish(:_, :_, :_))
+      end
+    end
+
+    test "refresh_repository_provider is a no-op when github user fetch returns 500",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          json(%{"valid" => "valid"})
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          {:ok, %Tesla.Env{status: 500, body: %{"message" => "boom"}}}
+      end)
+
+      with_mock Guard.Events.UserUpdated, publish: fn _u, _e, _r -> :ok end do
+        request =
+          User.RefreshRepositoryProviderRequest.new(
+            user_id: user.id,
+            type: User.RepositoryProvider.Type.value(:GITHUB)
+          )
+
+        {:ok, response} = channel |> Stub.refresh_repository_provider(request)
+
+        assert response.repository_provider.login == rha.login
+
+        {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+        assert reloaded.login == rha.login
+        assert reloaded.name == rha.name
+        assert reloaded.revoked == false
+
+        refute called(Guard.Events.UserUpdated.publish(:_, :_, :_))
+      end
+    end
+
+    test "refresh_repository_provider does not clobber stored name when github returns null name",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      new_login = "#{rha.login}-renamed"
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          json(%{"valid" => "valid"})
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => new_login, "name" => nil})
+      end)
+
+      with_mock Guard.Events.UserUpdated, publish: fn _u, _e, _r -> :ok end do
+        request =
+          User.RefreshRepositoryProviderRequest.new(
+            user_id: user.id,
+            type: User.RepositoryProvider.Type.value(:GITHUB)
+          )
+
+        {:ok, response} = channel |> Stub.refresh_repository_provider(request)
+
+        assert response.repository_provider.login == new_login
+
+        {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+        assert reloaded.login == new_login
+        assert reloaded.name == rha.name
+
+        assert called(Guard.Events.UserUpdated.publish(user.id, "user_exchange", "updated"))
+      end
+    end
+
+    test "refresh_repository_provider does not crash and skips event when update_profile fails",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      new_login = "#{rha.login}-renamed"
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          json(%{"valid" => "valid"})
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => new_login, "name" => rha.name})
+      end)
+
+      forced_error = {:error, %Ecto.Changeset{errors: [login: {"is invalid", []}], valid?: false}}
+
+      with_mocks([
+        {Guard.FrontRepo.RepoHostAccount, [:passthrough],
+         update_profile: fn _, _ -> forced_error end},
+        {Guard.Events.UserUpdated, [], publish: fn _u, _e, _r -> :ok end}
+      ]) do
+        request =
+          User.RefreshRepositoryProviderRequest.new(
+            user_id: user.id,
+            type: User.RepositoryProvider.Type.value(:GITHUB)
+          )
+
+        {:ok, response} = channel |> Stub.refresh_repository_provider(request)
+
+        assert response.repository_provider.login == rha.login
+
+        {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+        assert reloaded.login == rha.login
+        assert reloaded.name == rha.name
+
+        refute called(Guard.Events.UserUpdated.publish(:_, :_, :_))
+      end
+    end
+
+    test "refresh_repository_provider revokes account when refresh_token is missing and token is invalid",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      # Fixture rha has no refresh_token. Flow proven by this test:
+      #   get_token → user_token → validate_token → 401
+      #   → handle_fetch_token (refresh_token in [nil, ""]) → {:error, :revoked}
+      #   → get_token raises grpc_error!(:not_found, ...)
+      # handle_validate_token and GithubProfileSync.sync never run.
+      # No mock for /user/<uid> — if sync mistakenly tried to fetch, Tesla.Mock
+      # would raise and fail the test.
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 401, body: %{}}}
+      end)
+
+      request =
+        User.RefreshRepositoryProviderRequest.new(
+          user_id: user.id,
+          type: User.RepositoryProvider.Type.value(:GITHUB)
+        )
+
+      {:error, _} = channel |> Stub.refresh_repository_provider(request)
+
+      updated_account = Guard.FrontRepo.get!(Guard.FrontRepo.RepoHostAccount, rha.id)
+      assert updated_account.revoked == true
+      assert updated_account.login == rha.login
+    end
+
+    test "refresh_repository_provider revokes account and skips profile fetch when refreshed token is rejected by validate",
+         %{grpc_channel: channel} do
+      # Distinct from the test above: here user_token's *refresh* path succeeds
+      # (refresh_token is present, /login/oauth/access_token returns 200 with a
+      # new token). Then handle_validate_token validates the NEW token,
+      # api.github.com still returns 401 → {:ok, false} → update_revoke_status
+      # writes revoked: true. GithubProfileSync.sync sees revoked: true and
+      # passes through — /user/<uid> must NEVER be called (no mock).
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      {:ok, _rha} =
+        Support.Members.insert_repo_host_account(
+          login: "radwo",
+          name: "radwo",
+          github_uid: "184065",
+          repo_host: "github",
+          refresh_token: "old_refresh",
+          user_id: user.id,
+          token: "old_token",
+          revoked: false,
+          permission_scope: "repo"
+        )
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 401, body: %{}}}
+
+        %{method: :post, url: "https://github.com/login/oauth/access_token"} ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: %{"access_token" => "new_token", "expires_in" => 3600}
+           }}
+      end)
+
+      request =
+        User.RefreshRepositoryProviderRequest.new(
+          user_id: user.id,
+          type: User.RepositoryProvider.Type.value(:GITHUB)
+        )
+
+      {:ok, _response} = channel |> Stub.refresh_repository_provider(request)
+
+      {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+      # Proves user_token's refresh path was actually exercised (the new token
+      # is persisted from /login/oauth/access_token's response).
+      assert reloaded.token == "new_token"
+      # Proves handle_validate_token saw {:ok, false} on the new token and
+      # called update_revoke_status(_, true).
+      assert reloaded.revoked == true
+    end
+
+    test "refresh_repository_provider preserves revoke status on transient github validate_token 5xx",
+         %{grpc_channel: channel, user: user, repo_host_account: rha} do
+      # Two calls to validate_token happen per refresh:
+      #   1) inside user_token (must succeed to yield a token)
+      #   2) inside handle_validate_token (we force 500 here)
+      # Use a per-test counter to differentiate.
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          n = Agent.get_and_update(counter, &{&1 + 1, &1 + 1})
+
+          if n == 1 do
+            json(%{"valid" => "valid"})
+          else
+            {:ok, %Tesla.Env{status: 500, body: %{"message" => "boom"}}}
+          end
+
+        %{method: :get, url: "https://api.github.com/user/184065"} ->
+          json(%{"id" => 184_065, "login" => rha.login, "name" => rha.name})
+      end)
+
+      original_updated_at = rha.updated_at
+
+      request =
+        User.RefreshRepositoryProviderRequest.new(
+          user_id: user.id,
+          type: User.RepositoryProvider.Type.value(:GITHUB)
+        )
+
+      {:ok, _response} = channel |> Stub.refresh_repository_provider(request)
+
+      {:ok, reloaded} = Guard.FrontRepo.RepoHostAccount.get_for_github_user(user.id)
+      # Transient validate failure must NOT flip revoke status.
+      assert reloaded.revoked == false
+      # update_revoke_status was not invoked, so updated_at stays put.
+      assert reloaded.updated_at == original_updated_at
     end
 
     test "refresh_repository_provider should refresh repository provider details for a valid user with bitbucket",

--- a/guard/test/guard/user/github_profile_sync_test.exs
+++ b/guard/test/guard/user/github_profile_sync_test.exs
@@ -207,6 +207,40 @@ defmodule Guard.User.GithubProfileSyncTest do
       end
     end
 
+    test "skips publish and bumps concurrent_skip metric when another writer updated the row first",
+         %{user: user, rha: rha} do
+      # Simulate the concurrent writer (T1) committing before this sync runs
+      # via the same locked writer (so the optimistic-lock bump fires and
+      # leaves the persisted updated_at strictly after the stale snapshot's).
+      # T2 still holds the pre-rename `rha` in memory, so its optimistic lock
+      # on :updated_at must reject the write.
+      {:ok, _winner} = RepoHostAccount.update_profile(rha, %{login: "concurrent-winner"})
+
+      mock_global(fn
+        %{method: :get, url: "https://api.github.com/user/583231"} ->
+          json(%{"id" => 583_231, "login" => "stale-loser", "name" => rha.name})
+      end)
+
+      with_mocks([
+        {Guard.Events.UserUpdated, [], publish: fn _u, _e, _r -> :ok end},
+        {Watchman, [], increment: fn _ -> :ok end}
+      ]) do
+        assert {:ok, returned} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+        assert returned.id == rha.id
+
+        assert called(
+                 Watchman.increment({"guard.github_profile_sync.success", ["concurrent_skip"]})
+               )
+
+        refute called(Guard.Events.UserUpdated.publish(:_, :_, :_))
+      end
+
+      # DB still reflects the concurrent winner — the stale writer did not
+      # clobber it.
+      {:ok, reloaded} = RepoHostAccount.get_for_github_user(rha.user_id)
+      assert reloaded.login == "concurrent-winner"
+    end
+
     test "bumps tagged success counter on no-change write", %{user: user, rha: rha} do
       mock_global(fn
         %{method: :get, url: "https://api.github.com/user/583231"} ->

--- a/guard/test/guard/user/github_profile_sync_test.exs
+++ b/guard/test/guard/user/github_profile_sync_test.exs
@@ -1,0 +1,267 @@
+defmodule Guard.User.GithubProfileSyncTest do
+  use Guard.RepoCase, async: false
+
+  import ExUnit.CaptureLog
+  import Mock
+  import Tesla.Mock
+
+  alias Guard.FrontRepo.RepoHostAccount
+  alias Guard.User.GithubProfileSync
+
+  setup do
+    {user, rha} = Support.Members.insert_user_with_github_account()
+    {:ok, user: user, rha: rha}
+  end
+
+  describe "sync/3 — passthrough cases" do
+    test "returns input untouched for non-github account", %{user: user} do
+      account = %RepoHostAccount{repo_host: "bitbucket", revoked: false}
+      assert {:ok, ^account} = GithubProfileSync.sync({:ok, account}, user.id, "token")
+    end
+
+    test "returns input untouched for revoked github account", %{user: user} do
+      account = %RepoHostAccount{repo_host: "github", revoked: true}
+      assert {:ok, ^account} = GithubProfileSync.sync({:ok, account}, user.id, "token")
+    end
+
+    test "returns input untouched for non-:ok tuple", %{user: user} do
+      assert {:error, :boom} = GithubProfileSync.sync({:error, :boom}, user.id, "token")
+    end
+  end
+
+  describe "sync/3 — github profile fetch" do
+    test "persists login change", %{user: user, rha: rha} do
+      mock_global(fn
+        %{method: :get, url: "https://api.github.com/user/583231"} ->
+          json(%{"id" => 583_231, "login" => "octocat-renamed", "name" => "The Octocat"})
+      end)
+
+      with_mock Guard.Events.UserUpdated, publish: fn _u, _e, _r -> :ok end do
+        assert {:ok, updated} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+        assert updated.login == "octocat-renamed"
+
+        assert called(Guard.Events.UserUpdated.publish(user.id, "user_exchange", "updated"))
+      end
+    end
+
+    test "persists name change", %{user: user, rha: rha} do
+      mock_global(fn
+        %{method: :get, url: "https://api.github.com/user/583231"} ->
+          json(%{"id" => 583_231, "login" => "octocat", "name" => "Mona Lisa"})
+      end)
+
+      with_mock Guard.Events.UserUpdated, publish: fn _u, _e, _r -> :ok end do
+        assert {:ok, updated} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+        assert updated.name == "Mona Lisa"
+
+        assert called(Guard.Events.UserUpdated.publish(user.id, "user_exchange", "updated"))
+      end
+    end
+
+    test "no-op when github reports the same profile", %{user: user, rha: rha} do
+      mock_global(fn
+        %{method: :get, url: "https://api.github.com/user/583231"} ->
+          json(%{"id" => 583_231, "login" => rha.login, "name" => rha.name})
+      end)
+
+      with_mock Guard.Events.UserUpdated, publish: fn _u, _e, _r -> :ok end do
+        assert {:ok, returned} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+        assert returned.id == rha.id
+        refute called(Guard.Events.UserUpdated.publish(:_, :_, :_))
+      end
+    end
+
+    test "does not clobber stored name when github returns null", %{user: user, rha: rha} do
+      mock_global(fn
+        %{method: :get, url: "https://api.github.com/user/583231"} ->
+          json(%{"id" => 583_231, "login" => "octocat-renamed", "name" => nil})
+      end)
+
+      with_mock Guard.Events.UserUpdated, publish: fn _u, _e, _r -> :ok end do
+        assert {:ok, updated} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+        assert updated.login == "octocat-renamed"
+        assert updated.name == rha.name
+      end
+    end
+
+    test "warns and bumps tagged failure metric when github fetch returns 5xx",
+         %{user: user, rha: rha} do
+      mock_global(fn
+        %{method: :get, url: "https://api.github.com/user/583231"} ->
+          {:ok, %Tesla.Env{status: 500, body: %{"message" => "boom"}}}
+      end)
+
+      with_mocks([
+        {Guard.Events.UserUpdated, [], publish: fn _u, _e, _r -> :ok end},
+        {Watchman, [], increment: fn _ -> :ok end}
+      ]) do
+        log =
+          capture_log([level: :warning], fn ->
+            assert {:ok, returned} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+            assert returned.id == rha.id
+          end)
+
+        assert log =~ "[warning]"
+        assert log =~ "Skipping GitHub profile sync for #{user.id}"
+        assert log =~ ":http"
+        assert called(Watchman.increment({"guard.github_profile_sync.failure", ["http_5xx"]}))
+        refute called(Guard.Events.UserUpdated.publish(:_, :_, :_))
+      end
+    end
+
+    for status <- [401, 403, 429] do
+      test "warns and bumps tagged failure metric when github fetch returns #{status}",
+           %{user: user, rha: rha} do
+        status = unquote(status)
+
+        mock_global(fn
+          %{method: :get, url: "https://api.github.com/user/583231"} ->
+            {:ok, %Tesla.Env{status: status, body: %{"message" => "denied"}}}
+        end)
+
+        with_mocks([
+          {Guard.Events.UserUpdated, [], publish: fn _u, _e, _r -> :ok end},
+          {Watchman, [], increment: fn _ -> :ok end}
+        ]) do
+          log =
+            capture_log([level: :warning], fn ->
+              assert {:ok, _} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+            end)
+
+          assert log =~ "GitHub profile sync auth/limit failure for #{user.id}"
+          assert log =~ ":http"
+
+          assert called(
+                   Watchman.increment({"guard.github_profile_sync.failure", ["http_#{status}"]})
+                 )
+
+          refute called(Guard.Events.UserUpdated.publish(:_, :_, :_))
+        end
+      end
+    end
+
+    silent_cases = [
+      {"404", {:ok, %Tesla.Env{status: 404, body: %{"message" => "Not Found"}}}},
+      {"network/transport error", {:error, :timeout}}
+    ]
+
+    for {desc, mock_response} <- silent_cases do
+      test "skips silently on #{desc} without warning or metric",
+           %{user: user, rha: rha} do
+        mock_response = unquote(Macro.escape(mock_response))
+
+        mock_global(fn
+          %{method: :get, url: "https://api.github.com/user/583231"} ->
+            mock_response
+        end)
+
+        with_mocks([
+          {Guard.Events.UserUpdated, [], publish: fn _u, _e, _r -> :ok end},
+          {Watchman, [], increment: fn _ -> :ok end}
+        ]) do
+          warning_log =
+            capture_log([level: :warning], fn ->
+              assert {:ok, _} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+            end)
+
+          refute warning_log =~ "Skipping GitHub profile sync"
+          refute called(Watchman.increment(:_))
+          refute called(Guard.Events.UserUpdated.publish(:_, :_, :_))
+        end
+      end
+    end
+
+    test "bumps tagged changeset failure metric and returns {:ok, account} when update_profile fails",
+         %{user: user, rha: rha} do
+      mock_global(fn
+        %{method: :get, url: "https://api.github.com/user/583231"} ->
+          json(%{"id" => 583_231, "login" => "octocat-renamed", "name" => rha.name})
+      end)
+
+      forced_error = {:error, %Ecto.Changeset{errors: [login: {"is invalid", []}], valid?: false}}
+
+      with_mocks([
+        {RepoHostAccount, [:passthrough], update_profile: fn _, _ -> forced_error end},
+        {Guard.Events.UserUpdated, [], publish: fn _u, _e, _r -> :ok end},
+        {Watchman, [], increment: fn _ -> :ok end}
+      ]) do
+        assert {:ok, returned} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+        assert returned.id == rha.id
+        assert called(Watchman.increment({"guard.github_profile_sync.failure", ["changeset"]}))
+        refute called(Guard.Events.UserUpdated.publish(:_, :_, :_))
+      end
+    end
+
+    test "bumps tagged success counter on changed write", %{user: user, rha: rha} do
+      mock_global(fn
+        %{method: :get, url: "https://api.github.com/user/583231"} ->
+          json(%{"id" => 583_231, "login" => "octocat-renamed", "name" => rha.name})
+      end)
+
+      with_mocks([
+        {Guard.Events.UserUpdated, [], publish: fn _u, _e, _r -> :ok end},
+        {Watchman, [], increment: fn _ -> :ok end}
+      ]) do
+        assert {:ok, _} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+        assert called(Watchman.increment({"guard.github_profile_sync.success", ["changed"]}))
+      end
+    end
+
+    test "bumps tagged success counter on no-change write", %{user: user, rha: rha} do
+      mock_global(fn
+        %{method: :get, url: "https://api.github.com/user/583231"} ->
+          json(%{"id" => 583_231, "login" => rha.login, "name" => rha.name})
+      end)
+
+      with_mocks([
+        {Guard.Events.UserUpdated, [], publish: fn _u, _e, _r -> :ok end},
+        {Watchman, [], increment: fn _ -> :ok end}
+      ]) do
+        assert {:ok, _} = GithubProfileSync.sync({:ok, rha}, user.id, "token")
+        assert called(Watchman.increment({"guard.github_profile_sync.success", ["no_change"]}))
+        refute called(Guard.Events.UserUpdated.publish(:_, :_, :_))
+      end
+    end
+
+    test "error log never contains the OAuth access or refresh token", %{user: user, rha: rha} do
+      secret_token = "ghp_TEST_OAUTH_ACCESS_TOKEN_VALUE"
+      secret_refresh = "ghr_TEST_OAUTH_REFRESH_TOKEN_VALUE"
+
+      {:ok, rha_with_secrets} =
+        rha
+        |> Ecto.Changeset.change(%{token: secret_token, refresh_token: secret_refresh})
+        |> Guard.FrontRepo.update(force: true)
+
+      mock_global(fn
+        %{method: :get, url: "https://api.github.com/user/583231"} ->
+          json(%{"id" => 583_231, "login" => "octocat-renamed", "name" => rha_with_secrets.name})
+      end)
+
+      # Build a *real* changeset whose `:data` is the rha — exercises the
+      # default-Inspect leak path that a forged %Ecto.Changeset{} would skip.
+      real_changeset_error =
+        {:error,
+         rha_with_secrets
+         |> Ecto.Changeset.change(%{login: "octocat-renamed"})
+         |> Ecto.Changeset.add_error(:login, "is invalid")
+         |> Map.put(:valid?, false)}
+
+      with_mocks([
+        {RepoHostAccount, [:passthrough], update_profile: fn _, _ -> real_changeset_error end},
+        {Guard.Events.UserUpdated, [], publish: fn _u, _e, _r -> :ok end},
+        {Watchman, [], increment: fn _ -> :ok end}
+      ]) do
+        log =
+          ExUnit.CaptureLog.capture_log([level: :error], fn ->
+            assert {:ok, _returned} =
+                     GithubProfileSync.sync({:ok, rha_with_secrets}, user.id, "tok")
+          end)
+
+        refute log =~ secret_token
+        refute log =~ secret_refresh
+        # Field/message from the changeset must still be logged for diagnostics.
+        assert log =~ "login:is invalid"
+      end
+    end
+  end
+end

--- a/guard/test/support/members.ex
+++ b/guard/test/support/members.ex
@@ -47,6 +47,29 @@ defmodule Support.Members do
     FrontRepo.insert(user)
   end
 
+  @doc """
+  Insert an RbacUser + Front User + GitHub RepoHostAccount in one call.
+
+  Returns `{user, rha}`. Override RHA fields via `rha_attrs`.
+  """
+  def insert_user_with_github_account(rha_attrs \\ []) do
+    {:ok, user} = Support.Factories.RbacUser.insert()
+    {:ok, _} = insert_user(id: user.id, email: user.email, name: user.name)
+
+    rha_defaults = [
+      login: "octocat",
+      name: "The Octocat",
+      github_uid: "583231",
+      user_id: user.id,
+      token: "token",
+      revoked: false,
+      permission_scope: "repo"
+    ]
+
+    {:ok, rha} = insert_repo_host_account(Keyword.merge(rha_defaults, rha_attrs))
+    {user, rha}
+  end
+
   def valid_expires_at do
     DateTime.utc_now()
     |> DateTime.add(3600)


### PR DESCRIPTION
## 📝 Description
Allow the user to refresh their GitHub nickname 

On the user's profile render, Guard pipes the post-validation RepoHostAccount, which fetches the upstream profile, writes any changes with optimistic locking, and publishes user_updated. 
RBAC consumes that event and updates collaborators.github_username for the user's GitHub projects via a provider-scoped query, so per-project member listings and the $SEMAPHORE_WORKFLOW_TRIGGERED_BY env var self-heal after a GitHub username rename.


## ✅ Checklist
- [x] I have tested this change
- [x] ~~This change requires documentation update~~
