### PR TITLE
deps(github_hooks): update nokogiri to 1.19.4, net-imap to 0.5.15 and excon to 1.5 to fix CVEs

### DIFF
--- a/github_hooks/Dockerfile
+++ b/github_hooks/Dockerfile
@@ -24,7 +24,7 @@ ENV LANG=C.UTF-8 \
 
 RUN gem update --system 3.5.23
 RUN gem install bundler -v '2.6.2' --no-document
-RUN gem install net-imap -v '0.5.14' --no-document && \
+RUN gem install net-imap -v '0.5.15' --no-document && \
   rm -rf /usr/local/lib/ruby/gems/3.3.0/gems/net-imap-0.4.21 && \
   rm -f /usr/local/lib/ruby/gems/3.3.0/specifications/net-imap-0.4.21.gemspec \
     /usr/local/lib/ruby/gems/3.3.0/specifications/default/net-imap-0.4.21.gemspec

--- a/github_hooks/Gemfile
+++ b/github_hooks/Gemfile
@@ -36,7 +36,7 @@ gem "sentry-rails"
 gem "sentry-sidekiq"
 
 gem "sprockets", "< 4"
-gem "nokogiri", "~> 1.19.0"
+gem "nokogiri", "~> 1.19.4"
 gem "uri", "~> 1.0", ">= 1.0.4"
 
 gem "rt-watchman", :require => "watchman", :github => "renderedtext/watchman", :ref => "74530687a232aea678b6738114c82dfc163657cd"

--- a/github_hooks/Gemfile
+++ b/github_hooks/Gemfile
@@ -8,17 +8,19 @@ gem "rails", ">= 8.0.4.1", "< 8.1"
 gem "rack", "~> 2.2.23"
 gem "sprockets-rails"
 
-gem "excon", "~> 0.81.0"
+gem "excon", "~> 1.5"
 gem "app"
 gem "bunny"
 gem "net-http" # https://github.com/ruby/net-imap/issues/16#issuecomment-803086765
-gem 'net-imap', '~> 0.5.7'
+gem 'net-imap', '~> 0.5.15'
 gem "grpc", "~> 1.62.1"
 gem "googleapis-common-protos-types", "~> 1.18.0"
 gem "httparty", "~> 0.24.0"
 gem "httpclient"
+gem "faraday", ">= 2.14.3"
 gem "json"
-gem "erb", ">= 6.0.4" # CVE-2026-41316: @_init deserialization guard bypass
+gem "concurrent-ruby", ">= 1.3.7"
+gem "erb", ">= 6.0.4"
 gem "kaminari", "~> 1.2.2"
 gem "lograge"
 gem "octokit"

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (2.5.5)
     crack (1.0.0)
       bigdecimal
@@ -138,17 +138,18 @@ GEM
     et-orbi (1.3.0)
       tzinfo
     eventmachine (1.2.7)
-    excon (0.81.0)
+    excon (1.5.0)
+      logger
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.3)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-arm-linux-gnu)
@@ -194,7 +195,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.7)
+    json (2.20.0)
     jwt (3.2.0)
       base64
     kaminari (1.2.2)
@@ -236,7 +237,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.5.14)
+    net-imap (0.5.15)
       date
       net-protocol
     net-pop (0.1.2)
@@ -510,12 +511,14 @@ DEPENDENCIES
   bullet
   bundler (>= 1.8.4)
   bunny
+  concurrent-ruby (>= 1.3.7)
   connection_pool (< 3)
   database_cleaner
   dotenv (~> 3.0)
   erb (>= 6.0.4)
-  excon (~> 0.81.0)
+  excon (~> 1.5)
   factory_bot_rails (< 5)
+  faraday (>= 2.14.3)
   googleapis-common-protos-types (~> 1.18.0)
   grpc (~> 1.62.1)
   grpc-tools
@@ -526,7 +529,7 @@ DEPENDENCIES
   kaminari (~> 1.2.2)
   lograge
   net-http
-  net-imap (~> 0.5.7)
+  net-imap (~> 0.5.15)
   nokogiri (~> 1.19.4)
   octokit
   pg (~> 1.1)

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -246,15 +246,15 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.3-aarch64-linux-gnu)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-gnu)
+    nokogiri (1.19.4-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-musl)
+    nokogiri (1.19.4-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (10.0.0)
       faraday (>= 1, < 3)
@@ -527,7 +527,7 @@ DEPENDENCIES
   lograge
   net-http
   net-imap (~> 0.5.7)
-  nokogiri (~> 1.19.0)
+  nokogiri (~> 1.19.4)
   octokit
   pg (~> 1.1)
   pry-byebug (~> 3.10, >= 3.10.1)


### PR DESCRIPTION
## 📝 Description

<p>Bumps five vulnerable dependencies flagged by <code>bundler-audit</code> so the github_hooks dependency scan passes. All are version bumps with no application-code changes.</p>

Gem | From → To | Advisories
-- | -- | --
nokogiri | 1.19.3 → 1.19.4 | 8 libxml2 use-after-free / OOB-read advisories
net-imap | 0.5.14 → 0.5.15 | CVE-2026-47240/47241/47242 (command injection, DoS)
faraday | 2.14.2 → 2.14.3 | CVE-2026-54297 (NestedParamsEncoder DoS)
concurrent-ruby | 1.3.6 → 1.3.7 | CVE-2026-54904/54905/54906 (lock/atomic correctness)
excon | 0.81.0 → 1.5.0 | CVE-2026-54171 (sensitive-header leak on redirect)


<p><code>excon</code> is a major upgrade, but github_hooks only uses its stable module-level API (<code>Excon.get/post</code>, <code>Response#status/body/data</code>, <code>Excon::Error</code>), which is unchanged in 1.x - verified by a runtime smoke test and the excon-mocked specs.</p>

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
