### PR TITLE
docs(reference): document CACHE_FAIL_ON_ERROR and cache error handling

### DIFF
--- a/docs/docs/reference/env-vars.md
+++ b/docs/docs/reference/env-vars.md
@@ -571,6 +571,13 @@ The username is used for connecting to the cache server.
 
 The path in the server to the SSH key file to access the cache server.
 
+### Fail on error {#cache-fail-on-error}
+
+- **Environment variable**: `CACHE_FAIL_ON_ERROR`
+- **Example**: `true`
+
+When set to `true`, cache commands exit with a non-zero status if an operation fails — for example, when the cache server is unreachable. By default this variable is unset and cache commands are best-effort: they log the error and exit with status `0` so the job continues without the cache. A cache miss is not considered an error. See [cache error handling](./toolbox#cache-error-handling) for details.
+
 ## Semaphore Docker registry variables {#registry-variables}
 
 These variables can be used to access the [Semaphore Docker registry](../using-semaphore/containers/docker).

--- a/docs/docs/reference/toolbox.md
+++ b/docs/docs/reference/toolbox.md
@@ -155,6 +155,36 @@ The supported options for `--cleanup-by` are:
 - `STORE_TIME`: (default) delete oldest files first
 - `ACCESS_TIME`: delete oldest accessed files first
 
+### Error handling {#cache-error-handling}
+
+By default, cache commands are **best-effort**: if the cache server can't be reached, or an operation otherwise fails, the command logs the error and exits with status `0` so the job continues without the cache. This prevents a cache outage from failing your pipeline.
+
+A cache *miss* is not an error: `has_key` exits with a non-zero status when the key is absent, and `restore` exits with status `0` when nothing matches.
+
+To make cache errors (for example, a failed connection to the cache server) fail the job instead, set [`CACHE_FAIL_ON_ERROR`](./env-vars#cache-fail-on-error) to `true`. Any cache command that then encounters an error exits with a non-zero status:
+
+```yaml
+blocks:
+  - name: Build
+    task:
+      env_vars:
+        - name: CACHE_FAIL_ON_ERROR
+          value: "true"
+      jobs:
+        - name: bundle
+          commands:
+            - cache restore gems-$SEMAPHORE_GIT_BRANCH
+            - bundle install
+            - cache store gems-$SEMAPHORE_GIT_BRANCH vendor/bundle
+```
+
+You can also export it for specific commands only:
+
+```shell
+export CACHE_FAIL_ON_ERROR=true
+cache restore gems-$SEMAPHORE_GIT_BRANCH
+```
+
 ### Environment variables {#cache-env-vars}
 
 The cache tool depends on the following environment variables:
@@ -162,6 +192,7 @@ The cache tool depends on the following environment variables:
 - [`SEMAPHORE_CACHE_URL`](./env-vars#cache-url)
 - [`SEMAPHORE_CACHE_USERNAME`](./env-vars#cache-username)
 - [`SEMAPHORE_CACHE_PRIVATE_KEY_PATH`](./env-vars#cache-private-key-path)
+- [`CACHE_FAIL_ON_ERROR`](./env-vars#cache-fail-on-error) (optional) — fail the job on cache errors instead of continuing. See [Error handling](#cache-error-handling).
 
 ## checkout {#checkout}
 

--- a/docs/versioned_docs/version-CE-1.4/reference/env-vars.md
+++ b/docs/versioned_docs/version-CE-1.4/reference/env-vars.md
@@ -537,6 +537,13 @@ The username is used for connecting to the cache server.
 
 The path in the server to the SSH key file to access the cache server.
 
+### Fail on error {#cache-fail-on-error}
+
+- **Environment variable**: `CACHE_FAIL_ON_ERROR`
+- **Example**: `true`
+
+When set to `true`, cache commands exit with a non-zero status if an operation fails — for example, when the cache server is unreachable. By default this variable is unset and cache commands are best-effort: they log the error and exit with status `0` so the job continues without the cache. A cache miss is not considered an error. See [cache error handling](./toolbox#cache-error-handling) for details.
+
 ## Semaphore Docker registry variables {#registry-variables}
 
 These variables can be used to access the [Semaphore Docker registry](../using-semaphore/containers/docker).

--- a/docs/versioned_docs/version-CE-1.4/reference/toolbox.md
+++ b/docs/versioned_docs/version-CE-1.4/reference/toolbox.md
@@ -160,6 +160,36 @@ The supported options for `--cleanup-by` are:
 - `STORE_TIME`: (default) delete oldest files first
 - `ACCESS_TIME`: delete oldest accessed files first
 
+### Error handling {#cache-error-handling}
+
+By default, cache commands are **best-effort**: if the cache server can't be reached, or an operation otherwise fails, the command logs the error and exits with status `0` so the job continues without the cache. This prevents a cache outage from failing your pipeline.
+
+A cache *miss* is not an error: `has_key` exits with a non-zero status when the key is absent, and `restore` exits with status `0` when nothing matches.
+
+To make cache errors (for example, a failed connection to the cache server) fail the job instead, set [`CACHE_FAIL_ON_ERROR`](./env-vars#cache-fail-on-error) to `true`. Any cache command that then encounters an error exits with a non-zero status:
+
+```yaml
+blocks:
+  - name: Build
+    task:
+      env_vars:
+        - name: CACHE_FAIL_ON_ERROR
+          value: "true"
+      jobs:
+        - name: bundle
+          commands:
+            - cache restore gems-$SEMAPHORE_GIT_BRANCH
+            - bundle install
+            - cache store gems-$SEMAPHORE_GIT_BRANCH vendor/bundle
+```
+
+You can also export it for specific commands only:
+
+```shell
+export CACHE_FAIL_ON_ERROR=true
+cache restore gems-$SEMAPHORE_GIT_BRANCH
+```
+
 ### Environment variables {#cache-env-vars}
 
 The cache tool depends on the following environment variables:
@@ -167,6 +197,7 @@ The cache tool depends on the following environment variables:
 - [`SEMAPHORE_CACHE_URL`](./env-vars#cache-url)
 - [`SEMAPHORE_CACHE_USERNAME`](./env-vars#cache-username)
 - [`SEMAPHORE_CACHE_PRIVATE_KEY_PATH`](./env-vars#cache-private-key-path)
+- [`CACHE_FAIL_ON_ERROR`](./env-vars#cache-fail-on-error) (optional) — fail the job on cache errors instead of continuing. See [Error handling](#cache-error-handling).
 
 ## checkout {#checkout}
 

--- a/docs/versioned_docs/version-CE/reference/env-vars.md
+++ b/docs/versioned_docs/version-CE/reference/env-vars.md
@@ -537,6 +537,13 @@ The username is used for connecting to the cache server.
 
 The path in the server to the SSH key file to access the cache server.
 
+### Fail on error {#cache-fail-on-error}
+
+- **Environment variable**: `CACHE_FAIL_ON_ERROR`
+- **Example**: `true`
+
+When set to `true`, cache commands exit with a non-zero status if an operation fails — for example, when the cache server is unreachable. By default this variable is unset and cache commands are best-effort: they log the error and exit with status `0` so the job continues without the cache. A cache miss is not considered an error. See [cache error handling](./toolbox#cache-error-handling) for details.
+
 ## Semaphore Docker registry variables {#registry-variables}
 
 These variables can be used to access the [Semaphore Docker registry](../using-semaphore/containers/docker).

--- a/docs/versioned_docs/version-CE/reference/toolbox.md
+++ b/docs/versioned_docs/version-CE/reference/toolbox.md
@@ -160,6 +160,36 @@ The supported options for `--cleanup-by` are:
 - `STORE_TIME`: (default) delete oldest files first
 - `ACCESS_TIME`: delete oldest accessed files first
 
+### Error handling {#cache-error-handling}
+
+By default, cache commands are **best-effort**: if the cache server can't be reached, or an operation otherwise fails, the command logs the error and exits with status `0` so the job continues without the cache. This prevents a cache outage from failing your pipeline.
+
+A cache *miss* is not an error: `has_key` exits with a non-zero status when the key is absent, and `restore` exits with status `0` when nothing matches.
+
+To make cache errors (for example, a failed connection to the cache server) fail the job instead, set [`CACHE_FAIL_ON_ERROR`](./env-vars#cache-fail-on-error) to `true`. Any cache command that then encounters an error exits with a non-zero status:
+
+```yaml
+blocks:
+  - name: Build
+    task:
+      env_vars:
+        - name: CACHE_FAIL_ON_ERROR
+          value: "true"
+      jobs:
+        - name: bundle
+          commands:
+            - cache restore gems-$SEMAPHORE_GIT_BRANCH
+            - bundle install
+            - cache store gems-$SEMAPHORE_GIT_BRANCH vendor/bundle
+```
+
+You can also export it for specific commands only:
+
+```shell
+export CACHE_FAIL_ON_ERROR=true
+cache restore gems-$SEMAPHORE_GIT_BRANCH
+```
+
 ### Environment variables {#cache-env-vars}
 
 The cache tool depends on the following environment variables:
@@ -167,6 +197,7 @@ The cache tool depends on the following environment variables:
 - [`SEMAPHORE_CACHE_URL`](./env-vars#cache-url)
 - [`SEMAPHORE_CACHE_USERNAME`](./env-vars#cache-username)
 - [`SEMAPHORE_CACHE_PRIVATE_KEY_PATH`](./env-vars#cache-private-key-path)
+- [`CACHE_FAIL_ON_ERROR`](./env-vars#cache-fail-on-error) (optional) — fail the job on cache errors instead of continuing. See [Error handling](#cache-error-handling).
 
 ## checkout {#checkout}
 

--- a/docs/versioned_docs/version-EE-1.4/reference/env-vars.md
+++ b/docs/versioned_docs/version-EE-1.4/reference/env-vars.md
@@ -562,6 +562,13 @@ The username is used for connecting to the cache server.
 
 The path in the server to the SSH key file to access the cache server.
 
+### Fail on error {#cache-fail-on-error}
+
+- **Environment variable**: `CACHE_FAIL_ON_ERROR`
+- **Example**: `true`
+
+When set to `true`, cache commands exit with a non-zero status if an operation fails — for example, when the cache server is unreachable. By default this variable is unset and cache commands are best-effort: they log the error and exit with status `0` so the job continues without the cache. A cache miss is not considered an error. See [cache error handling](./toolbox#cache-error-handling) for details.
+
 ## Semaphore Docker registry variables {#registry-variables}
 
 These variables can be used to access the [Semaphore Docker registry](../using-semaphore/containers/docker).

--- a/docs/versioned_docs/version-EE-1.4/reference/toolbox.md
+++ b/docs/versioned_docs/version-EE-1.4/reference/toolbox.md
@@ -160,6 +160,36 @@ The supported options for `--cleanup-by` are:
 - `STORE_TIME`: (default) delete oldest files first
 - `ACCESS_TIME`: delete oldest accessed files first
 
+### Error handling {#cache-error-handling}
+
+By default, cache commands are **best-effort**: if the cache server can't be reached, or an operation otherwise fails, the command logs the error and exits with status `0` so the job continues without the cache. This prevents a cache outage from failing your pipeline.
+
+A cache *miss* is not an error: `has_key` exits with a non-zero status when the key is absent, and `restore` exits with status `0` when nothing matches.
+
+To make cache errors (for example, a failed connection to the cache server) fail the job instead, set [`CACHE_FAIL_ON_ERROR`](./env-vars#cache-fail-on-error) to `true`. Any cache command that then encounters an error exits with a non-zero status:
+
+```yaml
+blocks:
+  - name: Build
+    task:
+      env_vars:
+        - name: CACHE_FAIL_ON_ERROR
+          value: "true"
+      jobs:
+        - name: bundle
+          commands:
+            - cache restore gems-$SEMAPHORE_GIT_BRANCH
+            - bundle install
+            - cache store gems-$SEMAPHORE_GIT_BRANCH vendor/bundle
+```
+
+You can also export it for specific commands only:
+
+```shell
+export CACHE_FAIL_ON_ERROR=true
+cache restore gems-$SEMAPHORE_GIT_BRANCH
+```
+
 ### Environment variables {#cache-env-vars}
 
 The cache tool depends on the following environment variables:
@@ -167,6 +197,7 @@ The cache tool depends on the following environment variables:
 - [`SEMAPHORE_CACHE_URL`](./env-vars#cache-url)
 - [`SEMAPHORE_CACHE_USERNAME`](./env-vars#cache-username)
 - [`SEMAPHORE_CACHE_PRIVATE_KEY_PATH`](./env-vars#cache-private-key-path)
+- [`CACHE_FAIL_ON_ERROR`](./env-vars#cache-fail-on-error) (optional) — fail the job on cache errors instead of continuing. See [Error handling](#cache-error-handling).
 
 ## checkout {#checkout}
 

--- a/docs/versioned_docs/version-EE/reference/env-vars.md
+++ b/docs/versioned_docs/version-EE/reference/env-vars.md
@@ -562,6 +562,13 @@ The username is used for connecting to the cache server.
 
 The path in the server to the SSH key file to access the cache server.
 
+### Fail on error {#cache-fail-on-error}
+
+- **Environment variable**: `CACHE_FAIL_ON_ERROR`
+- **Example**: `true`
+
+When set to `true`, cache commands exit with a non-zero status if an operation fails — for example, when the cache server is unreachable. By default this variable is unset and cache commands are best-effort: they log the error and exit with status `0` so the job continues without the cache. A cache miss is not considered an error. See [cache error handling](./toolbox#cache-error-handling) for details.
+
 ## Semaphore Docker registry variables {#registry-variables}
 
 These variables can be used to access the [Semaphore Docker registry](../using-semaphore/containers/docker).

--- a/docs/versioned_docs/version-EE/reference/toolbox.md
+++ b/docs/versioned_docs/version-EE/reference/toolbox.md
@@ -160,6 +160,36 @@ The supported options for `--cleanup-by` are:
 - `STORE_TIME`: (default) delete oldest files first
 - `ACCESS_TIME`: delete oldest accessed files first
 
+### Error handling {#cache-error-handling}
+
+By default, cache commands are **best-effort**: if the cache server can't be reached, or an operation otherwise fails, the command logs the error and exits with status `0` so the job continues without the cache. This prevents a cache outage from failing your pipeline.
+
+A cache *miss* is not an error: `has_key` exits with a non-zero status when the key is absent, and `restore` exits with status `0` when nothing matches.
+
+To make cache errors (for example, a failed connection to the cache server) fail the job instead, set [`CACHE_FAIL_ON_ERROR`](./env-vars#cache-fail-on-error) to `true`. Any cache command that then encounters an error exits with a non-zero status:
+
+```yaml
+blocks:
+  - name: Build
+    task:
+      env_vars:
+        - name: CACHE_FAIL_ON_ERROR
+          value: "true"
+      jobs:
+        - name: bundle
+          commands:
+            - cache restore gems-$SEMAPHORE_GIT_BRANCH
+            - bundle install
+            - cache store gems-$SEMAPHORE_GIT_BRANCH vendor/bundle
+```
+
+You can also export it for specific commands only:
+
+```shell
+export CACHE_FAIL_ON_ERROR=true
+cache restore gems-$SEMAPHORE_GIT_BRANCH
+```
+
 ### Environment variables {#cache-env-vars}
 
 The cache tool depends on the following environment variables:
@@ -167,6 +197,7 @@ The cache tool depends on the following environment variables:
 - [`SEMAPHORE_CACHE_URL`](./env-vars#cache-url)
 - [`SEMAPHORE_CACHE_USERNAME`](./env-vars#cache-username)
 - [`SEMAPHORE_CACHE_PRIVATE_KEY_PATH`](./env-vars#cache-private-key-path)
+- [`CACHE_FAIL_ON_ERROR`](./env-vars#cache-fail-on-error) (optional) — fail the job on cache errors instead of continuing. See [Error handling](#cache-error-handling).
 
 ## checkout {#checkout}
 


### PR DESCRIPTION
## What

Documents the cache toolbox's error-handling behavior and the existing `CACHE_FAIL_ON_ERROR` opt-in.

The cache commands (`cache restore`, `cache has_key`, `cache store`, …) are **best-effort by default**: on a failure such as an unreachable cache server, they log the error and exit `0` so the job continues without the cache. That default is intentional (a cache outage shouldn't fail your pipeline), but it was undocumented — so users reasonably expected `cache has_key` / `cache restore` to exit non-zero on a connection error.

`CACHE_FAIL_ON_ERROR=true` already flips this: with it set, any cache command that hits an error exits non-zero. This PR just documents the behavior and the flag.

## Changes

- **`reference/toolbox.md`** — new *Error handling* subsection in the cache reference: best-effort default, `CACHE_FAIL_ON_ERROR=true` opt-in (with `env_vars` and per-command `export` examples), and a note that a cache *miss* is not an error.
- **`reference/env-vars.md`** — new *Fail on error* entry under Cache variables, cross-linked to the toolbox page.

Mirrored across Cloud (current), CE/EE latest, and CE/EE 1.4 — the behavior applies to self-hosted runners too.

No behavior change; documentation only.

Ref: semaphoreci/toolbox#540

🤖 Generated with [Claude Code](https://claude.com/claude-code)