### PR TITLE
feat(v1alpha): implement feature provider invalidator worker

### DIFF
--- a/public-api/v1alpha/Makefile
+++ b/public-api/v1alpha/Makefile
@@ -32,7 +32,7 @@ PROJECTHUB_API_GRPC_URL?=127.0.0.1:50052
 LOG_LEVEL?=debug
 API_VERSION?=v1alpha
 ON_PREM?="false"
-AMQP_URL?=amqp://rabbitmq:5672
+AMQP_URL?=amqp://0.0.0.0:5672
 AUDIT_LOGGING?=true
 
 CONTAINER_ENV_VARS= \
@@ -67,6 +67,7 @@ ifeq ($(CI),)
 # Localy we use database supplied by docker-compose
 	docker compose $(DOCKER_COMPOSE_OPTS) run -e MIX_ENV=$(MIX_ENV) --build app mix do deps.get
 else
+	sem-service start rabbitmq 3.8
 	docker run --network host -v $(PWD)/out:/app/out $(CONTAINER_ENV_VARS) $(IMAGE):$(IMAGE_TAG) sh
 endif
 

--- a/public-api/v1alpha/config/runtime.exs
+++ b/public-api/v1alpha/config/runtime.exs
@@ -11,6 +11,8 @@ config :pipelines_api,
 
 config :pipelines_api, :audit_logging, System.get_env("AUDIT_LOGGING") == "true"
 
+config :pipelines_api, :amqp_url, System.get_env("AMQP_URL")
+
 if System.get_env("AMQP_URL") != nil do
   config :amqp,
     connections: [

--- a/public-api/v1alpha/lib/pipelines_api/application.ex
+++ b/public-api/v1alpha/lib/pipelines_api/application.ex
@@ -12,6 +12,7 @@ defmodule PipelinesAPI.Application do
 
     provider = Application.fetch_env!(:pipelines_api, :feature_provider)
     FeatureProvider.init(provider)
+    on_prem? = Application.fetch_env!(:pipelines_api, :on_prem?)
 
     children =
       [
@@ -24,11 +25,19 @@ defmodule PipelinesAPI.Application do
           id: :project_api_cache,
           start: {Cachex, :start_link, [:project_api_cache, []]}
         }
-      ] ++ if Application.fetch_env!(:pipelines_api, :on_prem?), do: [provider], else: []
+      ] ++ maybe_feature_provider_invalidator() ++ if on_prem?, do: [provider], else: []
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: PipelinesAPI.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp maybe_feature_provider_invalidator do
+    case Application.get_env(:pipelines_api, :amqp_url) do
+      nil -> []
+      "" -> []
+      _ -> [PipelinesAPI.FeatureProviderInvalidatorWorker]
+    end
   end
 end

--- a/public-api/v1alpha/lib/pipelines_api/feature_provider_invalidator_worker.ex
+++ b/public-api/v1alpha/lib/pipelines_api/feature_provider_invalidator_worker.ex
@@ -1,0 +1,59 @@
+defmodule PipelinesAPI.FeatureProviderInvalidatorWorker do
+  require Logger
+
+  @moduledoc """
+  This module consumes RabbitMQ feature and machine state change events
+  and invalidates features and machines caches.
+  """
+
+  use Tackle.Multiconsumer,
+    url: Application.get_env(:pipelines_api, :amqp_url),
+    service: "pipelines_api",
+    routes: [
+      {"feature_exchange", "machines_changed", :machines_changed},
+      {"feature_exchange", "organization_machines_changed", :organization_machines_changed},
+      {"feature_exchange", "features_changed", :features_changed},
+      {"feature_exchange", "organization_features_changed", :organization_features_changed}
+    ],
+    # This queue is used to consume events from the feature exchange.
+    # It is declared as non-durable, auto-delete and exclusive.
+    # This means that the queue will be deleted when the consumer disconnects.
+    # This is the desired behavior because events invalidate pod-level caches.
+    queue: :dynamic,
+    queue_opts: [
+      durable: false,
+      auto_delete: true,
+      exclusive: true
+    ],
+    connection_id: PipelinesAPI.FeatureProviderInvalidatorWorker
+
+  def machines_changed(_message) do
+    log("invalidating machines")
+    {:ok, _} = FeatureProvider.list_machines(reload: true)
+    :ok
+  end
+
+  def organization_machines_changed(message) do
+    event = InternalApi.Feature.OrganizationMachinesChanged.decode(message)
+    log("invalidating machines for org #{event.org_id}")
+    {:ok, _} = FeatureProvider.list_machines(reload: true, param: event.org_id)
+    :ok
+  end
+
+  def features_changed(_message) do
+    log("invalidating features")
+    {:ok, _} = FeatureProvider.list_features(reload: true)
+    :ok
+  end
+
+  def organization_features_changed(message) do
+    event = InternalApi.Feature.OrganizationFeaturesChanged.decode(message)
+    log("invalidating features for org #{event.org_id}")
+    {:ok, _} = FeatureProvider.list_features(reload: true, param: event.org_id)
+    :ok
+  end
+
+  defp log(message) do
+    Logger.info("[FEATURE PROVIDER INVALIDATOR WORKER] #{message}")
+  end
+end

--- a/public-api/v1alpha/test/feature_provider_invalidator_worker_test.exs
+++ b/public-api/v1alpha/test/feature_provider_invalidator_worker_test.exs
@@ -1,0 +1,49 @@
+defmodule PipelinesAPI.FeatureProviderInvalidatorWorker.Test do
+  use ExUnit.Case
+
+  alias InternalApi.Feature.{FeaturesChanged, OrganizationFeaturesChanged}
+  alias PipelinesAPI.FeatureProviderInvalidatorWorker, as: Worker
+
+  setup do
+    Support.Stubs.reset()
+    Support.Stubs.build_shared_factories()
+    org = Support.Stubs.DB.first(:organizations)
+
+    {:ok, org_id: org.id}
+  end
+
+  test "features_changed invalidates global feature cache" do
+    assert feature_state(nil, "deployment_targets") == :enabled
+
+    Support.Stubs.Feature.setup_feature("deployment_targets", state: :HIDDEN, quantity: 0)
+    assert feature_state(nil, "deployment_targets") == :enabled
+
+    callback_message = %FeaturesChanged{} |> FeaturesChanged.encode()
+
+    assert :ok = Worker.features_changed(callback_message)
+    assert feature_state(nil, "deployment_targets") == :disabled
+  end
+
+  test "organization_features_changed invalidates organization feature cache", %{org_id: org_id} do
+    assert feature_state(org_id, "deployment_targets") == :enabled
+
+    Support.Stubs.Feature.disable_feature(org_id, :deployment_targets)
+    assert feature_state(org_id, "deployment_targets") == :enabled
+
+    callback_message =
+      %OrganizationFeaturesChanged{org_id: org_id} |> OrganizationFeaturesChanged.encode()
+
+    assert :ok = Worker.organization_features_changed(callback_message)
+    assert feature_state(org_id, "deployment_targets") == :disabled
+  end
+
+  defp feature_state(nil, feature_type) do
+    {:ok, features} = FeatureProvider.list_features()
+    features |> Enum.find(&(&1.type == feature_type)) |> Map.fetch!(:state)
+  end
+
+  defp feature_state(org_id, feature_type) do
+    {:ok, features} = FeatureProvider.list_features(param: org_id)
+    features |> Enum.find(&(&1.type == feature_type)) |> Map.fetch!(:state)
+  end
+end


### PR DESCRIPTION
## 📝 Description

Adds a `FeatureProviderInvalidatorWorker` that consumes RabbitMQ `feature_exchange` events and reloads the corresponding feature/machine caches, so feature flag changes take effect immediately instead of waiting for the cache TTL to expire.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
