### PR TITLE
fix(zebra): isolate self-hosted dispatch per organization

### DIFF
--- a/zebra/lib/zebra/workers/db_worker.ex
+++ b/zebra/lib/zebra/workers/db_worker.ex
@@ -69,6 +69,9 @@ defmodule Zebra.Workers.DbWorker do
   defp submit_batch_size(name, v, {machine_type, machine_os_image}),
     do: Watchman.submit({"#{name}.batch_size", ["#{machine_type}-#{machine_os_image}"]}, v)
 
+  defp submit_batch_size(name, v, {_organization_id, machine_type, machine_os_image}),
+    do: Watchman.submit({"#{name}.batch_size", ["#{machine_type}-#{machine_os_image}"]}, v)
+
   def process(worker, id) do
     Watchman.benchmark("#{worker.metric_name}.process.duration", fn ->
       Repo.transaction(fn ->
@@ -116,8 +119,14 @@ defmodule Zebra.Workers.DbWorker do
           from(r in worker.schema,
             where: field(r, ^worker.state_field) == ^worker.state_value,
             where: like(field(r, ^worker.machine_type_field), @self_hosted_prefix),
-            distinct: [field(r, ^worker.machine_type_field), field(r, ^machine_os_image_field)],
-            select: {field(r, ^worker.machine_type_field), field(r, ^machine_os_image_field)}
+            distinct: [
+              r.organization_id,
+              field(r, ^worker.machine_type_field),
+              field(r, ^machine_os_image_field)
+            ],
+            select:
+              {r.organization_id, field(r, ^worker.machine_type_field),
+               field(r, ^machine_os_image_field)}
           )
         )
 
@@ -186,6 +195,31 @@ defmodule Zebra.Workers.DbWorker do
     base_query =
       from(r in worker.schema,
         where: field(r, ^worker.state_field) == ^worker.state_value,
+        where: field(r, ^worker.machine_type_field) == ^machine_type
+      )
+
+    filtered_query =
+      maybe_filter_machine_os_image(base_query, machine_os_image_field, machine_os_image)
+
+    Repo.all(
+      from(r in filtered_query,
+        order_by: [{^order_dir, ^order_by}],
+        select: r.id,
+        limit: ^records_per_tick
+      )
+    )
+  end
+
+  defp query_jobs(worker, {organization_id, machine_type, machine_os_image}) do
+    order_by = worker.order_by || :id
+    order_dir = worker.order_direction || :asc
+    records_per_tick = worker.records_per_tick || 100
+    machine_os_image_field = worker.machine_os_image_field
+
+    base_query =
+      from(r in worker.schema,
+        where: field(r, ^worker.state_field) == ^worker.state_value,
+        where: r.organization_id == ^organization_id,
         where: field(r, ^worker.machine_type_field) == ^machine_type
       )
 

--- a/zebra/lib/zebra/workers/dispatcher.ex
+++ b/zebra/lib/zebra/workers/dispatcher.ex
@@ -21,7 +21,7 @@ defmodule Zebra.Workers.Dispatcher do
       metric_name: "dispatcher",
       naptime: 1000,
       records_per_tick: 100,
-      isolate_machine_types: isolate_machine_types(),
+      isolate_machine_types: true,
       processor: &process/1
     }
   end
@@ -38,8 +38,6 @@ defmodule Zebra.Workers.Dispatcher do
         :all
     end
   end
-
-  def isolate_machine_types, do: System.get_env("DISPATCH_SELF_HOSTED_ONLY") != "true"
 
   def start_link do
     init() |> Zebra.Workers.DbWorker.start_link()

--- a/zebra/priv/legacy_repo/migrations/20260625090000_add_scheduled_dispatch_index_at_jobs_table.exs
+++ b/zebra/priv/legacy_repo/migrations/20260625090000_add_scheduled_dispatch_index_at_jobs_table.exs
@@ -1,0 +1,14 @@
+defmodule Zebra.LegacyRepo.Migrations.AddScheduledDispatchIndexAtJobsTable do
+  use Ecto.Migration
+  @disable_migration_lock true
+  @disable_ddl_transaction true
+
+  def change do
+    create index(:jobs, [:machine_type, :organization_id, :machine_os_image, :scheduled_at],
+      name: "index_jobs_on_machine_type_org_image_when_scheduled",
+      concurrently: true,
+      where: "aasm_state = 'scheduled'",
+      if_not_exists: true
+    )
+  end
+end

--- a/zebra/priv/legacy_repo/migrations/20260625090000_add_scheduled_dispatch_index_at_jobs_table.exs
+++ b/zebra/priv/legacy_repo/migrations/20260625090000_add_scheduled_dispatch_index_at_jobs_table.exs
@@ -4,11 +4,12 @@ defmodule Zebra.LegacyRepo.Migrations.AddScheduledDispatchIndexAtJobsTable do
   @disable_ddl_transaction true
 
   def change do
-    create index(:jobs, [:machine_type, :organization_id, :machine_os_image, :scheduled_at],
-      name: "index_jobs_on_machine_type_org_image_when_scheduled",
-      concurrently: true,
-      where: "aasm_state = 'scheduled'",
-      if_not_exists: true
+    create_if_not_exists(
+      index(:jobs, [:machine_type, :organization_id, :machine_os_image, :scheduled_at],
+        name: "index_jobs_on_machine_type_org_image_when_scheduled",
+        concurrently: true,
+        where: "aasm_state = 'scheduled'"
+      )
     )
   end
 end

--- a/zebra/test/zebra/workers/dispatcher_test.exs
+++ b/zebra/test/zebra/workers/dispatcher_test.exs
@@ -324,6 +324,141 @@ defmodule Zebra.Workers.DispatcherTest do
       assert Enum.count(requested_os_images, &(&1 == "ubuntu2404")) == 10
     end
 
+    test "isolates self-hosted dispatching per organization so one org's backlog can't starve another" do
+      System.put_env("DISPATCH_SELF_HOSTED_ONLY", "true")
+      System.put_env("DISPATCH_CLOUD_ONLY", "false")
+
+      org_a = Ecto.UUID.generate()
+      org_b = Ecto.UUID.generate()
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      older = Timex.shift(now, seconds: -300)
+
+      # Org A: a large backlog of OLDER self-hosted jobs, same machine_type and
+      # os_image as org B's jobs (only the organization differs).
+      org_a_jobs =
+        Enum.map(1..5, fn _ ->
+          {:ok, job} =
+            Support.Factories.Job.create(:scheduled, %{
+              organization_id: org_a,
+              machine_type: "s1-local-testing",
+              machine_os_image: "ubuntu2004",
+              scheduled_at: older
+            })
+
+          job
+        end)
+
+      # Org B: a couple of NEWER self-hosted jobs of the same type name.
+      org_b_jobs =
+        Enum.map(1..2, fn _ ->
+          {:ok, job} =
+            Support.Factories.Job.create(:scheduled, %{
+              organization_id: org_b,
+              machine_type: "s1-local-testing",
+              machine_os_image: "ubuntu2004",
+              scheduled_at: now
+            })
+
+          job
+        end)
+
+      GrpcMock.stub(Support.FakeServers.SelfHosted, :occupy_agent, fn _, _ ->
+        %InternalApi.SelfHosted.OccupyAgentResponse{
+          agent_id: @agent_id,
+          agent_name: "self-hosted-agent"
+        }
+      end)
+
+      # records_per_tick smaller than org A's backlog: under a single global FIFO
+      # the oldest jobs (all org A) would consume the entire per-tick budget and
+      # org B's newer jobs would never be dispatched. With per-org isolation each
+      # {organization_id, machine_type, os_image} key gets its own budget.
+      worker = %{Worker.init() | records_per_tick: 3}
+
+      with_stubbed_http_calls(fn ->
+        Zebra.Workers.DbWorker.tick(worker)
+      end)
+
+      # Org B is not starved: all of its jobs were dispatched this tick.
+      Enum.each(org_b_jobs, fn job ->
+        job = Job.reload(job)
+        assert Job.started?(job) == true
+        assert job.agent_id == @agent_id
+      end)
+
+      # Org A gets its own independent budget (records_per_tick of its backlog).
+      started_org_a = Enum.count(org_a_jobs, fn job -> Job.started?(Job.reload(job)) end)
+      assert started_org_a == 3
+    end
+
+    test "cloud dispatching is not isolated per organization (unchanged behaviour)" do
+      System.put_env("DISPATCH_SELF_HOSTED_ONLY", "false")
+      System.put_env("DISPATCH_CLOUD_ONLY", "true")
+
+      org_a = Ecto.UUID.generate()
+      org_b = Ecto.UUID.generate()
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      older = Timex.shift(now, seconds: -300)
+
+      # Two orgs, same cloud machine_type and os_image, org A older.
+      org_a_jobs =
+        Enum.map(1..3, fn _ ->
+          {:ok, job} =
+            Support.Factories.Job.create(:scheduled, %{
+              organization_id: org_a,
+              machine_type: "e1-standard-2",
+              machine_os_image: "ubuntu2004",
+              scheduled_at: older
+            })
+
+          job
+        end)
+
+      org_b_jobs =
+        Enum.map(1..3, fn _ ->
+          {:ok, job} =
+            Support.Factories.Job.create(:scheduled, %{
+              organization_id: org_b,
+              machine_type: "e1-standard-2",
+              machine_os_image: "ubuntu2004",
+              scheduled_at: now
+            })
+
+          job
+        end)
+
+      GrpcMock.stub(Support.FakeServers.ChmuraApi, :occupy_agent, fn _, _ ->
+        %InternalApi.Chmura.OccupyAgentResponse{
+          agent: %InternalApi.Chmura.Agent{
+            id: @agent_id,
+            ip_address: "1.2.3.4",
+            ssh_port: 80,
+            ctrl_port: 80,
+            auth_token: "asdas"
+          }
+        }
+      end)
+
+      worker = %{Worker.init() | records_per_tick: 3}
+
+      with_stubbed_http_calls(fn ->
+        Zebra.Workers.DbWorker.tick(worker)
+      end)
+
+      # Cloud is isolated only by {machine_type, os_image}, NOT by org: the single
+      # per-key budget is consumed by the oldest jobs (org A), so org B's same-type
+      # jobs are NOT dispatched in this tick. This locks the cloud path as unchanged.
+      Enum.each(org_a_jobs, fn job ->
+        assert Job.started?(Job.reload(job)) == true
+      end)
+
+      Enum.each(org_b_jobs, fn job ->
+        assert Job.scheduled?(Job.reload(job)) == true
+      end)
+    end
+
     test "dispatches self-hosted jobs when os_image is blank or nil" do
       System.put_env("DISPATCH_SELF_HOSTED_ONLY", "false")
       System.put_env("DISPATCH_CLOUD_ONLY", "false")


### PR DESCRIPTION
## What

The dispatcher (`DbWorker` polling jobs in the `scheduled` state) drains queued jobs per machine-type key. Cloud jobs are isolated per `{machine_type, machine_os_image}` — each gets its own per-tick batch, so one type cannot starve another. Self-hosted jobs had that isolation **off**: they were drained as a single global FIFO across **all organizations**, ordered by `scheduled_at`. One organization with a large backlog therefore head-of-line-blocked every other organization's self-hosted jobs (a backlog of a couple thousand queued agents could starve others' self-hosted jobs for minutes).

This change isolates the self-hosted path per `{organization_id, machine_type, machine_os_image}`. Each key gets its own `records_per_tick` batch per tick, so a big backlog in one organization no longer delays others.

## Changes

- **`query_machine_types/1` (`:self_hosted`)** now selects `DISTINCT {organization_id, machine_type, machine_os_image}` (was `{machine_type, machine_os_image}`).
- **New `query_jobs/2` clause** matching the 3-element self-hosted key, adding `where organization_id == ^org_id` alongside the existing `machine_type` / `machine_os_image` filters + `order_by scheduled_at` + `limit`.
- **New `submit_batch_size/3` clause** for the 3-element key (the existing 2-tuple clause would not match a 3-tuple and would raise). The metric tag shape is unchanged (`"<machine_type>-<os_image>"`, no org → no cardinality change).
- **`isolate_machine_types`** is now always `true` for the dispatcher. It was already true for cloud and the dev `:all` mode; only the self-hosted-only deployment had it forced off. The previous env-conditional helper is removed.

## Cloud path is unchanged

The `:cloud` branch of `query_machine_types/1`, the `nil` and 2-tuple `query_jobs/2` clauses, the `FOR UPDATE SKIP LOCKED` claim, and all job state transitions are untouched. A regression test locks in that cloud dispatch stays org-blind (isolated only by `{machine_type, machine_os_image}`).

## Supporting index (bundled)

Add a partial composite index, created `CONCURRENTLY` (jobs is a large, hot, shared table):

```
on jobs (machine_type, organization_id, machine_os_image, scheduled_at)
WHERE aasm_state = 'scheduled'
```

Rationale: without it, each per-key drain query scans the entire scheduled set (via the partial `aasm_state` index), filters `machine_type` + `organization_id` in memory, then sorts — i.e. `O(#keys × scheduled-set)` per tick once isolation fans out. This index makes each per-key query a direct range scan (no in-memory filter, no sort) and also serves the per-tick `DISTINCT`.

## Per-tick fan-out

Distinct key counts are modest (tens), and with the index each per-key query is a cheap range scan, so the existing serial `Enum.each` over keys is kept — no cap, no extra parallelism added. The `dispatcher.tick.duration` Watchman benchmark already wraps the whole tick and can be watched post-deploy.

## Deploy

No manifest change. Self-hosted isolation is gated by the existing `DISPATCH_SELF_HOSTED_ONLY` deployment; this is a normal image roll.

## Tests

Extended the dispatcher test harness:
- self-hosted jobs are isolated per `{org, type, os_image}` — one org's older/larger backlog does **not** block another org's jobs of the same type name (this test fails on the pre-change global-FIFO behaviour and passes after).
- cloud dispatch is **not** org-isolated (unchanged behaviour) — regression guard.

Results (run via `make test.ex`, `mix test --warnings-as-errors`, Postgres 9.6):
- `test/zebra/workers/dispatcher_test.exs`: **14 tests, 0 failures**
- full zebra suite: **497 tests, 0 failures**

## Unrelated smell noticed (not fixed here)

`Dispatcher.duration_bucket/1` maps `sec >= 3 and sec < 10` to `"from_0s_to_3s"` — looks like a copy/paste slip (should be a `3s..10s` bucket). Left untouched to keep this PR focused; flagging for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)