### PR TITLE
fix(rbac): scope group operations by organization

### DIFF
--- a/ee/rbac/lib/rbac/grpc_servers/groups_server.ex
+++ b/ee/rbac/lib/rbac/grpc_servers/groups_server.ex
@@ -49,7 +49,7 @@ defmodule Rbac.GrpcServers.GroupsServer do
       if group_id == "" do
         Group.fetch_all_org_groups(org_id, page.page_no, page.page_size)
       else
-        case Group.fetch_group(group_id) do
+        case Group.fetch_group(group_id, org_id) do
           {:ok, group} -> [group]
           {:error, _} -> []
         end
@@ -63,26 +63,37 @@ defmodule Rbac.GrpcServers.GroupsServer do
       do: grpc_error!(:invalid_argument, "Required group information not provided")
 
     validate_uuid!([req.org_id, req.requester_id, req.group.id])
-    authorize!(@manage_groups_permission, req.requester_id, req.org_id)
-    check_if_members_are_in_org!(req.members_to_add, req.org_id)
 
-    with {:ok, _} <- Group.fetch_group(req.group.id),
-         {:ok, group} <-
-           Group.modify_metadata(req.group.id, req.org_id, req.group.name, req.group.description) do
-      {:ok, _} = create_request(req.members_to_remove, group.id, :remove_user, req.requester_id)
-      {:ok, _} = create_request(req.members_to_add, group.id, :add_user, req.requester_id)
+    case Group.fetch_group(req.group.id, req.org_id) do
+      {:ok, group} ->
+        authorize!(@manage_groups_permission, req.requester_id, req.org_id)
+        check_if_members_are_in_org!(req.members_to_add, req.org_id)
 
-      %Groups.ModifyGroupResponse{group: construct_grpc_group(group)}
-    else
+        case Group.modify_metadata(group.id, req.org_id, req.group.name, req.group.description) do
+          {:ok, modified_group} ->
+            {:ok, _} =
+              create_request(
+                req.members_to_remove,
+                modified_group.id,
+                :remove_user,
+                req.requester_id
+              )
+
+            {:ok, _} =
+              create_request(req.members_to_add, modified_group.id, :add_user, req.requester_id)
+
+            %Groups.ModifyGroupResponse{group: construct_grpc_group(modified_group)}
+
+          {:error, :name_taken} ->
+            grpc_error!(:invalid_argument, "The new group name is already in use")
+
+          {:error, _error_msg} ->
+            Watchman.increment("modify_group.failure")
+            grpc_error!(:internal)
+        end
+
       {:error, :not_found} ->
-        grpc_error!(:invalid_argument, "The group you are trying to modify does not exist")
-
-      {:error, :name_taken} ->
-        grpc_error!(:invalid_argument, "The new group name is already in use")
-
-      {:error, _error_msg} ->
-        Watchman.increment("modify_group.failure")
-        grpc_error!(:internal)
+        grpc_error!(:not_found, "The group you are trying to modify does not exist")
     end
   end
 

--- a/ee/rbac/lib/rbac/store/group.ex
+++ b/ee/rbac/lib/rbac/store/group.ex
@@ -28,6 +28,18 @@ defmodule Rbac.Store.Group do
     end
   end
 
+  def fetch_group(group_id, org_id) do
+    Rbac.Repo.Group
+    |> where([g], g.id == ^group_id and g.org_id == ^org_id)
+    |> join(:inner, [g], s in assoc(g, :subject))
+    |> select([g, s], %{id: g.id, org_id: g.org_id, name: s.name, description: g.description})
+    |> Rbac.Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      group -> {:ok, group}
+    end
+  end
+
   def fetch_group_by_name(name, org_id) do
     Rbac.Repo.Group
     |> where([g], g.org_id == ^org_id)

--- a/ee/rbac/test/rbac/grpc_servers/groups_server_test.exs
+++ b/ee/rbac/test/rbac/grpc_servers/groups_server_test.exs
@@ -83,6 +83,14 @@ defmodule Rbac.GrpcServers.GroupsServer.Test do
       {:ok, response} = state.grpc_channel |> Stub.list_groups(request)
       assert response.groups == []
     end
+
+    test "returns an empty list for a group that belongs to another organization", state do
+      {:ok, group} = Factories.Group.insert(org_id: Ecto.UUID.generate())
+
+      request = %Request{org_id: @org_id, group_id: group.id}
+      {:ok, response} = state.grpc_channel |> Stub.list_groups(request)
+      assert response.groups == []
+    end
   end
 
   describe "modify_group/2" do
@@ -159,7 +167,7 @@ defmodule Rbac.GrpcServers.GroupsServer.Test do
 
     test "unauthorized requests", state do
       request = %Request{
-        group: %Groups.Group{id: Ecto.UUID.generate()},
+        group: %Groups.Group{id: state.group.id},
         requester_id: @requester_id,
         org_id: @org_id
       }
@@ -177,8 +185,46 @@ defmodule Rbac.GrpcServers.GroupsServer.Test do
       }
 
       {:error, %{status: status, message: msg}} = state.grpc_channel |> Stub.modify_group(request)
-      assert status == GRPC.Status.invalid_argument()
+      assert status == GRPC.Status.not_found()
       assert msg == "The group you are trying to modify does not exist"
+    end
+
+    test "returns not found when modifying a group in another organization", state do
+      {:ok, other_group} = Support.Factories.Group.insert(org_id: Ecto.UUID.generate())
+
+      request = %Request{
+        group: %Groups.Group{id: other_group.id, name: "New Name"},
+        requester_id: @requester_id,
+        org_id: @org_id
+      }
+
+      {:error, %{status: status}} = state.grpc_channel |> Stub.modify_group(request)
+      assert status == GRPC.Status.not_found()
+
+      {:ok, unchanged} = Rbac.Store.Group.fetch_group(other_group.id)
+      assert unchanged.name == other_group.name
+    end
+
+    test "does not add members to a group in another organization", state do
+      {:ok, other_group} = Support.Factories.Group.insert(org_id: Ecto.UUID.generate())
+      {:ok, member} = Support.Factories.RbacUser.insert()
+
+      Support.Rbac.create_org_roles(@org_id)
+      Support.Rbac.assign_org_role_by_name(@org_id, member.id, "Member")
+
+      request = %Request{
+        group: %Groups.Group{id: other_group.id},
+        members_to_add: [member.id],
+        requester_id: @requester_id,
+        org_id: @org_id
+      }
+
+      {:error, %{status: status}} = state.grpc_channel |> Stub.modify_group(request)
+      assert status == GRPC.Status.not_found()
+
+      refute Rbac.Repo.GroupManagementRequest
+             |> where([r], r.group_id == ^other_group.id and r.action == :add_user)
+             |> Rbac.Repo.exists?()
     end
 
     test "user that is being added to the group is not org member", state do


### PR DESCRIPTION
Brings group fetch, modify, and list in line with the organization scoping already used by `destroy_group` and the role operations — group lookups now resolve against the group's own organization.

## ✅ Checklist
- [x] I have tested this change