### PR TITLE
fix(front): disable autocomplete on secret env var value input

### DIFF
--- a/front/assets/js/manage_secret.js
+++ b/front/assets/js/manage_secret.js
@@ -48,7 +48,7 @@ export var ManageSecret = {
         </div>
 
         <div class="w-100 w-50-ns">
-          <input id=${envVarValueId} class="form-control w-100 f5 code" style="${envVar.name? "display: none" : ""}" value='${envVar.value}' name=${envVarValueName} type="text" placeholder="Value">
+          <input id=${envVarValueId} class="form-control w-100 f5 code" style="${envVar.name? "display: none" : ""}" value='${envVar.value}' name=${envVarValueName} type="text" placeholder="Value" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" data-1p-ignore data-lpignore="true">
 
           <div id=${envVarDivId} class="secret-manipulation flex items-center ba b--light-gray ph2 h2 br2 bg-washed-gray" style="${envVar.name ? "" : "display: none"}">
             <div class="flex-auto f5 code overflow-x-scroll">

--- a/front/assets/js/manage_secret.spec.js
+++ b/front/assets/js/manage_secret.spec.js
@@ -1,0 +1,26 @@
+/**
+ * @prettier
+ */
+
+import { expect } from "chai";
+import { ManageSecret } from "./manage_secret";
+
+describe("ManageSecret", () => {
+  describe("envVarElement", () => {
+    it("disables browser autocomplete on the value input so secret values are not cached", () => {
+      let [element, , , , envVarValueId] = ManageSecret.envVarElement(
+        { name: "", value: "", md5: "" },
+        0
+      );
+
+      document.body.innerHTML = element;
+      let valueInput = document.getElementById(envVarValueId);
+
+      expect(valueInput).to.not.be.null;
+      expect(valueInput.getAttribute("autocomplete")).to.eq("off");
+      // Keep password managers from offering to store/fill the value.
+      expect(valueInput.hasAttribute("data-1p-ignore")).to.be.true;
+      expect(valueInput.getAttribute("data-lpignore")).to.eq("true");
+    });
+  });
+});


### PR DESCRIPTION
## Problem

On the secret creation pages — org secrets (`/secrets/new`) and project secrets (`.../projects/<project>/settings/secrets/new`) — the environment-variables **Value** input was a plain `type="text"` field with no autocomplete controls. Browsers therefore cached every value ever entered under the field name `env_vars[i][value]` and offered previously entered secret values as autocomplete suggestions. This leaks secret values across sessions — a security problem.

## Fix

Both forms render the env-var rows client-side via the shared `ManageSecret.envVarElement` factory in `front/assets/js/manage_secret.js`, so a single change covers both controllers. The Value input now carries:

- `autocomplete="off"` — stops the browser saving/suggesting prior values
- `data-1p-ignore` / `data-lpignore="true"` — keep 1Password / LastPass from storing/filling it
- `autocapitalize="off"`, `autocorrect="off"`, `spellcheck="false"` — avoid leaking value fragments to spellcheck/correction services

The file-content input is already `display:none`, and the variable-name field isn't sensitive, so both were left as-is.

## Test

Added `front/assets/js/manage_secret.spec.js` (Mocha + chai + jsdom, matching the existing JS test stack). It renders the markup from `envVarElement` and asserts the Value input carries the autocomplete/ignore attributes. Verified it fails against the unpatched JS (`expected null to equal 'off'`) and passes with the fix.

## Verification

- Ran the front JS suite in Docker: 269 passing, 0 failing.
- CI pipeline green — all Front blocks (Provision Test Image, QA, Security checks) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)