### PR TITLE
feat(zebra): add macOS Xcode 15 brownout schedule

### DIFF
--- a/zebra/lib/zebra/machines/brownout.ex
+++ b/zebra/lib/zebra/machines/brownout.ex
@@ -18,8 +18,7 @@ defmodule Zebra.Machines.Brownout do
   """
   @spec schedules() :: brownout_schedules()
   def schedules do
-    BrownoutSchedule.ubuntu2004() ++
-      BrownoutSchedule.macosxcode15()
+    BrownoutSchedule.macosxcode15()
   end
 
   @doc """

--- a/zebra/lib/zebra/machines/brownout.ex
+++ b/zebra/lib/zebra/machines/brownout.ex
@@ -18,7 +18,8 @@ defmodule Zebra.Machines.Brownout do
   """
   @spec schedules() :: brownout_schedules()
   def schedules do
-    BrownoutSchedule.ubuntu2004()
+    BrownoutSchedule.ubuntu2004() ++
+      BrownoutSchedule.macosxcode15()
   end
 
   @doc """

--- a/zebra/lib/zebra/machines/brownout_schedule.ex
+++ b/zebra/lib/zebra/machines/brownout_schedule.ex
@@ -105,6 +105,50 @@ defmodule Zebra.Machines.BrownoutSchedule do
     first_phase ++ second_phase ++ third_phase ++ fourth_phase
   end
 
+  @spec macosxcode15 :: Brownout.brownout_schedules()
+  def macosxcode15 do
+    first_phase =
+      phase(
+        Date.range(~D[2026-06-15], ~D[2026-06-21]),
+        [
+          {~T[10:00:00], ~T[10:15:00]},
+          {~T[13:00:00], ~T[13:15:00]},
+          {~T[16:00:00], ~T[16:15:00]},
+          {~T[19:00:00], ~T[19:15:00]},
+          {~T[22:00:00], ~T[22:15:00]}
+        ],
+        ["macos-xcode15"]
+      )
+
+    second_phase =
+      phase(
+        Date.range(~D[2026-06-22], ~D[2026-06-28]),
+        [
+          {~T[10:00:00], ~T[11:00:00]},
+          {~T[13:00:00], ~T[14:00:00]},
+          {~T[16:00:00], ~T[17:00:00]},
+          {~T[19:00:00], ~T[20:00:00]},
+          {~T[22:00:00], ~T[23:00:00]}
+        ],
+        ["macos-xcode15"]
+      )
+
+    third_phase =
+      phase(
+        Date.range(~D[2026-06-29], ~D[2026-07-05]),
+        [
+          {~T[10:00:00], ~T[12:00:00]},
+          {~T[13:00:00], ~T[15:00:00]},
+          {~T[16:00:00], ~T[18:00:00]},
+          {~T[19:00:00], ~T[21:00:00]},
+          {~T[22:00:00], ~T[00:00:00]}
+        ],
+        ["macos-xcode15"]
+      )
+
+    first_phase ++ second_phase ++ third_phase
+  end
+
   @doc """
   Creates a brownout schedule for a given date and time range.
   """
@@ -113,15 +157,22 @@ defmodule Zebra.Machines.BrownoutSchedule do
     dates
     |> Enum.flat_map(fn date ->
       times
-      |> Enum.map(fn {from, to} ->
+      |> Enum.map(fn {from_time, to_time} ->
         from =
           date
-          |> NaiveDateTime.new!(from)
+          |> NaiveDateTime.new!(from_time)
           |> DateTime.from_naive!("Etc/UTC")
 
+        to_date =
+          if Time.compare(to_time, from_time) == :lt do
+            Date.add(date, 1)
+          else
+            date
+          end
+
         to =
-          date
-          |> NaiveDateTime.new!(to)
+          to_date
+          |> NaiveDateTime.new!(to_time)
           |> DateTime.from_naive!("Etc/UTC")
 
         Brownout.schedule(from, to, os_images)

--- a/zebra/test/zebra/machines/brownout_schedule_test.exs
+++ b/zebra/test/zebra/machines/brownout_schedule_test.exs
@@ -47,6 +47,28 @@ defmodule Zebra.Machines.BrownoutScheduleTest do
            }
   end
 
+  test "creates macos-xcode15 brownout schedule" do
+    schedule = BrownoutSchedule.macosxcode15()
+
+    assert length(schedule) == 105
+
+    [first_event | _] = schedule
+
+    assert first_event == %{
+             from: ~U[2026-06-15 10:00:00Z],
+             os_images: ["macos-xcode15"],
+             to: ~U[2026-06-15 10:15:00Z]
+           }
+
+    [last_event | _] = schedule |> Enum.reverse()
+
+    assert last_event == %{
+             from: ~U[2026-07-05 22:00:00Z],
+             os_images: ["macos-xcode15"],
+             to: ~U[2026-07-06 00:00:00Z]
+           }
+  end
+
   describe "creating phases" do
     test "work as expected" do
       phase =
@@ -68,6 +90,25 @@ defmodule Zebra.Machines.BrownoutScheduleTest do
                  from: ~U[2024-01-02 00:00:00Z],
                  os_images: ["ubuntu2004"],
                  to: ~U[2024-01-02 00:15:00Z]
+               }
+             ]
+    end
+
+    test "supports periods crossing midnight" do
+      phase =
+        BrownoutSchedule.phase(
+          Date.range(~D[2024-01-01], ~D[2024-01-01]),
+          [
+            {~T[22:00:00], ~T[00:00:00]}
+          ],
+          ["ubuntu2004"]
+        )
+
+      assert phase == [
+               %{
+                 from: ~U[2024-01-01 22:00:00Z],
+                 os_images: ["ubuntu2004"],
+                 to: ~U[2024-01-02 00:00:00Z]
                }
              ]
     end

--- a/zebra/test/zebra/machines/brownout_test.exs
+++ b/zebra/test/zebra/machines/brownout_test.exs
@@ -88,4 +88,20 @@ defmodule Zebra.Machines.BrownoutTest do
                false
     end
   end
+
+  describe "applying brownout on default schedules" do
+    test "works for macos-xcode15" do
+      assert Brownout.os_image_in_brownout?(
+               ~U[2026-06-15 10:10:00Z],
+               "regular-org",
+               "macos-xcode15"
+             ) == true
+
+      assert Brownout.os_image_in_brownout?(
+               ~U[2026-06-15 10:15:01Z],
+               "regular-org",
+               "macos-xcode15"
+             ) == false
+    end
+  end
 end


### PR DESCRIPTION
## 📝 Description

Adding the macOS Xcode 15 image to the brownout schedule, as announced in [the blog](https://semaphore.io/blog/announcement-xcode15-deprecation-in-semaphore).

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
