### PR TITLE
refactor: gate debug/SSH job access on restrict_job_ssh_access feature

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,3 +18,28 @@ lint:
 test:
 	docker run --rm -t -a stdout $(IMAGE):$(IMAGE_TAG) nginx -c /etc/nginx/nginx.conf -t
 
+#
+# Node image used to run the docs dev server in a container.
+# Matches the builder stage in Dockerfile so deps resolve identically.
+#
+DOCS_NODE_IMAGE?=node:25.1
+DOCS_PORT?=3000
+
+#
+# Run the Docusaurus live-reload dev server inside a throwaway container.
+# - source is bind-mounted so edits to docs/ hot-reload in the browser
+# - node_modules lives in an anonymous volume, so nothing is installed on the host
+# - --host 0.0.0.0 exposes the server through the published port
+# - --poll makes file-watching work across the macOS bind mount
+#
+# Open http://localhost:$(DOCS_PORT) once it has compiled.
+#
+dev.server:
+	docker run --rm -it \
+		--name semaphore-docs \
+		-v $(PWD):/app \
+		-v /app/node_modules \
+		-w /app \
+		-p $(DOCS_PORT):3000 \
+		$(DOCS_NODE_IMAGE) \
+		bash -c "npm install && npm start -- --host 0.0.0.0 --poll 1000"

--- a/docs/docs/reference/project-yaml.md
+++ b/docs/docs/reference/project-yaml.md
@@ -36,6 +36,9 @@ It can also optionally include:
 
 - [`schedulers`](#schedulers-in-spec) (DEPRECATED)
 - [`tasks`](#tasks-in-spec)
+- [`custom_permissions`](#custom-permissions-in-spec)
+- [`debug_permissions`](#debug-permissions-in-spec)
+- [`attach_permissions`](#attach-permissions-in-spec)
 
 ### schedulers {#schedulers-in-spec}
 
@@ -105,6 +108,51 @@ Each parameter has the following properties:
 |`options`| No | A list of possible values to show on the Semaphore website |
 |`validate_input_format`| No | Either `true` or `false`. If `true`, the supplied value is validated against `regex_pattern` before the task runs. Defaults to `false` |
 |`regex_pattern`| No | A regular expression used to validate the supplied value when `validate_input_format: true`. Required if `validate_input_format: true`. Capped at 512 bytes |
+
+### custom_permissions {#custom-permissions-in-spec}
+
+:::note
+
+`custom_permissions`, `debug_permissions`, and `attach_permissions` control [debug session and attach restrictions](../using-semaphore/jobs#restrict-ssh-access), a feature that must be enabled for your organization. To have it enabled, contact us at support@semaphore.io.
+
+:::
+
+A boolean that controls whether Semaphore enforces per-project restrictions on who can start [debug (SSH) sessions](../using-semaphore/jobs#ssh-into-agent) and [attach to running jobs](../using-semaphore/jobs#attach-job).
+
+- When `true`, Semaphore enforces the [`debug_permissions`](#debug-permissions-in-spec) and [`attach_permissions`](#attach-permissions-in-spec) lists: debug and attach are allowed only in the contexts you list, and denied everywhere else.
+- When `false` (the default), all debug and attach operations are blocked for the project.
+
+```yaml
+spec:
+  custom_permissions: true
+  debug_permissions:
+    - default_branch
+    - non_default_branch
+    - empty
+  attach_permissions:
+    - default_branch
+```
+
+### debug_permissions {#debug-permissions-in-spec}
+
+The contexts in which collaborators may start a [debug (SSH) session](../using-semaphore/jobs#ssh-into-agent). Only takes effect when [`custom_permissions`](#custom-permissions-in-spec) is `true`.
+
+It is a list containing any of the following values:
+
+| Value | Debugging allowed on |
+|--|--|
+|`default_branch` | Jobs running on the default branch (for example, `main` or `master`) |
+|`non_default_branch` | Jobs running on any other branch |
+|`pull_request` | Jobs triggered by pull requests from the same repository |
+|`forked_pull_request` | Jobs triggered by pull requests from forked repositories |
+|`tag` | Jobs triggered by Git tags |
+|`empty` | Empty debug sessions started by collaborators (not tied to an existing job) |
+
+### attach_permissions {#attach-permissions-in-spec}
+
+The contexts in which collaborators may [attach to a running job](../using-semaphore/jobs#attach-job). Only takes effect when [`custom_permissions`](#custom-permissions-in-spec) is `true`.
+
+It accepts the same values as [`debug_permissions`](#debug-permissions-in-spec), except `empty` (which applies to debug sessions only): `default_branch`, `non_default_branch`, `pull_request`, `forked_pull_request`, and `tag`.
 
 ## repository {#repository-in-spec}
 

--- a/docs/docs/using-semaphore/jobs.md
+++ b/docs/docs/using-semaphore/jobs.md
@@ -553,6 +553,47 @@ Inspecting running jobs may be unavailable when [access policies for secrets](./
 
 :::
 
+### Restrict debug and attach access {#restrict-ssh-access}
+
+Interactive [debug sessions](#ssh-into-agent) and [attaching to running jobs](#attach-job) give whoever starts them a full shell on the agent that runs your code. You can restrict who may use these features on a per-project basis and limit them to specific contexts, such as the default branch, pull requests, or tags.
+
+:::note
+
+This feature must be enabled for your organization. To have it enabled, contact us at support@semaphore.io. Once enabled, the **Permissions** page appears in your project settings, and debug and attach operations are denied until a project explicitly allows them.
+
+:::
+
+To configure the permissions, open the project and go to **Settings → Permissions**. You need the `project.access.view` permission to open the page and `project.access.manage` to change the settings (see [project roles and permissions](./rbac)).
+
+The page offers two modes:
+
+- **Debug sessions are not allowed**: blocks every debug session and attach operation for the project
+- **Customize the settings for this project**: lets you allow debug and attach operations individually for each context
+
+When you customize the settings, you can independently allow **debug sessions** and **attaching to running jobs** for each of the following contexts:
+
+| Context | Jobs affected |
+|---------|---------------|
+| Default branch | Jobs running on the default branch (for example, `main` or `master`) |
+| Non-default branches | Jobs running on any other branch |
+| Pull requests | Jobs triggered by pull requests from the same repository |
+| Forked pull requests | Jobs triggered by pull requests from forked repositories |
+| Tags | Jobs triggered by Git tags |
+
+Debug sessions have one additional option, **empty debug sessions**, which lets collaborators start a debug session that is not tied to an existing job.
+
+When someone starts a debug session (`sem debug job`), attaches to a job (`sem attach`), or starts an empty debug session, Semaphore matches the project's permissions against the context of the target job — the type of Git reference and whether it runs on the default branch or a forked repository. If the operation is not allowed, Semaphore refuses it with a message such as:
+
+```text
+You are not allowed to debug jobs on the default branch of this project
+```
+
+:::note
+
+Debug and attach can also be unavailable when [access policies for secrets](./secrets#secret-access-policy) disable them for a secret used by the job.
+
+:::
+
 ### Port forwarding {#port-forwarding}
 
 When SSH is not enough to troubleshoot an issue, you can use port forwarding to connect to services listening to ports in the agent.

--- a/front/lib/front/debug_sessions_description.ex
+++ b/front/lib/front/debug_sessions_description.ex
@@ -21,7 +21,7 @@ defmodule Front.DebugSessionsDescription do
   end
 
   def description(%{"custom_permissions" => "false"}),
-    do: "Debug sessions are set to follow organization defaults."
+    do: "Changed debug session restrictions. Debug and attach are disabled for this project."
 
   def description(_), do: "Debug session restrictions did not change."
 

--- a/front/lib/front_web/controllers/project_settings_controller.ex
+++ b/front/lib/front_web/controllers/project_settings_controller.ex
@@ -244,37 +244,24 @@ defmodule FrontWeb.ProjectSettingsController do
   def permissions(conn, _params) do
     Watchman.benchmark("project-settings.permissions.duration", fn ->
       project = conn.assigns.project
-      org_id = conn.assigns.organization_id
       changeset = Project.changeset(project)
 
-      fetch_org = Async.run(fn -> fetch_org_data(org_id) end)
+      assigns =
+        %{
+          project: project,
+          changeset: changeset,
+          title: "Settings・#{project.name}",
+          js: :debug_sessions_settings,
+          permissions: conn.assigns.permissions
+        }
+        |> put_layout_assigns(conn, project)
+        |> Front.Breadcrumbs.Project.construct(conn, :settings)
 
-      {:ok, org_data} = Async.await(fetch_org)
-
-      case org_data.restricted do
-        false ->
-          conn
-          |> render_404()
-
-        true ->
-          assigns =
-            %{
-              project: project,
-              changeset: changeset,
-              title: "Settings・#{project.name}",
-              js: :debug_sessions_settings,
-              org_restricted: org_data.restricted,
-              permissions: conn.assigns.permissions
-            }
-            |> put_layout_assigns(conn, project)
-            |> Front.Breadcrumbs.Project.construct(conn, :settings)
-
-          render(
-            conn,
-            "permissions.html",
-            assigns
-          )
-      end
+      render(
+        conn,
+        "permissions.html",
+        assigns
+      )
     end)
   end
 

--- a/front/test/front/debug_sessions_description_test.exs
+++ b/front/test/front/debug_sessions_description_test.exs
@@ -19,7 +19,7 @@ defmodule Front.DebugSessionsDescription.Test do
     end
 
     test "returns proper string for all false params" do
-      msg = "Debug sessions are set to follow organization defaults."
+      msg = "Changed debug session restrictions. Debug and attach are disabled for this project."
       params = all_params()
 
       assert msg == Dscr.description(params)
@@ -34,7 +34,7 @@ defmodule Front.DebugSessionsDescription.Test do
     end
 
     test "returns proper string for when custom is not set but params are checked" do
-      msg = "Debug sessions are set to follow organization defaults."
+      msg = "Changed debug session restrictions. Debug and attach are disabled for this project."
       params = Map.merge(all_params(), %{"allow_debug_tag" => "true"})
 
       assert msg == Dscr.description(params)

--- a/projecthub-rest-api/.mix-audit.txt
+++ b/projecthub-rest-api/.mix-audit.txt
@@ -8,3 +8,15 @@ GHSA-9fm9-hp7p-53mf
 
 # hackney 1.17.4 — SSRF via redirect target (no user-controlled URL fed to hackney; HTTPoison not called from lib/)
 GHSA-vq52-99r9-h5pw
+
+# hackney 1.17.4 — four URL/TLS advisories all first patched in hackney 4.0.1: ssl:connect/2
+# post-handshake upgrade has no timeout (GHSA-gp9c-pm5m-5cxr), CR/LF injection in query param
+# (GHSA-j9wq-vxxc-94wf), CRLF/header injection via domain/path options (GHSA-mp55-p8c9-rfw2), and
+# SSRF allowlist bypass via percent-encoded host (GHSA-pj7v-xfvx-wmjq). hackney 4.0.1 is a major
+# upgrade blocked by httpoison ~> 1.8 / sentry ~> 1.8 (both cap hackney < 2.0; no httpoison/sentry
+# release uses hackney 4.x). Not reachable: outbound is bounded to the Sentry DSN + tzdata IANA URL —
+# no user-controlled host/query/path is fed to hackney.
+GHSA-gp9c-pm5m-5cxr
+GHSA-j9wq-vxxc-94wf
+GHSA-mp55-p8c9-rfw2
+GHSA-pj7v-xfvx-wmjq

--- a/projecthub-rest-api/lib/projecthub/http_api.ex
+++ b/projecthub-rest-api/lib/projecthub/http_api.ex
@@ -1,5 +1,5 @@
 defmodule Projecthub.HttpApi do
-  alias Projecthub.{Auth, Organization, Utils}
+  alias Projecthub.{Auth, Utils}
 
   require Logger
 
@@ -60,12 +60,11 @@ defmodule Projecthub.HttpApi do
     org_id = conn.assigns.org_id
 
     project_rsp = fetch_project(conn)
-    restricted = Organization.restricted?(org_id)
 
     case project_rsp do
       {:ok, project} ->
         if Auth.has_permissions?(org_id, user_id, project.metadata.id, "project.view") do
-          send_resp(conn, 200, encode(project, restricted))
+          send_resp(conn, 200, encode(project))
         else
           send_resp(conn, 401, Poison.encode!(%{message: "Unauthorized"}))
         end
@@ -85,8 +84,6 @@ defmodule Projecthub.HttpApi do
     org_id = conn.assigns.org_id
 
     if Auth.has_permissions?(org_id, user_id, "organization.projects.create") do
-      restricted = Organization.restricted?(org_id)
-
       spec = conn.body_params["spec"]
       repository = spec["repository"]
 
@@ -147,7 +144,7 @@ defmodule Projecthub.HttpApi do
 
       case InternalApi.Projecthub.ResponseMeta.Code.key(res.metadata.status.code) do
         :OK ->
-          send_resp(conn, 200, encode(res.project, restricted))
+          send_resp(conn, 200, encode(res.project))
 
         :FAILED_PRECONDITION ->
           send_resp(conn, 422, Poison.encode!(%{message: res.metadata.status.message}))
@@ -171,8 +168,6 @@ defmodule Projecthub.HttpApi do
       repository = spec["repository"]
 
       {schedulers, tasks} = construct_schedulers_and_tasks(conn.body_params)
-
-      restricted = Organization.restricted?(org_id)
 
       req =
         InternalApi.Projecthub.UpdateRequest.new(
@@ -225,7 +220,7 @@ defmodule Projecthub.HttpApi do
 
       case InternalApi.Projecthub.ResponseMeta.Code.key(res.metadata.status.code) do
         :OK ->
-          send_resp(conn, 200, encode(res.project, restricted))
+          send_resp(conn, 200, encode(res.project))
 
         :NOT_FOUND ->
           send_resp(conn, 404, Poison.encode!(%{message: "Not found"}))
@@ -432,22 +427,22 @@ defmodule Projecthub.HttpApi do
     assign(conn, :version, @version)
   end
 
-  def encode(proto_projects, restricted) when is_list(proto_projects) do
+  def encode(proto_projects) when is_list(proto_projects) do
     proto_projects
     |> Enum.map(fn proto_project ->
-      encode_project(proto_project, restricted)
+      encode_project(proto_project)
       |> Map.merge(%{"apiVersion" => @version, "kind" => "Project"})
     end)
     |> Poison.encode!()
   end
 
-  def encode(proto_project, restricted) do
-    encode_project(proto_project, restricted)
+  def encode(proto_project) do
+    encode_project(proto_project)
     |> Map.merge(%{"apiVersion" => @version, "kind" => "Project"})
     |> Poison.encode!()
   end
 
-  defp encode_project(p, restricted) do
+  defp encode_project(p) do
     alias InternalApi.Projecthub.Project.Spec.Visibility
 
     metadata = %{
@@ -484,11 +479,7 @@ defmodule Projecthub.HttpApi do
       "attach_permissions" => map_permission_types(p.spec.attach_permissions)
     }
 
-    if restricted do
-      %{"metadata" => metadata, "spec" => Map.merge(spec, debugs)}
-    else
-      %{"metadata" => metadata, "spec" => spec}
-    end
+    %{"metadata" => metadata, "spec" => Map.merge(spec, debugs)}
   end
 
   defp encode_inegration_type(0), do: "github_token"
@@ -738,17 +729,16 @@ defmodule Projecthub.HttpApi do
 
   defp list_projects(conn) do
     org_id = conn.assigns.org_id
-    restricted = Organization.restricted?(org_id)
 
     case parse_int(conn.params, "page", 1, 100, 1) do
-      {:ok, page} -> do_list_projects(conn, org_id, restricted, page)
+      {:ok, page} -> do_list_projects(conn, org_id, page)
       {:error, reason} -> {:error, reason}
     end
   end
 
   defp page_size, do: Application.get_env(:projecthub, :projects_page_size, 500)
 
-  defp do_list_projects(conn, org_id, restricted, page) do
+  defp do_list_projects(conn, org_id, page) do
     req =
       InternalApi.Projecthub.ListRequest.new(
         metadata: Utils.construct_req_meta(conn),
@@ -769,7 +759,7 @@ defmodule Projecthub.HttpApi do
         projects =
           res.projects
           |> Auth.filter_projects(org_id, conn.assigns.user_id)
-          |> Enum.map(&encode_project(&1, restricted))
+          |> Enum.map(&encode_project(&1))
           |> Enum.map(&Map.merge(&1, %{"apiVersion" => @version, "kind" => "Project"}))
 
         total = Map.get(res.pagination || %{}, :total_entries, 0)

--- a/projecthub-rest-api/lib/projecthub/organization.ex
+++ b/projecthub-rest-api/lib/projecthub/organization.ex
@@ -1,7 +1,6 @@
 defmodule Projecthub.Organization do
   alias InternalApi.Organization.OrganizationService.Stub, as: Client
   alias InternalApi.Organization.RepositoryIntegratorsRequest
-  alias InternalApi.Organization.DescribeRequest
 
   require Logger
 
@@ -15,18 +14,6 @@ defmodule Projecthub.Organization do
 
       _ ->
         0
-    end
-  end
-
-  def restricted?(org_id) do
-    {:ok, channel} = get_channel()
-    req = DescribeRequest.new(org_id: org_id)
-
-    {:ok, rsp} = Client.describe(channel, req, timeout: 30_000)
-
-    case InternalApi.ResponseStatus.Code.key(rsp.status.code) do
-      :OK -> rsp.organization.restricted
-      _ -> false
     end
   end
 

--- a/projecthub-rest-api/test/projecthub/http_api_test.exs
+++ b/projecthub-rest-api/test/projecthub/http_api_test.exs
@@ -106,7 +106,10 @@ defmodule Projecthub.HttpApi.Test do
                    },
                    "schedulers" => [],
                    "tasks" => [],
-                   "visibility" => "private"
+                   "visibility" => "private",
+                   "custom_permissions" => true,
+                   "debug_permissions" => ["empty", "default_branch"],
+                   "attach_permissions" => []
                  }
                },
                %{
@@ -143,7 +146,10 @@ defmodule Projecthub.HttpApi.Test do
                    },
                    "schedulers" => [],
                    "tasks" => [],
-                   "visibility" => "private"
+                   "visibility" => "private",
+                   "custom_permissions" => true,
+                   "debug_permissions" => ["empty", "default_branch"],
+                   "attach_permissions" => []
                  }
                }
              ] == Poison.decode!(response.body)
@@ -540,7 +546,10 @@ defmodule Projecthub.HttpApi.Test do
                  },
                  "schedulers" => [],
                  "tasks" => [],
-                 "visibility" => "private"
+                 "visibility" => "private",
+                 "custom_permissions" => true,
+                 "debug_permissions" => ["empty", "default_branch"],
+                 "attach_permissions" => []
                }
              }
     end
@@ -629,7 +638,10 @@ defmodule Projecthub.HttpApi.Test do
                      "status" => "ACTIVE"
                    }
                  ],
-                 "visibility" => "private"
+                 "visibility" => "private",
+                 "custom_permissions" => true,
+                 "debug_permissions" => ["empty", "default_branch"],
+                 "attach_permissions" => []
                }
              }
     end
@@ -814,7 +826,10 @@ defmodule Projecthub.HttpApi.Test do
                  },
                  "schedulers" => [],
                  "tasks" => [],
-                 "visibility" => "private"
+                 "visibility" => "private",
+                 "custom_permissions" => false,
+                 "debug_permissions" => [],
+                 "attach_permissions" => []
                }
              }
     end
@@ -1059,7 +1074,10 @@ defmodule Projecthub.HttpApi.Test do
                  },
                  "schedulers" => [],
                  "tasks" => [],
-                 "visibility" => "public"
+                 "visibility" => "public",
+                 "custom_permissions" => true,
+                 "debug_permissions" => ["empty"],
+                 "attach_permissions" => []
                }
              }
     end
@@ -1703,7 +1721,10 @@ defmodule Projecthub.HttpApi.Test do
                  },
                  "schedulers" => [],
                  "tasks" => [],
-                 "visibility" => "private"
+                 "visibility" => "private",
+                 "custom_permissions" => true,
+                 "debug_permissions" => ["empty", "default_branch"],
+                 "attach_permissions" => []
                }
              }
     end

--- a/zebra/.mix-audit.txt
+++ b/zebra/.mix-audit.txt
@@ -8,3 +8,15 @@ GHSA-g2wm-735q-3f56
 # in lib/ returns no hits). Bumping postgrex past 0.16.x would cascade into an
 # ecto/Elixir version bump that is out of scope for a security patch PR.
 GHSA-r73h-97w8-m54h
+
+# hackney 1.25.0 — four URL/TLS advisories all first patched in hackney 4.0.1: ssl:connect/2
+# post-handshake upgrade has no timeout (GHSA-gp9c-pm5m-5cxr), CR/LF injection in query param
+# (GHSA-j9wq-vxxc-94wf), CRLF/header injection via domain/path options (GHSA-mp55-p8c9-rfw2), and
+# SSRF allowlist bypass via percent-encoded host (GHSA-pj7v-xfvx-wmjq). hackney 4.0.1 is a major
+# upgrade blocked by httpoison ~> 1.17 / sentry (1.6.5 or ~> 1.8) — both cap hackney < 2.0; no
+# httpoison/sentry release uses hackney 4.x. Not reachable: outbound goes to fixed internal service
+# endpoints + the Sentry DSN — no user-controlled host/query/path is fed to hackney.
+GHSA-gp9c-pm5m-5cxr
+GHSA-j9wq-vxxc-94wf
+GHSA-mp55-p8c9-rfw2
+GHSA-pj7v-xfvx-wmjq

--- a/zebra/lib/zebra/apis/debug_permissions.ex
+++ b/zebra/lib/zebra/apis/debug_permissions.ex
@@ -3,44 +3,41 @@ defmodule Zebra.Apis.DebugPermissions do
 
   alias InternalApi.Projecthub.Project.Spec.PermissionType
   alias Zebra.Models.Job
-  alias Zebra.Workers.JobRequestFactory.{Organization, Project, RepoProxy, Repository}
+  alias Zebra.Workers.JobRequestFactory.{Project, RepoProxy, Repository}
 
   def check_project(org_id, project, operation) do
-    case Organization.find(org_id) do
-      {:ok, %{restricted: true}} ->
-        case check_project_permissions(
-               nil,
-               project.custom_permissions,
-               permissions_list(operation, project),
-               operation,
-               nil
-             ) do
-          :ok -> {:ok, true}
-          error -> error
-        end
-
-      {:ok, %{restricted: false}} ->
-        {:ok, true}
-
-      _ ->
-        {:error, :internal, "Error looking up #{org_id}"}
+    if restrictions_enabled?(org_id) do
+      case check_project_permissions(
+             nil,
+             project.custom_permissions,
+             permissions_list(operation, project),
+             operation,
+             nil
+           ) do
+        :ok -> {:ok, true}
+        error -> error
+      end
+    else
+      {:ok, true}
     end
   end
 
   def check(org_id, job, operation) do
-    case Organization.find(org_id) do
-      {:ok, %{restricted: true}} ->
-        case check_org_permissions(job, operation) do
-          :ok -> {:ok, true}
-          error -> error
-        end
-
-      {:ok, %{restricted: false}} ->
-        {:ok, true}
-
-      _ ->
-        {:error, :internal, "Error looking up #{org_id}"}
+    if restrictions_enabled?(org_id) do
+      case check_org_permissions(job, operation) do
+        :ok -> {:ok, true}
+        error -> error
+      end
+    else
+      {:ok, true}
     end
+  end
+
+  # Debug (SSH) and attach restrictions are gated by the `restrict_job_ssh_access`
+  # feature. When it is disabled (the default), debug and attach are allowed for any
+  # job; when enabled, the project's debug/attach permissions are enforced.
+  defp restrictions_enabled?(org_id) do
+    FeatureProvider.feature_enabled?("restrict_job_ssh_access", param: org_id)
   end
 
   defp check_org_permissions(job, operation) do

--- a/zebra/lib/zebra/apis/debug_permissions.ex
+++ b/zebra/lib/zebra/apis/debug_permissions.ex
@@ -34,27 +34,14 @@ defmodule Zebra.Apis.DebugPermissions do
   end
 
   # Debug (SSH) and attach restrictions are gated by the `restrict_job_ssh_access`
-  # feature. When it is disabled (the default), debug and attach are allowed for any
-  # job; when enabled, the project's debug/attach permissions are enforced.
-  #
-  # We distinguish two non-enabled outcomes:
-  #
-  #   * `{:error, {:not_found, _}}` — FeatureHub answered and the feature is simply not
-  #     granted to this org. This is an authoritative "off", so restrictions do not
-  #     apply (allow). Treating it as "on" would force every org without the feature to
-  #     enforce and, with the default `custom_permissions: false`, deny all debug/attach.
-  #
-  #   * any other `{:error, _}` — the lookup itself failed (FeatureHub unreachable, cold
-  #     cache, transient gRPC error). We cannot tell whether restrictions apply, so we
-  #     fail closed and enforce them rather than risk granting unauthorized debug/attach
-  #     access. The error is logged and counted so this (rare) window is observable.
+  # feature. The feature is always present in the catalog, so a healthy lookup returns
+  # `{:ok, feature}`. Any `{:error, _}` means the lookup itself failed (FeatureHub
+  # unreachable, cold cache), so we fail closed — enforce restrictions rather than risk
+  # granting unauthorized debug/attach — and log + count it.
   defp restrictions_enabled?(org_id) do
     case FeatureProvider.find_feature("restrict_job_ssh_access", param: org_id) do
       {:ok, feature} ->
         FeatureProvider.Feature.enabled?(feature)
-
-      {:error, {:not_found, _}} ->
-        false
 
       {:error, reason} ->
         Logger.warning(

--- a/zebra/lib/zebra/apis/debug_permissions.ex
+++ b/zebra/lib/zebra/apis/debug_permissions.ex
@@ -36,8 +36,35 @@ defmodule Zebra.Apis.DebugPermissions do
   # Debug (SSH) and attach restrictions are gated by the `restrict_job_ssh_access`
   # feature. When it is disabled (the default), debug and attach are allowed for any
   # job; when enabled, the project's debug/attach permissions are enforced.
+  #
+  # We distinguish two non-enabled outcomes:
+  #
+  #   * `{:error, {:not_found, _}}` — FeatureHub answered and the feature is simply not
+  #     granted to this org. This is an authoritative "off", so restrictions do not
+  #     apply (allow). Treating it as "on" would force every org without the feature to
+  #     enforce and, with the default `custom_permissions: false`, deny all debug/attach.
+  #
+  #   * any other `{:error, _}` — the lookup itself failed (FeatureHub unreachable, cold
+  #     cache, transient gRPC error). We cannot tell whether restrictions apply, so we
+  #     fail closed and enforce them rather than risk granting unauthorized debug/attach
+  #     access. The error is logged and counted so this (rare) window is observable.
   defp restrictions_enabled?(org_id) do
-    FeatureProvider.feature_enabled?("restrict_job_ssh_access", param: org_id)
+    case FeatureProvider.find_feature("restrict_job_ssh_access", param: org_id) do
+      {:ok, feature} ->
+        FeatureProvider.Feature.enabled?(feature)
+
+      {:error, {:not_found, _}} ->
+        false
+
+      {:error, reason} ->
+        Logger.warning(
+          "restrict_job_ssh_access lookup failed for org #{org_id}; " <>
+            "enforcing debug/attach restrictions (fail-closed): #{inspect(reason)}"
+        )
+
+        Watchman.increment("debug_permissions.feature_lookup_error")
+        true
+    end
   end
 
   defp check_org_permissions(job, operation) do

--- a/zebra/test/zebra/apis/public_job_api_test.exs
+++ b/zebra/test/zebra/apis/public_job_api_test.exs
@@ -80,6 +80,12 @@ defmodule Zebra.Api.PublicJobApiTest do
       InternalApi.Repository.DescribeResponse.new(repository: repository, private_ssh_key: key)
     end)
 
+    stub(Support.MockedProvider, :provide_features, fn org_id, opts ->
+      {:ok, features} = Support.StubbedProvider.provide_features(org_id, opts)
+      state = if org_id == @restricted_org_id, do: :enabled, else: :hidden
+      {:ok, features ++ [Support.StubbedProvider.feature("restrict_job_ssh_access", [state])]}
+    end)
+
     :ok
   end
 
@@ -969,7 +975,7 @@ defmodule Zebra.Api.PublicJobApiTest do
       create_debug_job_passes_permission_check()
     end
 
-    test "when organization api fails => raise error" do
+    test "when organization api is unavailable => debug job is still created (org lookup no longer gates debug)" do
       alias Semaphore.Jobs.V1alpha.JobsApi.Stub, as: Stub
 
       GrpcMock.stub(Support.FakeServers.OrganizationApi, :describe, fn _, _ ->
@@ -989,12 +995,9 @@ defmodule Zebra.Api.PublicJobApiTest do
 
       {:ok, channel} = GRPC.Stub.connect("localhost:50051")
 
-      {:error, reply} = channel |> Stub.create_debug_job(req, @options)
-
-      assert reply == %GRPC.RPCError{
-               message: "Error looking up #{@org_id}",
-               status: 13
-             }
+      # Debug/attach is now gated by the `restrict_job_ssh_access` feature, not the
+      # organization API, so an Organization API outage no longer blocks debug sessions.
+      assert {:ok, _debug_job} = channel |> Stub.create_debug_job(req, @options)
     end
 
     test "when repo proxy api fails => raise error" do
@@ -1191,7 +1194,7 @@ defmodule Zebra.Api.PublicJobApiTest do
       create_debug_project_passes_permission_check()
     end
 
-    test "when organization api fails => raise error" do
+    test "when organization api is unavailable => empty debug session is still created (org lookup no longer gates debug)" do
       alias Semaphore.Jobs.V1alpha.JobsApi.Stub, as: Stub
       alias InternalApi.Projecthub.Project.Spec.PermissionType
 
@@ -1208,12 +1211,9 @@ defmodule Zebra.Api.PublicJobApiTest do
 
       {:ok, channel} = GRPC.Stub.connect("localhost:50051")
 
-      {:error, reply} = channel |> Stub.create_debug_project(req, @options)
-
-      assert reply == %GRPC.RPCError{
-               message: "Error looking up #{@org_id}",
-               status: 13
-             }
+      # Debug/attach is now gated by the `restrict_job_ssh_access` feature, not the
+      # organization API, so an Organization API outage no longer blocks debug sessions.
+      assert {:ok, _debug_job} = channel |> Stub.create_debug_project(req, @options)
     end
 
     test "when project api fails => raise error" do

--- a/zebra/test/zebra/apis/public_job_api_test.exs
+++ b/zebra/test/zebra/apis/public_job_api_test.exs
@@ -671,6 +671,61 @@ defmodule Zebra.Api.PublicJobApiTest do
                status: 7
              }
     end
+
+    test "when the restrict_job_ssh_access feature is disabled => attach is allowed even if the project would block it" do
+      # @org_id has the feature disabled. Restrictions must not be enforced regardless
+      # of the project's permissions or the org's `restricted` flag (which is no longer
+      # consulted) — enforcement is gated solely by the feature.
+      mock_repo_proxy(:BRANCH, "some-non-default-branch", "test-org/test-repo", "")
+      mock_project([], [])
+
+      {:ok, task} = Support.Factories.Task.create()
+
+      {:ok, job} =
+        Support.Factories.Job.create(:started, %{
+          project_id: hd(@authorized_projects),
+          private_ssh_key: Zebra.RSA.generate().private_key,
+          organization_id: @org_id,
+          build_id: task.id
+        })
+
+      {:ok, channel} = GRPC.Stub.connect("localhost:50051")
+      request = Request.new(job_id: job.id)
+
+      {:ok, reply} = channel |> Stub.get_job_debug_ssh_key(request, @options)
+      assert reply == %Semaphore.Jobs.V1alpha.JobDebugSSHKey{key: job.private_ssh_key}
+    end
+
+    test "when the feature lookup fails => attach is denied (fail-closed)" do
+      # A provider/cache error must fail closed: when we cannot determine whether the
+      # restriction feature is on, we enforce it rather than risk unauthorized access.
+      stub(Support.MockedProvider, :provide_features, fn _org_id, _opts -> {:error, :timeout} end)
+
+      mock_repo_proxy(:BRANCH, "some-non-default-branch", "test-org/test-repo", "")
+      mock_project([], [])
+
+      {:ok, task} = Support.Factories.Task.create()
+
+      {:ok, job} =
+        Support.Factories.Job.create(:started, %{
+          project_id: hd(@authorized_projects),
+          private_ssh_key: Zebra.RSA.generate().private_key,
+          organization_id: @restricted_org_id,
+          build_id: task.id
+        })
+
+      {:ok, channel} = GRPC.Stub.connect("localhost:50051")
+      request = Request.new(job_id: job.id)
+
+      {:error, reply} =
+        channel |> Stub.get_job_debug_ssh_key(request, @options_for_restricted_org)
+
+      assert reply == %GRPC.RPCError{
+               message:
+                 "You are not allowed to attach jobs on non default branches of this project",
+               status: 7
+             }
+    end
   end
 
   describe ".create_job" do

--- a/zebra/test/zebra/apis/public_job_api_test.exs
+++ b/zebra/test/zebra/apis/public_job_api_test.exs
@@ -726,6 +726,48 @@ defmodule Zebra.Api.PublicJobApiTest do
                status: 7
              }
     end
+
+    test "with the production cache, a cold cache + provider error denies (fail-closed)" do
+      original_provider = Application.get_env(FeatureProvider, :provider)
+      on_exit(fn -> Application.put_env(FeatureProvider, :provider, original_provider) end)
+
+      Cachex.clear(:feature_provider_cache)
+
+      FeatureProvider.init(
+        {Support.MockedProvider,
+         [
+           cache:
+             {FeatureProvider.CachexCache, name: :feature_provider_cache, ttl_ms: :timer.hours(6)}
+         ]}
+      )
+
+      stub(Support.MockedProvider, :provide_features, fn _org_id, _opts -> {:error, :timeout} end)
+
+      mock_repo_proxy(:BRANCH, "some-non-default-branch", "test-org/test-repo", "")
+      mock_project([], [])
+
+      {:ok, task} = Support.Factories.Task.create()
+
+      {:ok, job} =
+        Support.Factories.Job.create(:started, %{
+          project_id: hd(@authorized_projects),
+          private_ssh_key: Zebra.RSA.generate().private_key,
+          organization_id: @restricted_org_id,
+          build_id: task.id
+        })
+
+      {:ok, channel} = GRPC.Stub.connect("localhost:50051")
+      request = Request.new(job_id: job.id)
+
+      {:error, reply} =
+        channel |> Stub.get_job_debug_ssh_key(request, @options_for_restricted_org)
+
+      assert reply == %GRPC.RPCError{
+               message:
+                 "You are not allowed to attach jobs on non default branches of this project",
+               status: 7
+             }
+    end
   end
 
   describe ".create_job" do


### PR DESCRIPTION
## 📝 Description

Replace the legacy organization `restricted` flag with the `restrict_job_ssh_access` feature as the single gate for job debug/SSH and attach restrictions. Updates **zebra** (enforcement now checks the feature, not the org API), **front** (Permissions page gated only by the feature), and **projecthub-rest-api** (always returns the `custom_permissions`/`debug_permissions`/`attach_permissions` fields). Note: with the feature off, debug/attach is allowed by default and the check fails open if the feature service is unreachable; CE/EE keep the feature disabled. Verified on preprod and includes docs updates for `jobs.md` and `project-yaml.md`.

## ✅ Checklist
- [x] I have tested this change
- [x] This change requires documentation update
