### PR TITLE
chore(ee/rbac/deps): accept hackney <4.0.1 advisories blocking deps checks

### DIFF
--- a/ee/rbac/.mix-audit.txt
+++ b/ee/rbac/.mix-audit.txt
@@ -14,3 +14,21 @@ GHSA-r73h-97w8-m54h
 # bump that is out of scope for a security patch PR. ee/rbac does not parse
 # untrusted decimal strings.
 GHSA-rhv4-8758-jx7v
+
+# --- hackney 1.25.0 advisories, all fixed in 4.0.1 ---
+# Bump to 4.0.1 is blocked: httpoison 2.x requires hackney ~> 1.17, so hackney cannot move to
+# 4.x without a fleet-wide httpoison/grpc upgrade. Real fix tracked for the dep-bump branch.
+# ee/rbac's only outbound HTTP is via Tesla to configured provider base URLs (GitHub, Bitbucket,
+# OIDC) — hosts and paths are static config or server-issued identifiers, never free-form user input.
+#
+# ssl:connect/2 post-handshake upgrade has no timeout (operational DoS; outbound calls only, to
+# trusted provider endpoints)
+GHSA-gp9c-pm5m-5cxr
+# CR/LF injection in query parameter (no user-controlled data fed to hackney query params from lib/)
+GHSA-j9wq-vxxc-94wf
+# SSRF allowlist bypass in hackney_url:normalize/2 via percent-encoded host (base URLs are static
+# config, no user-controlled URL fed to hackney from lib/)
+GHSA-pj7v-xfvx-wmjq
+# CRLF / header injection via unvalidated `domain` and `path` options (no user-controlled domain/path
+# fed to hackney from lib/)
+GHSA-mp55-p8c9-rfw2


### PR DESCRIPTION
Extends semaphoreio/semaphore#1078 to `ee/rbac`, whose `mix_audit` deployment-precondition still fails on the four hackney advisories (all fixed in hackney 4.0.1). ee/rbac cannot adopt 4.0.1 while httpoison 2.x pins hackney to `~> 1.17`, so the advisories are accepted with per-advisory reachability justifications, matching the entries already present for front, guard, and public-api/v1alpha.

## ✅ Checklist
- [x] I have tested this change