### PR TITLE
chore(public-api/v1alpha): ignore plug_cowboy HTTP/2 :scheme DoS (CVE-2026-32688)

### DIFF
--- a/public-api/v1alpha/.mix-audit.txt
+++ b/public-api/v1alpha/.mix-audit.txt
@@ -26,3 +26,11 @@ GHSA-84f2-rp86-235p
 # cluster ingress L7 body limits; bump blocked by grpc 0.3.1 / cowboy 2.5 — real fix tracked for the
 # dep-bump branch.
 GHSA-468c-vq7p-gh64
+
+# plug_cowboy 2.0.0 — unauthenticated remote DoS via HTTP/2 :scheme atom-table exhaustion (CVE-2026-32688),
+# fixed in 2.8.1. Unreachable: pipelines_api/application.ex starts {Plug.Cowboy, scheme: :http, ...} — the
+# listener serves cleartext HTTP/1.1 behind the gateway and never negotiates HTTP/2, so the :scheme
+# pseudo-header path does not exist. Bump to 2.8.1 (needs plug ~> 1.14 / cowboy ~> 2.7) blocked by
+# grpc 0.3.1 / cowboy 2.5 — real fix tracked for the dep-bump branch. Same advisory already accepted in
+# public-api/v2, guard, front.
+GHSA-q8x4-x7mp-5vg2


### PR DESCRIPTION
The scheduled dependency audit went red on `public-api/v1alpha` for **GHSA-q8x4-x7mp-5vg2** (`CVE-2026-32688`) — Plug.Cowboy unauthenticated remote DoS via HTTP/2 `:scheme` atom-table exhaustion (`plug_cowboy < 2.8.1`, CVSS 8.7).

## Verdict: not reachable here — accept via the standard `.mix-audit.txt` mechanism

The vulnerability is **HTTP/2-only**: `:scheme` is an HTTP/2 pseudo-header, absent in HTTP/1.1. The advisory itself notes "many proxies use HTTP/1.1 internally, and would be unaffected."

`public-api/v1alpha` starts a cleartext HTTP/1.1 listener and never negotiates HTTP/2 — `lib/pipelines_api/application.ex`:

```elixir
{Plug.Cowboy, scheme: :http, plug: PipelinesAPI.Router, options: [port: 4004]}
```

It sits behind the gateway on port 4004, so the vulnerable `:scheme` path does not exist for this service.

## Why not just bump

`plug_cowboy 2.8.1` requires `plug ~> 1.14` / `cowboy ~> 2.7`. v1alpha is pinned to `plug 1.7.1` / `cowboy 2.5.0` because `grpc 0.3.1` requires `cowboy ~> 2.5`. The bump cascades through the whole HTTP stack and is out of scope for a security-hygiene change — it is tracked for the dep-bump branch, consistent with the 8 advisories already deferred in this file for the same reason.

## Precedent

The identical advisory is already accepted in `public-api/v2`, `guard`, and `front`. This adds the one missing entry so the scheduled audit is green for v1alpha too.

Net change: one `GHSA` line + justification comment in `public-api/v1alpha/.mix-audit.txt`.