### PR TITLE
chore(deps): clear CVEs blocking deps checks for #1029 (hackney accepts + linkify-it bump)

### DIFF
--- a/front/.mix-audit.txt
+++ b/front/.mix-audit.txt
@@ -22,3 +22,19 @@ GHSA-84f2-rp86-235p
 # /support file_input loads Plug.Parsers multipart. Mitigated at cluster ingress L7 body limits;
 # real fix tracked for the plug dep-bump branch.
 GHSA-468c-vq7p-gh64
+
+# --- hackney 1.25.0 advisories, all fixed in 4.0.1 ---
+# Bump to 4.0.1 is blocked: httpoison ~> 1.x requires hackney ~> 1.17, so hackney cannot move to
+# 4.x without a fleet-wide httpoison/grpc upgrade. Real fix tracked for the dep-bump branch.
+# front's outbound HTTP (httpoison/hackney) targets internal backend services and configured
+# third-party endpoints, not user-supplied URLs/queries/hosts.
+#
+# ssl:connect/2 post-handshake upgrade has no timeout (operational DoS; outbound bounded to known hosts)
+GHSA-gp9c-pm5m-5cxr
+# CR/LF injection in query parameter (query params to hackney are not user-controlled)
+GHSA-j9wq-vxxc-94wf
+# SSRF allowlist bypass in hackney_url:normalize/2 via percent-encoded host (target hosts are not
+# user-supplied)
+GHSA-pj7v-xfvx-wmjq
+# CRLF / header injection via unvalidated `domain` and `path` options (domain/path not user-controlled)
+GHSA-mp55-p8c9-rfw2

--- a/front/assets/package-lock.json
+++ b/front/assets/package-lock.json
@@ -9233,9 +9233,20 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }

--- a/guard/.mix-audit.txt
+++ b/guard/.mix-audit.txt
@@ -6,3 +6,19 @@ GHSA-rhv4-8758-jx7v
 
 # postgrex 0.20.0 — channel-name SQL injection in Notifications.listen/3 (not used by guard)
 GHSA-r73h-97w8-m54h
+
+# --- hackney 1.22.0 advisories, all fixed in 4.0.1 ---
+# Bump to 4.0.1 is blocked: httpoison ~> 1.x requires hackney ~> 1.17, so hackney cannot move to
+# 4.x without a fleet-wide httpoison/grpc upgrade. Real fix tracked for the dep-bump branch.
+#
+# ssl:connect/2 post-handshake upgrade has no timeout (operational DoS; outbound bounded, same
+# class as GHSA-9fm9 above)
+GHSA-gp9c-pm5m-5cxr
+# CR/LF injection in query parameter (no user-controlled data fed to hackney query params from lib/)
+GHSA-j9wq-vxxc-94wf
+# SSRF allowlist bypass in hackney_url:normalize/2 via percent-encoded host (no user-controlled URL
+# fed to hackney from lib/)
+GHSA-pj7v-xfvx-wmjq
+# CRLF / header injection via unvalidated `domain` and `path` options (no user-controlled domain/path
+# fed to hackney from lib/)
+GHSA-mp55-p8c9-rfw2

--- a/public-api/v1alpha/.mix-audit.txt
+++ b/public-api/v1alpha/.mix-audit.txt
@@ -11,3 +11,20 @@ GHSA-rhv4-8758-jx7v
 # latest release and is still flagged). v1alpha does not generate Set-Cookie headers from user input;
 # cowlib is pulled in only via cowboy/grpc_gun.
 GHSA-g2wm-735q-3f56
+
+# --- hackney 1.18.1 advisories, all fixed in 4.0.1 ---
+# Bump to 4.0.1 is blocked: httpoison ~> 1.3 requires hackney ~> 1.8, so hackney cannot move to
+# 4.x without a fleet-wide httpoison/grpc upgrade. Real fix tracked for the dep-bump branch.
+#
+# ssl:connect/2 post-handshake upgrade has no timeout (operational DoS; outbound bounded to Sentry
+# DSN + tzdata IANA URL, same class as GHSA-9fm9 above)
+GHSA-gp9c-pm5m-5cxr
+# CR/LF injection in query parameter (no user-controlled URL fed to hackney; HTTPoison not called
+# from lib/, same as GHSA-vq52 above)
+GHSA-j9wq-vxxc-94wf
+# SSRF allowlist bypass in hackney_url:normalize/2 via percent-encoded host (no user-controlled URL
+# fed to hackney from lib/)
+GHSA-pj7v-xfvx-wmjq
+# CRLF / header injection via unvalidated `domain` and `path` options (no user-controlled domain/path
+# fed to hackney from lib/)
+GHSA-mp55-p8c9-rfw2


### PR DESCRIPTION
Clears the dependency-scan failures (`mix_audit` + Trivy) on the three services touched by the org-management API work in #1029: **guard**, **public-api/v1alpha**, **front**.

## 1. hackney `<4.0.1` advisories — accepted in `.mix-audit.txt`

| advisory | severity | issue |
|---|---|---|
| GHSA-gp9c-pm5m-5cxr | high | `ssl:connect/2` post-handshake upgrade has no timeout |
| GHSA-j9wq-vxxc-94wf | moderate | CR/LF injection in query parameter |
| GHSA-pj7v-xfvx-wmjq | moderate | SSRF allowlist bypass via percent-encoded host |
| GHSA-mp55-p8c9-rfw2 | low | CRLF/header injection via `domain`/`path` |

Bumping hackney to 4.0.1 is not possible in isolation: `httpoison ~> 1.x` requires `hackney ~> 1.17`, and the grpc-pinned dep tree (`grpc 0.5.0-beta.1` → `cowboy ~> 2.7.0`) forbids the companion cowboy bump. A real upgrade needs a fleet-wide httpoison/grpc bump (tracked separately). Accepted with per-service reachability justifications, matching the existing accept-with-reason entries already in those files.

## 2. linkify-it ReDoS — bumped (not ignored)

`CVE-2026-48801` (HIGH, ReDoS) in `linkify-it 5.0.0`, transitive via `markdown-it ^14.1.0` which front uses to render markdown. Because it is plausibly reachable on user-influenced content, bumped to the patched **5.0.1** (semver-compatible, lock-only) rather than ignored.

## Scope

Only the three services whose deps checks are currently blocked. Other hackney-using services are out of scope.

Unblocks the deps checks for #1029.