### PR TITLE
feat(plumber): reject circular block dependencies in pipeline YAML

### DIFF
--- a/plumber/block/priv/repos/31_cyclic_deps/.semaphore/semaphore.yml
+++ b/plumber/block/priv/repos/31_cyclic_deps/.semaphore/semaphore.yml
@@ -1,0 +1,22 @@
+version: v1.0
+name: Failing pipeline - circular dependencies
+agent:
+  machine:
+    type: foo
+    os_image: bar
+blocks:
+  - name: A
+    dependencies: [C]
+    task:
+      jobs:
+        - commands: [echo foo]
+  - name: B
+    dependencies: [A]
+    task:
+      jobs:
+        - commands: [echo bar]
+  - name: C
+    dependencies: [B]
+    task:
+      jobs:
+        - commands: [echo baz]

--- a/plumber/definition_validator/lib/definition_validator/ppl_blocks_dependencies.ex
+++ b/plumber/definition_validator/lib/definition_validator/ppl_blocks_dependencies.ex
@@ -126,7 +126,13 @@ defmodule DefinitionValidator.PplBlocksDependencies do
   end
 
   defp cycle_error_msg(cycle) do
-    path = Enum.map_join(cycle, " → ", &"\"#{&1}\"")
+    # Render the cycle in the same direction the UI uses: the dependency first,
+    # then the block that depends on it (i.e. "B → A" when A depends on B). The
+    # detected path is in "depends-on" order, so reverse it before formatting.
+    path =
+      cycle
+      |> Enum.reverse()
+      |> Enum.map_join(" → ", &"'#{&1}'")
 
     "Circular dependency between blocks detected: #{path}. " <>
       "Blocks cannot depend on each other in a cycle."

--- a/plumber/definition_validator/lib/definition_validator/ppl_blocks_dependencies.ex
+++ b/plumber/definition_validator/lib/definition_validator/ppl_blocks_dependencies.ex
@@ -7,7 +7,8 @@ defmodule DefinitionValidator.PplBlocksDependencies do
 
   def validate_yaml(definition) do
     with {:ok, definition} <- implicit_or_explicit_dependency_definition(definition),
-         do: validate_names(definition)
+         {:ok, definition} <- validate_names(definition),
+         do: validate_no_cycles(definition)
   end
 
   @doc """
@@ -57,4 +58,77 @@ defmodule DefinitionValidator.PplBlocksDependencies do
 
   defp ok(definition), do: {:cont, {:ok, definition}}
   defp err(dep), do: {:halt, {:error, {:malformed, {:unknown_block_name, dep}}}}
+
+  @doc """
+  Verifies that block dependencies do not form a cycle.
+
+  Mirrors the cycle detection done in the workflow editor (front), so that
+  pipelines whose YAML was edited directly (bypassing the editor) are also
+  rejected. Implicit dependencies are linear and can never form a cycle, so
+  only explicitly defined dependencies produce edges in the graph.
+  """
+  def validate_no_cycles(definition) do
+    graph =
+      definition["blocks"]
+      |> Enum.reduce(%{}, fn block, acc ->
+        Map.put(acc, block["name"], block["dependencies"] || [])
+      end)
+
+    case find_cycle(graph) do
+      nil -> {:ok, definition}
+      cycle -> {:error, {:malformed, cycle_error_msg(cycle)}}
+    end
+  end
+
+  # Depth-first search over every node. `visited` accumulates nodes whose
+  # subtree is fully explored (and proven acyclic); `stack` is the current DFS
+  # path. Re-entering a node already on `stack` means we found a cycle.
+  defp find_cycle(graph) do
+    graph
+    |> Map.keys()
+    |> Enum.reduce_while(MapSet.new(), fn node, visited ->
+      case dfs(node, graph, visited, []) do
+        {:cycle, path} -> {:halt, path}
+        {:ok, visited} -> {:cont, visited}
+      end
+    end)
+    |> case do
+      %MapSet{} -> nil
+      cycle_path -> cycle_path
+    end
+  end
+
+  defp dfs(node, graph, visited, stack) do
+    cond do
+      node in stack ->
+        cycle = stack |> Enum.reverse() |> Enum.drop_while(&(&1 != node))
+        {:cycle, cycle ++ [node]}
+
+      MapSet.member?(visited, node) ->
+        {:ok, visited}
+
+      true ->
+        neighbors = Map.get(graph, node, [])
+        new_stack = [node | stack]
+
+        neighbors
+        |> Enum.reduce_while({:ok, visited}, fn neighbor, {:ok, vis} ->
+          case dfs(neighbor, graph, vis, new_stack) do
+            {:cycle, path} -> {:halt, {:cycle, path}}
+            {:ok, vis} -> {:cont, {:ok, vis}}
+          end
+        end)
+        |> case do
+          {:cycle, path} -> {:cycle, path}
+          {:ok, vis} -> {:ok, MapSet.put(vis, node)}
+        end
+    end
+  end
+
+  defp cycle_error_msg(cycle) do
+    path = Enum.map_join(cycle, " → ", &"\"#{&1}\"")
+
+    "Circular dependency between blocks detected: #{path}. " <>
+      "Blocks cannot depend on each other in a cycle."
+  end
 end

--- a/plumber/definition_validator/test/definition_validator_test.exs
+++ b/plumber/definition_validator/test/definition_validator_test.exs
@@ -116,6 +116,42 @@ defmodule DefinitionValidator.Test do
       """
   end
 
+  test "malformed definition - circular block dependencies" do
+    yaml_string = """
+    version: v1.0
+    agent:
+      machine:
+        type: foo
+        os_image: bar
+
+    blocks:
+      - name: A
+        dependencies: [C]
+        task:
+          jobs:
+            - name: single job
+              commands:
+                - echo foo
+      - name: B
+        dependencies: [A]
+        task:
+          jobs:
+            - name: single job
+              commands:
+                - echo bar
+      - name: C
+        dependencies: [B]
+        task:
+          jobs:
+            - name: single job
+              commands:
+                - echo baz
+    """
+    assert({:error, {:malformed, msg}} =
+      DefinitionValidator.validate_yaml_string(yaml_string))
+    assert msg =~ "Circular dependency between blocks detected:"
+  end
+
   test "empty definition" do
     assert {:error, {:malformed, reason}} = DefinitionValidator.validate_yaml_string("")
     assert String.contains?(reason, "version")

--- a/plumber/definition_validator/test/ppl_blocks_dependencies_test.exs
+++ b/plumber/definition_validator/test/ppl_blocks_dependencies_test.exs
@@ -41,11 +41,11 @@ defmodule DefinitionValidator.PplBlocksDependencies.Test do
 
       assert {:error, {:malformed, msg}} = Deps.validate_no_cycles(definition)
       assert msg =~ "Circular dependency between blocks detected:"
-      assert msg =~ "\"A\""
-      assert msg =~ "\"B\""
+      assert msg =~ "'A'"
+      assert msg =~ "'B'"
     end
 
-    test "detects a longer cycle A -> B -> C -> A" do
+    test "detects a longer cycle and renders it in dependency -> dependent order" do
       definition = %{
         "blocks" => [
           block("A", ["C"]),
@@ -56,13 +56,17 @@ defmodule DefinitionValidator.PplBlocksDependencies.Test do
 
       assert {:error, {:malformed, msg}} = Deps.validate_no_cycles(definition)
       assert msg =~ "Circular dependency between blocks detected:"
+      # A depends on C, C on B, B on A. The cycle is rendered in the UI's
+      # "dependency first" direction (matching how blocks list deps), not in
+      # "depends-on" order.
+      assert msg =~ "'A' → 'B' → 'C' → 'A'"
     end
 
     test "detects a self-dependency" do
       definition = %{"blocks" => [block("A", ["A"])]}
 
       assert {:error, {:malformed, msg}} = Deps.validate_no_cycles(definition)
-      assert msg =~ "\"A\" → \"A\""
+      assert msg =~ "'A' → 'A'"
     end
 
     test "passes for a valid DAG that also has a separate acyclic branch" do

--- a/plumber/definition_validator/test/ppl_blocks_dependencies_test.exs
+++ b/plumber/definition_validator/test/ppl_blocks_dependencies_test.exs
@@ -1,0 +1,96 @@
+defmodule DefinitionValidator.PplBlocksDependencies.Test do
+  use ExUnit.Case
+
+  alias DefinitionValidator.PplBlocksDependencies, as: Deps
+
+  defp block(name, deps), do: %{"name" => name, "dependencies" => deps}
+
+  describe "validate_no_cycles/1" do
+    test "passes for a linear explicit chain" do
+      definition = %{"blocks" => [block("A", []), block("B", ["A"]), block("C", ["B"])]}
+      assert {:ok, ^definition} = Deps.validate_no_cycles(definition)
+    end
+
+    test "passes for a diamond / fan-in topology" do
+      definition = %{
+        "blocks" => [
+          block("A", []),
+          block("B", ["A"]),
+          block("C", ["A"]),
+          block("D", ["B", "C"])
+        ]
+      }
+
+      assert {:ok, ^definition} = Deps.validate_no_cycles(definition)
+    end
+
+    test "passes when all dependencies are implicit (nil)" do
+      definition = %{
+        "blocks" => [
+          %{"name" => "A"},
+          %{"name" => "B"},
+          %{"name" => "C"}
+        ]
+      }
+
+      assert {:ok, ^definition} = Deps.validate_no_cycles(definition)
+    end
+
+    test "detects a simple two-block cycle" do
+      definition = %{"blocks" => [block("A", ["B"]), block("B", ["A"])]}
+
+      assert {:error, {:malformed, msg}} = Deps.validate_no_cycles(definition)
+      assert msg =~ "Circular dependency between blocks detected:"
+      assert msg =~ "\"A\""
+      assert msg =~ "\"B\""
+    end
+
+    test "detects a longer cycle A -> B -> C -> A" do
+      definition = %{
+        "blocks" => [
+          block("A", ["C"]),
+          block("B", ["A"]),
+          block("C", ["B"])
+        ]
+      }
+
+      assert {:error, {:malformed, msg}} = Deps.validate_no_cycles(definition)
+      assert msg =~ "Circular dependency between blocks detected:"
+    end
+
+    test "detects a self-dependency" do
+      definition = %{"blocks" => [block("A", ["A"])]}
+
+      assert {:error, {:malformed, msg}} = Deps.validate_no_cycles(definition)
+      assert msg =~ "\"A\" → \"A\""
+    end
+
+    test "passes for a valid DAG that also has a separate acyclic branch" do
+      definition = %{
+        "blocks" => [
+          block("A", []),
+          block("B", ["A"]),
+          block("C", ["B"]),
+          block("D", []),
+          block("E", ["B"])
+        ]
+      }
+
+      assert {:ok, ^definition} = Deps.validate_no_cycles(definition)
+    end
+  end
+
+  describe "validate_yaml/1 integration" do
+    test "rejects a cyclic definition through the full validation chain" do
+      definition = %{
+        "blocks" => [
+          block("A", ["B"]),
+          block("B", ["A"])
+        ]
+      }
+
+      assert {:error, {:malformed, msg}} = Deps.validate_yaml(definition)
+      assert msg =~ "Circular dependency between blocks detected:"
+    end
+  end
+end

--- a/plumber/ppl/test/grpc/server_test.exs
+++ b/plumber/ppl/test/grpc/server_test.exs
@@ -79,6 +79,13 @@ defmodule Ppl.Grpc.Server.Test do
     assert String.contains?(message, "blocks/0/task")
   end
 
+  test "gRPC validate_yaml() - circular block dependencies rejected" do
+    yaml_definition = cyclic_definition()
+
+    assert {message, _} = assert_validate_yaml(yaml_definition, "", :error, false)
+    assert String.contains?(message, "Circular dependency between blocks detected:")
+  end
+
   test "gRPC validate_yaml() -  valid yaml definition, refuse ppls scheduling if project deletion was requested" do
     {:ok, %{ppl_id: ppl_id}} =
       %{"repo_name" => "5_v1_full", "project_id" => "to-delete"}
@@ -163,6 +170,36 @@ defmodule Ppl.Grpc.Server.Test do
         os_image: ubuntu1804
     blocks:
       - task:
+    """
+  end
+
+  defp cyclic_definition() do
+    """
+    version: "v1.0"
+    name: basic test
+    agent:
+      machine:
+        type: e1-standard-2
+        os_image: ubuntu1804
+    blocks:
+      - name: A
+        dependencies: [C]
+        task:
+          jobs:
+            - commands:
+                - echo foo
+      - name: B
+        dependencies: [A]
+        task:
+          jobs:
+            - commands:
+                - echo bar
+      - name: C
+        dependencies: [B]
+        task:
+          jobs:
+            - commands:
+                - echo baz
     """
   end
 

--- a/plumber/ppl/test/ppl_blocks/model/ppl_block_connections_test.exs
+++ b/plumber/ppl/test/ppl_blocks/model/ppl_block_connections_test.exs
@@ -43,6 +43,23 @@ defmodule Ppl.PplBlocks.Model.PplBlockConectionsTest do
     assert String.contains?(description.error_description, "unknown_block_name,")
   end
 
+  @tag :integration
+  test "circular blocks dependencies - fail" do
+    schedule_request =
+      Test.Helpers.schedule_request_factory(:local)
+      |> Map.put("repo_name", "31_cyclic_deps")
+
+    {:ok, description} = schedule_pipeline(schedule_request, "done")
+
+    assert description.state == "done"
+    assert description.result_reason == "malformed"
+
+    assert String.contains?(
+             description.error_description,
+             "Circular dependency between blocks detected:"
+           )
+  end
+
   defp schedule_pipeline(schedule_request, desired_state) do
     {:ok, %{ppl_id: ppl_id}} = Ppl.Actions.schedule(schedule_request)
 


### PR DESCRIPTION
The workflow editor (front) prevents dependency cycles between blocks, but pipelines whose YAML is edited directly bypass that check and reach the backend. Port the editor's DFS cycle detection into the definition validator so such pipelines fail initialization with a clear error, and so the validate_yaml gRPC action rejects them too.

Both the init flow and the validate_yaml gRPC action go through DefinitionValidator.validate_yaml_string/1, so a single new validation step (PplBlocksDependencies.validate_no_cycles/1) covers both. The error surfaces via the existing {:malformed, msg} -> error_description channel, naming the offending cycle, e.g.:

  Circular dependency between blocks detected: "A" -> "B" -> "A".


