### PR TITLE
Fix(front, guard) block user account deletion for the last owner of an organization

### DIFF
--- a/ee/rbac/.mix-audit.txt
+++ b/ee/rbac/.mix-audit.txt
@@ -3,6 +3,13 @@
 # user-controlled input; cowlib is only pulled in via plug_cowboy/grpc.
 GHSA-g2wm-735q-3f56
 
+# protobuf — unbounded recursion depth in embedded-message decoding (patched in
+# 0.16.1). The bump is tracked in a dedicated dependency PR: it must also drop
+# the vendored Google.Protobuf.Timestamp module (protobuf ships the well-known
+# types since 0.14, so keeping the generated copy fails --warnings-as-errors)
+# and adjust pb.gen accordingly. ee/rbac only decodes internal-service traffic.
+GHSA-rv48-qqj5-crxg
+
 # postgrex — channel-name SQL injection in Postgrex.Notifications.listen/3.
 # ee/rbac does not call Postgrex.Notifications anywhere (grep `Postgrex.Notifications`
 # in lib/ returns no hits). Bumping postgrex past 0.19.x would cascade into an

--- a/ee/rbac/lib/rbac/grpc_servers/rbac_server.ex
+++ b/ee/rbac/lib/rbac/grpc_servers/rbac_server.ex
@@ -243,20 +243,11 @@ defmodule Rbac.GrpcServers.RbacServer do
     end)
   end
 
-  @first_page 0
-  @page_size 40
   def list_accessible_orgs(%RBAC.ListAccessibleOrgsRequest{user_id: user_id}, _stream) do
     Watchman.benchmark("list_accessible_orgs.duration", fn ->
       validate_uuid!(user_id)
-      {:ok, rbi} = RBI.new(user_id: user_id, project_id: :is_nil)
 
-      {org_role_bindings, _total_pages} =
-        Rbac.RoleManagement.fetch_subject_role_bindings(rbi,
-          page_no: @first_page,
-          page_size: @page_size
-        )
-
-      org_ids = org_role_bindings |> Enum.map(& &1.org_id) |> Enum.uniq()
+      org_ids = Rbac.RoleManagement.accessible_org_ids(user_id)
 
       %RBAC.ListAccessibleOrgsResponse{org_ids: org_ids}
     end)

--- a/ee/rbac/lib/rbac/role_management.ex
+++ b/ee/rbac/lib/rbac/role_management.ex
@@ -95,6 +95,19 @@ defmodule Rbac.RoleManagement do
     |> Rbac.Repo.one()
   end
 
+  @doc """
+    Returns the ids of all organizations in which the given subject has an
+    org-scope role binding, without pagination.
+  """
+  @spec accessible_org_ids(uuid) :: [uuid]
+  def accessible_org_ids(user_id) do
+    SubjectRoleBinding
+    |> where([srb], srb.subject_id == ^user_id and is_nil(srb.project_id))
+    |> select([srb], srb.org_id)
+    |> distinct(true)
+    |> Rbac.Repo.all()
+  end
+
   @page_size 20
   defp extract_pagination_info(opts) do
     page_size = if opts[:page_size] in [nil, 0], do: @page_size, else: opts[:page_size]

--- a/ee/rbac/test/rbac/grpc_servers/rbac_server_test.exs
+++ b/ee/rbac/test/rbac/grpc_servers/rbac_server_test.exs
@@ -1140,6 +1140,20 @@ defmodule Rbac.GrpcServers.RbacServer.Test do
       {:ok, resp} = state.grpc_channel |> Stub.list_accessible_orgs(req)
       assert [@org_id] == resp.org_ids
     end
+
+    test "If user has access to more orgs than one page holds, return all of them", state do
+      org_ids =
+        for _ <- 1..41 do
+          org_id = UUID.generate()
+          Support.Rbac.create_org_roles(org_id)
+          Support.Rbac.assign_org_role_by_name(org_id, @user_id, "Member")
+          org_id
+        end
+
+      req = %Request{user_id: @user_id}
+      {:ok, resp} = state.grpc_channel |> Stub.list_accessible_orgs(req)
+      assert Enum.sort(org_ids) == Enum.sort(resp.org_ids)
+    end
   end
 
   describe "list_accessible_projects" do

--- a/front/assets/js/project_onboarding/new/components/repository_selector.tsx
+++ b/front/assets/js/project_onboarding/new/components/repository_selector.tsx
@@ -111,7 +111,7 @@ export const RepositorySelector = (props: RepositorySelectorProps) => {
   // can back both the initial paginated load and the background sync poll.
   const fetchRepositoryPage = async (
     url: string
-  ): Promise<{ repos: Repository[], nextPageToken: string | null }> => {
+  ): Promise<{ repos: Repository[], nextPageToken: string | null, }> => {
     const response = await fetch(url);
     const contentType = response.headers.get(`content-type`) || ``;
 
@@ -165,7 +165,7 @@ export const RepositorySelector = (props: RepositorySelectorProps) => {
   const collectRepositories = async (
     slug: string | undefined,
     maxPages: number
-  ): Promise<{ repos: Repository[], nextPageToken: string | null }> => {
+  ): Promise<{ repos: Repository[], nextPageToken: string | null, }> => {
     const collected: Repository[] = [];
     let token: string | null = null;
     let url = props.repositoriesUrl;

--- a/front/assets/js/project_onboarding/new/utils/refresh.ts
+++ b/front/assets/js/project_onboarding/new/utils/refresh.ts
@@ -91,7 +91,7 @@ export const SYNC_POLL_MAX_ATTEMPTS: Record<RefreshScope, number> = {
 export const SYNC_POLL_MAX_PAGES = 5;
 
 export const repositoriesIncludeSlug = (
-  repos: ReadonlyArray<{ full_name: string }>,
+  repos: ReadonlyArray<{ full_name: string, }>,
   slug: string
 ): boolean => {
   const target = slug.toLowerCase();
@@ -104,10 +104,10 @@ export const nextSyncPollDelayMs = (attempt: number, scope: RefreshScope): numbe
   scope === `targeted` ? 3000 : Math.min(attempt * 5000, 20000);
 
 export const shouldStopPolling = (args: {
-  scope: RefreshScope,
-  attempt: number,
-  maxAttempts: number,
-  found: boolean,
+  scope: RefreshScope;
+  attempt: number;
+  maxAttempts: number;
+  found: boolean;
 }): boolean => {
   if (args.scope === `targeted` && args.found) return true;
   return args.attempt >= args.maxAttempts;

--- a/front/lib/front/models/user.ex
+++ b/front/lib/front/models/user.ex
@@ -308,7 +308,7 @@ defmodule Front.Models.User do
     end)
   end
 
-  def delete_with_owned_orgs(user_id, metadata \\ nil) do
+  def delete_user(user_id, metadata \\ nil) do
     Watchman.benchmark("delete_user_with_owned_orgs.duration", fn ->
       req = InternalApi.User.DeleteWithOwnedOrgsRequest.new(user_id: user_id)
 

--- a/front/lib/front/models/user.ex
+++ b/front/lib/front/models/user.ex
@@ -321,6 +321,21 @@ defmodule Front.Models.User do
         {:ok, user} ->
           {:ok, construct(user)}
 
+        {:error, %GRPC.RPCError{status: status, message: message} = error} ->
+          if status in [GRPC.Status.failed_precondition(), GRPC.Status.invalid_argument()] do
+            Logger.error(
+              "[User Model] Account deletion rejected for #{inspect(user_id)}: #{message}"
+            )
+
+            {:error, message}
+          else
+            Logger.error(
+              "[User Model] Error while deleting user with owned orgs #{inspect(user_id)}: #{inspect(error)}"
+            )
+
+            {:error, "Failed to delete account."}
+          end
+
         {:error, error} ->
           Logger.error(
             "[User Model] Error while deleting user with owned orgs #{inspect(user_id)}: #{inspect(error)}"

--- a/front/lib/front_web/controllers/account_controller.ex
+++ b/front/lib/front_web/controllers/account_controller.ex
@@ -248,12 +248,12 @@ defmodule FrontWeb.AccountController do
     end)
   end
 
-  def delete_with_owned_orgs(conn, _params) do
+  def delete_user(conn, _params) do
     Watchman.benchmark("account.delete_with_owned_orgs.duration", fn ->
       user_id = conn.assigns.user_id
       tracing_headers = conn.assigns.tracing_headers
 
-      case Models.User.delete_with_owned_orgs(user_id, tracing_headers) do
+      case Models.User.delete_user(user_id, tracing_headers) do
         {:ok, _user} ->
           conn
           |> redirect(external: destroyed_account_redirect_url(conn))

--- a/front/lib/front_web/controllers/people_controller.ex
+++ b/front/lib/front_web/controllers/people_controller.ex
@@ -11,7 +11,7 @@ defmodule FrontWeb.PeopleController do
   @all_management_pages @old_management_pages ++ ~w(create_member)a
   @project_actions ~w(project fetch_project_non_members)a
   @person_manage_action ~w(reset_password change_email)a
-  @self_manage_action ~w(update reset_token update_repo_scope delete_with_owned_orgs)a
+  @self_manage_action ~w(update reset_token update_repo_scope delete_user)a
   @person_action @person_manage_action ++ @self_manage_action ++ ~w(show)a
 
   plug(FetchPermissions, [scope: "org"] when action in @all_management_pages)
@@ -737,9 +737,9 @@ defmodule FrontWeb.PeopleController do
     end)
   end
 
-  def delete_with_owned_orgs(conn, %{"user_id" => user_id}) do
+  def delete_user(conn, %{"user_id" => user_id}) do
     Watchman.benchmark("people.delete_with_owned_orgs", fn ->
-      case Models.User.delete_with_owned_orgs(user_id, conn.assigns.tracing_headers) do
+      case Models.User.delete_user(user_id, conn.assigns.tracing_headers) do
         {:ok, _user} ->
           conn
           |> redirect(external: destroyed_account_redirect_url(conn))

--- a/front/lib/front_web/router.ex
+++ b/front/lib/front_web/router.ex
@@ -71,7 +71,7 @@ defmodule FrontWeb.Router do
     post("/account/change_email", AccountController, :change_my_email)
     post("/account/reset_my_password", AccountController, :reset_my_password)
     post("/account/update_repo_scope/:provider", AccountController, :update_repo_scope)
-    post("/account/delete_with_owned_orgs", AccountController, :delete_with_owned_orgs)
+    post("/account/delete_user", AccountController, :delete_user)
 
     get("/sso/zendesk", SSOController, :zendesk)
 
@@ -168,7 +168,7 @@ defmodule FrontWeb.Router do
 
       get("/:user_id", PeopleController, :show)
       post("/:user_id", PeopleController, :update)
-      post("/:user_id/delete_with_owned_orgs", PeopleController, :delete_with_owned_orgs)
+      post("/:user_id/delete_user", PeopleController, :delete_user)
       post("/:user_id/reset_token", PeopleController, :reset_token)
       post("/:user_id/reset_password", PeopleController, :reset_password)
       post("/:user_id/change_email", PeopleController, :change_email)

--- a/front/lib/front_web/templates/account/show.html.eex
+++ b/front/lib/front_web/templates/account/show.html.eex
@@ -199,12 +199,12 @@
             This action permanently deletes your account and cannot be undone.
           </p>
           <p class="mb3">
-            Every organization where you are the sole owner will also be permanently deleted.
+            If you are the last owner of an organization, you must transfer ownership or delete that organization before you can delete your account.
           </p>
           <%= form_for @conn, account_path(@conn, :delete_with_owned_orgs), [class: "mb0"], fn _f -> %>
-            <%= submit "Delete account and owned organizations",
+            <%= submit "Delete account",
               class: "btn btn-danger",
-              data: [confirm: "This will permanently delete your account and all organizations where you are the sole owner. This action cannot be undone. Continue?"] %>
+              data: [confirm: "This will permanently delete your account. This action cannot be undone. Continue?"] %>
           <% end %>
         </div>
       </div>

--- a/front/lib/front_web/templates/account/show.html.eex
+++ b/front/lib/front_web/templates/account/show.html.eex
@@ -201,7 +201,7 @@
           <p class="mb3">
             If you are the last owner of an organization, you must transfer ownership or delete that organization before you can delete your account.
           </p>
-          <%= form_for @conn, account_path(@conn, :delete_with_owned_orgs), [class: "mb0"], fn _f -> %>
+          <%= form_for @conn, account_path(@conn, :delete_user), [class: "mb0"], fn _f -> %>
             <%= submit "Delete account",
               class: "btn btn-danger",
               data: [confirm: "This will permanently delete your account. This action cannot be undone. Continue?"] %>

--- a/front/lib/front_web/templates/people/show.html.eex
+++ b/front/lib/front_web/templates/people/show.html.eex
@@ -213,12 +213,12 @@
             This action permanently deletes your account and cannot be undone.
           </p>
           <p class="mb3">
-            Every organization where you are the sole owner will also be permanently deleted.
+            If you are the last owner of an organization, you must transfer ownership or delete that organization before you can delete your account.
           </p>
           <%= form_for @conn, people_path(@conn, :delete_with_owned_orgs, @user.id), [class: "mb0"], fn _f -> %>
-            <%= submit "Delete account and owned organizations",
+            <%= submit "Delete account",
               class: "btn btn-danger",
-              data: [confirm: "This will permanently delete your account and all organizations where you are the sole owner. This action cannot be undone. Continue?"] %>
+              data: [confirm: "This will permanently delete your account. This action cannot be undone. Continue?"] %>
           <% end %>
         </div>
       </div>

--- a/front/lib/front_web/templates/people/show.html.eex
+++ b/front/lib/front_web/templates/people/show.html.eex
@@ -215,7 +215,7 @@
           <p class="mb3">
             If you are the last owner of an organization, you must transfer ownership or delete that organization before you can delete your account.
           </p>
-          <%= form_for @conn, people_path(@conn, :delete_with_owned_orgs, @user.id), [class: "mb0"], fn _f -> %>
+          <%= form_for @conn, people_path(@conn, :delete_user, @user.id), [class: "mb0"], fn _f -> %>
             <%= submit "Delete account",
               class: "btn btn-danger",
               data: [confirm: "This will permanently delete your account. This action cannot be undone. Continue?"] %>

--- a/front/test/front/models/scheduler_test.exs
+++ b/front/test/front/models/scheduler_test.exs
@@ -1,5 +1,5 @@
 defmodule Front.Models.SchedulerTest do
-  use ExUnit.Case
+  use Front.TestCase
 
   import Mock
 

--- a/front/test/front_web/controllers/account_controller_test.exs
+++ b/front/test/front_web/controllers/account_controller_test.exs
@@ -153,11 +153,11 @@ defmodule FrontWeb.AccountControllerTest do
     end
   end
 
-  describe "POST delete_with_owned_orgs" do
+  describe "POST delete_user" do
     test "deletes account and redirects to destroyed account page", %{conn: conn} do
       conn =
         conn
-        |> post("/account/delete_with_owned_orgs")
+        |> post("/account/delete_user")
 
       assert redirected_to(conn) == "https://id.semaphoretest.test/destroyed_account"
     end
@@ -168,7 +168,7 @@ defmodule FrontWeb.AccountControllerTest do
 
       conn =
         conn
-        |> post("/account/delete_with_owned_orgs")
+        |> post("/account/delete_user")
 
       assert redirected_to(conn) == "/account"
       assert get_flash(conn, :alert) == "Failed to delete account."
@@ -187,7 +187,7 @@ defmodule FrontWeb.AccountControllerTest do
 
       conn =
         conn
-        |> post("/account/delete_with_owned_orgs")
+        |> post("/account/delete_user")
 
       assert redirected_to(conn) == "/account"
       assert get_flash(conn, :alert) == message

--- a/front/test/front_web/controllers/account_controller_test.exs
+++ b/front/test/front_web/controllers/account_controller_test.exs
@@ -32,7 +32,7 @@ defmodule FrontWeb.AccountControllerTest do
 
       assert get_req_header(conn, "x-semaphore-org-id") == []
       assert html_response(conn, 200) =~ "Danger Zone"
-      assert html_response(conn, 200) =~ "Delete account and owned organizations"
+      assert html_response(conn, 200) =~ "transfer ownership"
       assert html_response(conn, 200) =~ "/account/update_repo_scope/bitbucket"
       refute html_response(conn, 200) =~ "/account/update_repo_scope/github"
     end
@@ -172,6 +172,25 @@ defmodule FrontWeb.AccountControllerTest do
 
       assert redirected_to(conn) == "/account"
       assert get_flash(conn, :alert) == "Failed to delete account."
+    end
+
+    test "when backend rejects with a precondition => surfaces the backend message", %{
+      conn: conn
+    } do
+      message =
+        "You are the last owner of organization(s): Acme. " <>
+          "Transfer ownership or delete the organization first before you can delete your account."
+
+      GrpcMock.stub(UserMock, :delete_with_owned_orgs, fn _req, _ ->
+        raise GRPC.RPCError, status: GRPC.Status.failed_precondition(), message: message
+      end)
+
+      conn =
+        conn
+        |> post("/account/delete_with_owned_orgs")
+
+      assert redirected_to(conn) == "/account"
+      assert get_flash(conn, :alert) == message
     end
   end
 

--- a/front/test/front_web/controllers/people_controller_test.exs
+++ b/front/test/front_web/controllers/people_controller_test.exs
@@ -594,14 +594,14 @@ defmodule FrontWeb.PeopleControllerTest do
     end
   end
 
-  describe "POST delete_with_owned_orgs" do
+  describe "POST delete_user" do
     test "user on own page deletes account and is redirected to destroyed account page", %{
       conn: conn,
       user: user
     } do
       conn =
         conn
-        |> post("/people/#{user.id}/delete_with_owned_orgs")
+        |> post("/people/#{user.id}/delete_user")
 
       assert redirected_to(conn) == "https://id.semaphoretest.test/destroyed_account"
     end
@@ -611,7 +611,7 @@ defmodule FrontWeb.PeopleControllerTest do
 
       conn =
         conn
-        |> post("/people/#{user.id}/delete_with_owned_orgs")
+        |> post("/people/#{user.id}/delete_user")
 
       assert redirected_to(conn) == "/people/#{user.id}"
       assert get_flash(conn, :alert) == "Failed to delete account."
@@ -631,7 +631,7 @@ defmodule FrontWeb.PeopleControllerTest do
 
       conn =
         conn
-        |> post("/people/#{user.id}/delete_with_owned_orgs")
+        |> post("/people/#{user.id}/delete_user")
 
       assert redirected_to(conn) == "/people/#{user.id}"
       assert get_flash(conn, :alert) == message

--- a/front/test/front_web/controllers/people_controller_test.exs
+++ b/front/test/front_web/controllers/people_controller_test.exs
@@ -164,7 +164,7 @@ defmodule FrontWeb.PeopleControllerTest do
       assert html_response(conn, 200) =~ "Reset Password"
       assert html_response(conn, 200) =~ "Reset API Token"
       assert html_response(conn, 200) =~ "Danger Zone"
-      assert html_response(conn, 200) =~ "Delete account and owned organizations"
+      assert html_response(conn, 200) =~ "transfer ownership"
     end
 
     test "user on own page when email_members is disabled => hides update email form", %{
@@ -615,6 +615,26 @@ defmodule FrontWeb.PeopleControllerTest do
 
       assert redirected_to(conn) == "/people/#{user.id}"
       assert get_flash(conn, :alert) == "Failed to delete account."
+    end
+
+    test "when backend rejects with a precondition => surfaces the backend message", %{
+      conn: conn,
+      user: user
+    } do
+      message =
+        "You are the last owner of organization(s): Acme. " <>
+          "Transfer ownership or delete the organization first before you can delete your account."
+
+      GrpcMock.stub(UserMock, :delete_with_owned_orgs, fn _req, _ ->
+        raise GRPC.RPCError, status: GRPC.Status.failed_precondition(), message: message
+      end)
+
+      conn =
+        conn
+        |> post("/people/#{user.id}/delete_with_owned_orgs")
+
+      assert redirected_to(conn) == "/people/#{user.id}"
+      assert get_flash(conn, :alert) == message
     end
   end
 

--- a/guard/config/config.exs
+++ b/guard/config/config.exs
@@ -33,6 +33,7 @@ config :guard,
   feature_app_endpoint: "127.0.0.1:50052",
   instance_config_grpc_endpoint: "127.0.0.1:50051",
   rbac_grpc_endpoint: "127.0.0.1:50052",
+  groups_grpc_endpoint: "127.0.0.1:50052",
   okta_grpc_endpoint: "127.0.0.1:50052"
 
 config :guard, Guard.Repo,

--- a/guard/config/runtime.exs
+++ b/guard/config/runtime.exs
@@ -164,6 +164,10 @@ if config_env() == :prod do
     feature_api_endpoint: System.fetch_env!("INTERNAL_API_URL_FEATURE"),
     instance_config_grpc_endpoint: System.fetch_env!("INTERNAL_API_URL_INSTANCE_CONFIG"),
     rbac_grpc_endpoint: System.fetch_env!("INTERNAL_API_URL_RBAC"),
+    # Backends without a separate Groups deployment never serve GROUP-typed
+    # owner subjects, so the fallback endpoint is never actually called there.
+    groups_grpc_endpoint:
+      System.get_env("INTERNAL_API_URL_GROUPS") || System.fetch_env!("INTERNAL_API_URL_RBAC"),
     okta_grpc_endpoint: System.fetch_env!("INTERNAL_API_URL_OKTA")
 end
 

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -33,12 +33,15 @@ defmodule Guard.Api.Rbac do
   end
 
   @doc """
-  Returns `{:ok, subject_ids}` for the users holding the Owner role in the
-  organization (deduped). Owners are fetched with a server-side role filter, so
-  the cost is proportional to the number of owners rather than to the total
-  membership. Returns `{:error, :owner_role_unresolved}` when the org has no
-  role named "Owner" (missing/renamed) — callers must fail closed, since
-  ownership cannot be proven.
+  Returns `{:ok, subject_ids}` for the users who effectively hold the Owner
+  role in the organization (deduped): users owning directly, plus the members
+  of any group that holds the role — ownership can be granted through a group,
+  and those users must count when deciding whether someone is the last owner.
+  Owners are fetched with a server-side role filter, so the cost is
+  proportional to the number of owners rather than to the total membership.
+  Returns `{:error, :owner_role_unresolved}` when the org has no role named
+  "Owner" (missing/renamed) — callers must fail closed, since ownership cannot
+  be proven.
   """
   def org_owner_ids(org_id) do
     case get_role_id(org_id, @owner_role_name, :SCOPE_ORG) do
@@ -51,18 +54,32 @@ defmodule Guard.Api.Rbac do
         {:error, :owner_role_unresolved}
 
       role_id ->
-        ids =
+        group_member_ids =
           org_id
-          |> collect_members("", role_id)
-          |> Enum.map(& &1.subject.subject_id)
-          |> Enum.uniq()
+          |> owner_subject_ids(role_id, :GROUP)
+          |> Enum.flat_map(&group_member_ids(org_id, &1))
 
-        {:ok, ids}
+        {:ok, Enum.uniq(owner_subject_ids(org_id, role_id, :USER) ++ group_member_ids)}
     end
   rescue
     e ->
       Logger.warning("[Guard.Api.Rbac] owner lookup failed for org #{org_id}: #{inspect(e)}")
       {:error, :ownership_unverified}
+  end
+
+  defp owner_subject_ids(org_id, role_id, member_type) do
+    org_id
+    |> collect_members("", role_id, member_type)
+    |> Enum.map(& &1.subject.subject_id)
+    |> Enum.uniq()
+  end
+
+  defp group_member_ids(org_id, group_id) do
+    req = InternalApi.Groups.ListGroupsRequest.new(org_id: org_id, group_id: group_id)
+
+    {:ok, response} = InternalApi.Groups.Groups.Stub.list_groups(channel(), req, timeout: 30_000)
+
+    Enum.flat_map(response.groups, & &1.member_ids)
   end
 
   # ListMembers pagination differs between editions: EE is 0-based
@@ -71,12 +88,12 @@ defmodule Guard.Api.Rbac do
   # fixed page-number convention or `total_pages`. Walk pages from 0, dedup by
   # subject_id (CE repeats the first page), and stop once a page comes back
   # shorter than a full page, which terminates on either backend.
-  defp collect_members(org_id, project_id, role_id) do
+  defp collect_members(org_id, project_id, role_id, member_type \\ :USER) do
     {members, _seen} =
       0
       |> Stream.iterate(&(&1 + 1))
       |> Enum.reduce_while({[], MapSet.new()}, fn page_no, {acc, seen} ->
-        page = fetch_member_page(org_id, project_id, role_id, page_no)
+        page = fetch_member_page(org_id, project_id, role_id, page_no, member_type)
 
         {acc, seen} =
           Enum.reduce(page, {acc, seen}, fn member, {acc, seen} ->
@@ -95,20 +112,20 @@ defmodule Guard.Api.Rbac do
     Enum.reverse(members)
   end
 
-  defp fetch_member_page(org_id, project_id, role_id, page_no) do
-    req = build_list_members_request(org_id, project_id, role_id, page_no)
+  defp fetch_member_page(org_id, project_id, role_id, page_no, member_type \\ :USER) do
+    req = build_list_members_request(org_id, project_id, role_id, page_no, member_type)
 
     {:ok, response} = InternalApi.RBAC.RBAC.Stub.list_members(channel(), req, timeout: 30_000)
 
     response.members
   end
 
-  defp build_list_members_request(org_id, project_id, role_id, page) do
+  defp build_list_members_request(org_id, project_id, role_id, page, member_type) do
     InternalApi.RBAC.ListMembersRequest.new(
       org_id: org_id,
       project_id: project_id,
       member_has_role: role_id,
-      member_type: InternalApi.RBAC.SubjectType.value(:USER),
+      member_type: InternalApi.RBAC.SubjectType.value(member_type),
       page:
         InternalApi.RBAC.ListMembersRequest.Page.new(
           page_no: page,

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -54,12 +54,16 @@ defmodule Guard.Api.Rbac do
   end
 
   def user_part_of_org?(user_id, org_id) do
+    Enum.member?(list_accessible_org_ids(user_id), org_id)
+  end
+
+  def list_accessible_org_ids(user_id) do
     req = InternalApi.RBAC.ListAccessibleOrgsRequest.new(user_id: user_id)
 
     {:ok, response} =
       InternalApi.RBAC.RBAC.Stub.list_accessible_orgs(channel(), req, timeout: 30_000)
 
-    Enum.member?(response.org_ids, org_id)
+    response.org_ids
   end
 
   defp get_role_id(org_id, role_name, scope) do

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -2,7 +2,9 @@ defmodule Guard.Api.Rbac do
   @list_page_size 100
   @owner_role_name "Owner"
 
-  def list_members(org_id, project_id \\ ""), do: do_list_members(org_id, project_id, "", 0, [])
+  def list_members(org_id, project_id \\ ""), do: collect_members(org_id, project_id, "")
+
+  def no_of_members(org_id), do: org_id |> collect_members("", "") |> length()
 
   @doc """
   Returns the unique subject ids of the users holding the Owner role in the
@@ -17,42 +19,48 @@ defmodule Guard.Api.Rbac do
 
       role_id ->
         org_id
-        |> do_list_members("", role_id, 0, [])
+        |> collect_members("", role_id)
         |> Enum.map(& &1.subject.subject_id)
         |> Enum.uniq()
     end
   end
 
-  # Pages are 0-indexed: the RBAC backend offsets by `page_no * page_size`, so the
-  # first page is page 0 and we keep fetching while a later page exists.
-  defp do_list_members(org_id, project_id, role_id, page_no, acc) do
+  # ListMembers pagination differs between editions: EE is 0-based
+  # (offset = page_no * size) while CE is 1-based and coerces page_no 0 to 1
+  # (so page_no 0 and 1 both return the first page). We therefore cannot trust a
+  # fixed page-number convention or `total_pages`. Walk pages from 0, dedup by
+  # subject_id (CE repeats the first page), and stop once a page comes back
+  # shorter than a full page, which terminates on either backend.
+  defp collect_members(org_id, project_id, role_id) do
+    {members, _seen} =
+      0
+      |> Stream.iterate(&(&1 + 1))
+      |> Enum.reduce_while({[], MapSet.new()}, fn page_no, {acc, seen} ->
+        page = fetch_member_page(org_id, project_id, role_id, page_no)
+
+        {acc, seen} =
+          Enum.reduce(page, {acc, seen}, fn member, {acc, seen} ->
+            id = member.subject.subject_id
+
+            if MapSet.member?(seen, id),
+              do: {acc, seen},
+              else: {[member | acc], MapSet.put(seen, id)}
+          end)
+
+        if length(page) < @list_page_size,
+          do: {:halt, {acc, seen}},
+          else: {:cont, {acc, seen}}
+      end)
+
+    Enum.reverse(members)
+  end
+
+  defp fetch_member_page(org_id, project_id, role_id, page_no) do
     req = build_list_members_request(org_id, project_id, role_id, page_no)
 
     {:ok, response} = InternalApi.RBAC.RBAC.Stub.list_members(channel(), req, timeout: 30_000)
 
-    acc = acc ++ response.members
-
-    if page_no + 1 < response.total_pages do
-      do_list_members(org_id, project_id, role_id, page_no + 1, acc)
-    else
-      acc
-    end
-  end
-
-  def no_of_members(org_id), do: do_no_of_members(org_id, 0, 0)
-
-  defp do_no_of_members(org_id, page_no, acc) do
-    req = build_list_members_request(org_id, "", "", page_no)
-
-    {:ok, response} = InternalApi.RBAC.RBAC.Stub.list_members(channel(), req, timeout: 30_000)
-
-    acc = acc + Enum.count(response.members)
-
-    if page_no + 1 < response.total_pages do
-      do_no_of_members(org_id, page_no + 1, acc)
-    else
-      acc
-    end
+    response.members
   end
 
   defp build_list_members_request(org_id, project_id, role_id, page) do

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -15,11 +15,18 @@ defmodule Guard.Api.Rbac do
   Subject ids are deduped because CE returns a row per role assignment.
   """
   def single_member?(org_id) do
-    org_id
-    |> fetch_member_page("", "", 0)
-    |> Enum.map(& &1.subject.subject_id)
-    |> Enum.uniq()
-    |> length() == 1
+    count =
+      org_id
+      |> fetch_member_page("", "", 0)
+      |> Enum.map(& &1.subject.subject_id)
+      |> Enum.uniq()
+      |> length()
+
+    {:ok, count == 1}
+  rescue
+    e ->
+      Logger.warning("[Guard.Api.Rbac] member lookup failed for org #{org_id}: #{inspect(e)}")
+      {:error, :ownership_unverified}
   end
 
   @doc """
@@ -49,6 +56,10 @@ defmodule Guard.Api.Rbac do
 
         {:ok, ids}
     end
+  rescue
+    e ->
+      Logger.warning("[Guard.Api.Rbac] owner lookup failed for org #{org_id}: #{inspect(e)}")
+      {:error, :ownership_unverified}
   end
 
   # ListMembers pagination differs between editions: EE is 0-based

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -23,26 +23,31 @@ defmodule Guard.Api.Rbac do
   end
 
   @doc """
-  Returns the unique subject ids of the users holding the Owner role in the
-  organization. Owners are fetched with a server-side role filter, so the cost
-  is proportional to the number of owners rather than to the total membership.
-  Returns `[]` when the Owner role cannot be resolved.
+  Returns `{:ok, subject_ids}` for the users holding the Owner role in the
+  organization (deduped). Owners are fetched with a server-side role filter, so
+  the cost is proportional to the number of owners rather than to the total
+  membership. Returns `{:error, :owner_role_unresolved}` when the org has no
+  role named "Owner" (missing/renamed) — callers must fail closed, since
+  ownership cannot be proven.
   """
   def org_owner_ids(org_id) do
     case get_role_id(org_id, @owner_role_name, :SCOPE_ORG) do
       nil ->
         Logger.warning(
           "[Guard.Api.Rbac] Owner role not found for org #{org_id}; " <>
-            "returning no owners (org may be ownerless or misconfigured)"
+            "cannot verify ownership (org may be misconfigured or unprovisioned)"
         )
 
-        []
+        {:error, :owner_role_unresolved}
 
       role_id ->
-        org_id
-        |> collect_members("", role_id)
-        |> Enum.map(& &1.subject.subject_id)
-        |> Enum.uniq()
+        ids =
+          org_id
+          |> collect_members("", role_id)
+          |> Enum.map(& &1.subject.subject_id)
+          |> Enum.uniq()
+
+        {:ok, ids}
     end
   end
 

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -12,7 +12,10 @@ defmodule Guard.Api.Rbac do
   Whether the organization has exactly one member. Only the first page is read
   (page 0 maps to offset 0 on both the EE and CE backends), so this stays a
   single request instead of walking the whole membership just to check for one.
-  Subject ids are deduped because CE returns a row per role assignment.
+  Both backends return at most one row per member (CE keys role assignments by
+  user and org, EE groups role bindings by subject), so a short first page is
+  the whole membership and a full one means more than one member; the dedup is
+  only insurance against a backend someday repeating subjects within the page.
   """
   def single_member?(org_id) do
     count =

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -2,7 +2,7 @@ defmodule Guard.Api.Rbac do
   @list_page_size 100
   @owner_role_name "Owner"
 
-  def list_members(org_id, project_id \\ ""), do: do_list_members(org_id, project_id, "", 1, [])
+  def list_members(org_id, project_id \\ ""), do: do_list_members(org_id, project_id, "", 0, [])
 
   @doc """
   Returns the unique subject ids of the users holding the Owner role in the
@@ -17,41 +17,41 @@ defmodule Guard.Api.Rbac do
 
       role_id ->
         org_id
-        |> do_list_members("", role_id, 1, [])
+        |> do_list_members("", role_id, 0, [])
         |> Enum.map(& &1.subject.subject_id)
         |> Enum.uniq()
     end
   end
 
+  # Pages are 0-indexed: the RBAC backend offsets by `page_no * page_size`, so the
+  # first page is page 0 and we keep fetching while a later page exists.
   defp do_list_members(org_id, project_id, role_id, page_no, acc) do
     req = build_list_members_request(org_id, project_id, role_id, page_no)
 
     {:ok, response} = InternalApi.RBAC.RBAC.Stub.list_members(channel(), req, timeout: 30_000)
 
-    if response.total_pages > page_no do
-      do_list_members(org_id, project_id, role_id, page_no + 1, acc ++ response.members)
+    acc = acc ++ response.members
+
+    if page_no + 1 < response.total_pages do
+      do_list_members(org_id, project_id, role_id, page_no + 1, acc)
     else
-      acc ++ response.members
+      acc
     end
   end
 
-  def no_of_members(org_id), do: do_no_of_members(org_id, 1, 0)
+  def no_of_members(org_id), do: do_no_of_members(org_id, 0, 0)
 
   defp do_no_of_members(org_id, page_no, acc) do
     req = build_list_members_request(org_id, "", "", page_no)
 
     {:ok, response} = InternalApi.RBAC.RBAC.Stub.list_members(channel(), req, timeout: 30_000)
-    members_count = Enum.count(response.members)
 
-    # if there is more than one page it is possible to calculate
-    # the total number of members until the last page. Then we
-    # add the number of members from the last page. This will make us not
-    # have to request each page to get the total number of members.
-    if response.total_pages > page_no do
-      members_count = @list_page_size * (response.total_pages - 1)
-      do_no_of_members(org_id, response.total_pages, members_count)
+    acc = acc + Enum.count(response.members)
+
+    if page_no + 1 < response.total_pages do
+      do_no_of_members(org_id, page_no + 1, acc)
     else
-      acc + members_count
+      acc
     end
   end
 

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -7,6 +7,20 @@ defmodule Guard.Api.Rbac do
   def no_of_members(org_id), do: org_id |> collect_members("", "") |> length()
 
   @doc """
+  Whether the organization has exactly one member. Only the first page is read
+  (page 0 maps to offset 0 on both the EE and CE backends), so this stays a
+  single request instead of walking the whole membership just to check for one.
+  Subject ids are deduped because CE returns a row per role assignment.
+  """
+  def single_member?(org_id) do
+    org_id
+    |> fetch_member_page("", "", 0)
+    |> Enum.map(& &1.subject.subject_id)
+    |> Enum.uniq()
+    |> length() == 1
+  end
+
+  @doc """
   Returns the unique subject ids of the users holding the Owner role in the
   organization. Owners are fetched with a server-side role filter, so the cost
   is proportional to the number of owners rather than to the total membership.

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -1,15 +1,35 @@
 defmodule Guard.Api.Rbac do
   @list_page_size 100
+  @owner_role_name "Owner"
 
-  def list_members(org_id, project_id \\ ""), do: do_list_members(org_id, project_id, 1, [])
+  def list_members(org_id, project_id \\ ""), do: do_list_members(org_id, project_id, "", 1, [])
 
-  defp do_list_members(org_id, project_id, page_no, acc) do
-    req = build_list_members_request(org_id, project_id, page_no)
+  @doc """
+  Returns the unique subject ids of the users holding the Owner role in the
+  organization. Owners are fetched with a server-side role filter, so the cost
+  is proportional to the number of owners rather than to the total membership.
+  Returns `[]` when the Owner role cannot be resolved.
+  """
+  def org_owner_ids(org_id) do
+    case get_role_id(org_id, @owner_role_name, :SCOPE_ORG) do
+      nil ->
+        []
+
+      role_id ->
+        org_id
+        |> do_list_members("", role_id, 1, [])
+        |> Enum.map(& &1.subject.subject_id)
+        |> Enum.uniq()
+    end
+  end
+
+  defp do_list_members(org_id, project_id, role_id, page_no, acc) do
+    req = build_list_members_request(org_id, project_id, role_id, page_no)
 
     {:ok, response} = InternalApi.RBAC.RBAC.Stub.list_members(channel(), req, timeout: 30_000)
 
     if response.total_pages > page_no do
-      do_list_members(org_id, project_id, page_no + 1, acc ++ response.members)
+      do_list_members(org_id, project_id, role_id, page_no + 1, acc ++ response.members)
     else
       acc ++ response.members
     end
@@ -18,7 +38,7 @@ defmodule Guard.Api.Rbac do
   def no_of_members(org_id), do: do_no_of_members(org_id, 1, 0)
 
   defp do_no_of_members(org_id, page_no, acc) do
-    req = build_list_members_request(org_id, "", page_no)
+    req = build_list_members_request(org_id, "", "", page_no)
 
     {:ok, response} = InternalApi.RBAC.RBAC.Stub.list_members(channel(), req, timeout: 30_000)
     members_count = Enum.count(response.members)
@@ -35,10 +55,11 @@ defmodule Guard.Api.Rbac do
     end
   end
 
-  defp build_list_members_request(org_id, project_id, page) do
+  defp build_list_members_request(org_id, project_id, role_id, page) do
     InternalApi.RBAC.ListMembersRequest.new(
       org_id: org_id,
       project_id: project_id,
+      member_has_role: role_id,
       member_type: InternalApi.RBAC.SubjectType.value(:USER),
       page:
         InternalApi.RBAC.ListMembersRequest.Page.new(

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -77,7 +77,8 @@ defmodule Guard.Api.Rbac do
   defp group_member_ids(org_id, group_id) do
     req = InternalApi.Groups.ListGroupsRequest.new(org_id: org_id, group_id: group_id)
 
-    {:ok, response} = InternalApi.Groups.Groups.Stub.list_groups(channel(), req, timeout: 30_000)
+    {:ok, response} =
+      InternalApi.Groups.Groups.Stub.list_groups(groups_channel(), req, timeout: 30_000)
 
     Enum.flat_map(response.groups, & &1.member_ids)
   end
@@ -222,6 +223,13 @@ defmodule Guard.Api.Rbac do
 
   defp channel do
     {:ok, channel} = GRPC.Stub.connect(Application.fetch_env!(:guard, :rbac_grpc_endpoint))
+
+    channel
+  end
+
+  # The Groups API is served by its own deployment, not by the RBAC endpoint.
+  defp groups_channel do
+    {:ok, channel} = GRPC.Stub.connect(Application.fetch_env!(:guard, :groups_grpc_endpoint))
 
     channel
   end

--- a/guard/lib/guard/api/rbac.ex
+++ b/guard/lib/guard/api/rbac.ex
@@ -1,4 +1,6 @@
 defmodule Guard.Api.Rbac do
+  require Logger
+
   @list_page_size 100
   @owner_role_name "Owner"
 
@@ -29,6 +31,11 @@ defmodule Guard.Api.Rbac do
   def org_owner_ids(org_id) do
     case get_role_id(org_id, @owner_role_name, :SCOPE_ORG) do
       nil ->
+        Logger.warning(
+          "[Guard.Api.Rbac] Owner role not found for org #{org_id}; " <>
+            "returning no owners (org may be ownerless or misconfigured)"
+        )
+
         []
 
       role_id ->

--- a/guard/lib/guard/grpc_servers/user_server.ex
+++ b/guard/lib/guard/grpc_servers/user_server.ex
@@ -343,16 +343,40 @@ defmodule Guard.GrpcServers.UserServer do
     end)
   end
 
-  defp blocking_orgs_message([{_id, name}]) do
+  defp blocking_orgs_message(orgs) do
+    {unverified, owned} =
+      Enum.split_with(orgs, fn {_id, _name, reason} -> reason == :ownership_unverified end)
+
+    [owned_sentence(org_names(owned)), unverified_sentence(org_names(unverified))]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join(" ")
+  end
+
+  defp org_names(orgs), do: Enum.map(orgs, fn {_id, name, _reason} -> name end)
+
+  defp owned_sentence([]), do: ""
+
+  defp owned_sentence([name]) do
     "You are the last owner of #{name}. " <>
       "Transfer ownership or delete it first before you can delete your account."
   end
 
-  defp blocking_orgs_message(orgs) do
-    names = Enum.map_join(orgs, ", ", fn {_id, name} -> name end)
-
-    "You are the last owner of these organizations: #{names}. " <>
+  defp owned_sentence(names) do
+    "You are the last owner of these organizations: #{Enum.join(names, ", ")}. " <>
       "Transfer ownership or delete them first before you can delete your account."
+  end
+
+  defp unverified_sentence([]), do: ""
+
+  defp unverified_sentence([name]) do
+    "We couldn't verify ownership of #{name}. If you are the owner, " <>
+      "transfer ownership or delete it first (or contact support) before deleting your account."
+  end
+
+  defp unverified_sentence(names) do
+    "We couldn't verify ownership of these organizations: #{Enum.join(names, ", ")}. " <>
+      "If you are the owner, transfer ownership or delete them first (or contact support) " <>
+      "before deleting your account."
   end
 
   @spec create(User.CreateRequest.t(), GRPC.Server.Stream.t()) :: User.User.t()

--- a/guard/lib/guard/grpc_servers/user_server.ex
+++ b/guard/lib/guard/grpc_servers/user_server.ex
@@ -334,7 +334,7 @@ defmodule Guard.GrpcServers.UserServer do
           # still orphan an org. Closing that race needs RBAC-side enforcement.
           case Guard.Store.Organization.orgs_blocking_user_deletion(user.id) do
             [] ->
-              handle_delete_with_owned_orgs(user.id)
+              handle_delete_user(user.id)
 
             orgs ->
               grpc_error!(:failed_precondition, blocking_orgs_message(orgs))
@@ -455,8 +455,8 @@ defmodule Guard.GrpcServers.UserServer do
     end
   end
 
-  defp handle_delete_with_owned_orgs(user_id) do
-    case Front.delete_with_owned_orgs(user_id) do
+  defp handle_delete_user(user_id) do
+    case Front.delete_user(user_id) do
       {:ok, _} ->
         Guard.Events.UserDeleted.publish(user_id, @user_exchange, @deleted_routing_key)
         User.User.new(id: user_id)

--- a/guard/lib/guard/grpc_servers/user_server.ex
+++ b/guard/lib/guard/grpc_servers/user_server.ex
@@ -338,11 +338,16 @@ defmodule Guard.GrpcServers.UserServer do
     end)
   end
 
+  defp blocking_orgs_message([{_id, name}]) do
+    "You are the last owner of #{name}. " <>
+      "Transfer ownership or delete it first before you can delete your account."
+  end
+
   defp blocking_orgs_message(orgs) do
     names = Enum.map_join(orgs, ", ", fn {_id, name} -> name end)
 
-    "You are the last owner of organization(s): #{names}. " <>
-      "Transfer ownership or delete the organization first before you can delete your account."
+    "You are the last owner of these organizations: #{names}. " <>
+      "Transfer ownership or delete them first before you can delete your account."
   end
 
   @spec create(User.CreateRequest.t(), GRPC.Server.Stream.t()) :: User.User.t()

--- a/guard/lib/guard/grpc_servers/user_server.ex
+++ b/guard/lib/guard/grpc_servers/user_server.ex
@@ -327,9 +327,22 @@ defmodule Guard.GrpcServers.UserServer do
             grpc_error!(:invalid_argument, "User #{user_id} is owner of projects.")
           end
 
-          handle_delete_with_owned_orgs(user.id)
+          case Guard.Store.Organization.orgs_blocking_user_deletion(user.id) do
+            [] ->
+              handle_delete_with_owned_orgs(user.id)
+
+            orgs ->
+              grpc_error!(:failed_precondition, blocking_orgs_message(orgs))
+          end
       end
     end)
+  end
+
+  defp blocking_orgs_message(orgs) do
+    names = Enum.map_join(orgs, ", ", fn {_id, name} -> name end)
+
+    "You are the last owner of organization(s): #{names}. " <>
+      "Transfer ownership or delete the organization first before you can delete your account."
   end
 
   @spec create(User.CreateRequest.t(), GRPC.Server.Stream.t()) :: User.User.t()

--- a/guard/lib/guard/grpc_servers/user_server.ex
+++ b/guard/lib/guard/grpc_servers/user_server.ex
@@ -324,7 +324,10 @@ defmodule Guard.GrpcServers.UserServer do
 
         {:ok, user} ->
           if Guard.Api.Project.user_has_any_project?(user_id) do
-            grpc_error!(:invalid_argument, "User #{user_id} is owner of projects.")
+            grpc_error!(
+              :invalid_argument,
+              "You still own projects — transfer or delete them first."
+            )
           end
 
           case Guard.Store.Organization.orgs_blocking_user_deletion(user.id) do

--- a/guard/lib/guard/grpc_servers/user_server.ex
+++ b/guard/lib/guard/grpc_servers/user_server.ex
@@ -330,6 +330,8 @@ defmodule Guard.GrpcServers.UserServer do
             )
           end
 
+          # Best-effort: a co-owner removed between this check and the delete can
+          # still orphan an org. Closing that race needs RBAC-side enforcement.
           case Guard.Store.Organization.orgs_blocking_user_deletion(user.id) do
             [] ->
               handle_delete_with_owned_orgs(user.id)

--- a/guard/lib/guard/store/organization.ex
+++ b/guard/lib/guard/store/organization.ex
@@ -71,7 +71,7 @@ defmodule Guard.Store.Organization do
 
   # The user is known to be a member of the org (it came from their accessible
   # orgs), so a total of one member means that member is the user.
-  defp sole_member?(org_id), do: Guard.Api.Rbac.no_of_members(org_id) == 1
+  defp sole_member?(org_id), do: Guard.Api.Rbac.single_member?(org_id)
 
   defp last_owner?(org_id, user_id) do
     owner_ids = Guard.Api.Rbac.org_owner_ids(org_id)

--- a/guard/lib/guard/store/organization.ex
+++ b/guard/lib/guard/store/organization.ex
@@ -58,8 +58,20 @@ defmodule Guard.Store.Organization do
   def orgs_blocking_user_deletion(user_id) do
     user_id
     |> Guard.Api.Rbac.list_accessible_org_ids()
-    |> Enum.filter(&blocks_user_deletion?(&1, user_id))
-    |> Enum.map(&{&1, org_name(&1)})
+    |> active_orgs()
+    |> Enum.filter(fn {org_id, _name} -> blocks_user_deletion?(org_id, user_id) end)
+  end
+
+  # Only active orgs can block account deletion: a user may still own soft-deleted
+  # orgs (pending hard-delete, RBAC bindings not yet retracted), and those must not
+  # prevent deletion. list_by_ids/1 already filters out soft-deleted rows and gives
+  # us the names for the message; accessible order is preserved for a stable message.
+  defp active_orgs(org_ids) do
+    names_by_id = org_ids |> list_by_ids() |> Map.new(&{&1.id, &1.name})
+
+    org_ids
+    |> Enum.filter(&Map.has_key?(names_by_id, &1))
+    |> Enum.map(&{&1, names_by_id[&1]})
   end
 
   # Decided from a member count and an owner-only lookup so we never enumerate
@@ -76,13 +88,6 @@ defmodule Guard.Store.Organization do
   defp last_owner?(org_id, user_id) do
     owner_ids = Guard.Api.Rbac.org_owner_ids(org_id)
     user_id in owner_ids and length(owner_ids) == 1
-  end
-
-  defp org_name(org_id) do
-    case get_by_id(org_id) do
-      {:ok, org} -> org.name
-      _ -> org_id
-    end
   end
 
   @doc """

--- a/guard/lib/guard/store/organization.ex
+++ b/guard/lib/guard/store/organization.ex
@@ -85,17 +85,19 @@ defmodule Guard.Store.Organization do
   # deadline). Returns nil when the org does not block deletion.
   defp block_reason(org_id, user_id) do
     # The user came from their accessible orgs, so one member means it's them.
-    if Guard.Api.Rbac.single_member?(org_id) do
-      :sole_member
-    else
-      case Guard.Api.Rbac.org_owner_ids(org_id) do
-        {:ok, owner_ids} ->
-          if user_id in owner_ids and length(owner_ids) == 1, do: :last_owner
+    case Guard.Api.Rbac.single_member?(org_id) do
+      {:ok, true} -> :sole_member
+      {:ok, false} -> owner_block(org_id, user_id)
+      # Can't reach RBAC to count members → can't prove it's safe → block.
+      {:error, _} -> :ownership_unverified
+    end
+  end
 
-        # Can't resolve the Owner role → can't prove deletion is safe → block.
-        {:error, _reason} ->
-          :ownership_unverified
-      end
+  defp owner_block(org_id, user_id) do
+    case Guard.Api.Rbac.org_owner_ids(org_id) do
+      {:ok, owner_ids} -> if user_id in owner_ids and length(owner_ids) == 1, do: :last_owner
+      # Owner role unresolved or RBAC error → can't prove it's safe → block.
+      {:error, _} -> :ownership_unverified
     end
   end
 

--- a/guard/lib/guard/store/organization.ex
+++ b/guard/lib/guard/store/organization.ex
@@ -51,15 +51,21 @@ defmodule Guard.Store.Organization do
   def no_of_members(org_id), do: Guard.Api.Rbac.no_of_members(org_id)
 
   @doc """
-  Returns the organizations that block deletion of the given user because the
-  user is the sole member or the last Owner of them. Each entry is
-  `{org_id, org_name}`. An empty list means the user can be deleted.
+  Returns the organizations that block deletion of the given user, each as
+  `{org_id, name, reason}` where reason is `:sole_member`, `:last_owner`, or
+  `:ownership_unverified` (the Owner role could not be resolved, so we fail
+  closed). An empty list means the user can be deleted.
   """
   def orgs_blocking_user_deletion(user_id) do
     user_id
     |> Guard.Api.Rbac.list_accessible_org_ids()
     |> active_orgs()
-    |> Enum.filter(fn {org_id, _name} -> blocks_user_deletion?(org_id, user_id) end)
+    |> Enum.flat_map(fn {org_id, name} ->
+      case block_reason(org_id, user_id) do
+        nil -> []
+        reason -> [{org_id, name, reason}]
+      end
+    end)
   end
 
   # Only active orgs can block account deletion: a user may still own soft-deleted
@@ -74,20 +80,23 @@ defmodule Guard.Store.Organization do
     |> Enum.map(&{&1, names_by_id[&1]})
   end
 
-  # Decided from a member count and an owner-only lookup so we never enumerate
-  # every member of the org, which is prohibitively slow for large orgs on a
-  # request that carries a hard 30s deadline.
-  defp blocks_user_deletion?(org_id, user_id) do
-    sole_member?(org_id) or last_owner?(org_id, user_id)
-  end
+  # Member count and an owner-only lookup, so we never enumerate every member of
+  # the org (prohibitively slow for large orgs on a request with a hard 30s
+  # deadline). Returns nil when the org does not block deletion.
+  defp block_reason(org_id, user_id) do
+    # The user came from their accessible orgs, so one member means it's them.
+    if Guard.Api.Rbac.single_member?(org_id) do
+      :sole_member
+    else
+      case Guard.Api.Rbac.org_owner_ids(org_id) do
+        {:ok, owner_ids} ->
+          if user_id in owner_ids and length(owner_ids) == 1, do: :last_owner
 
-  # The user is known to be a member of the org (it came from their accessible
-  # orgs), so a total of one member means that member is the user.
-  defp sole_member?(org_id), do: Guard.Api.Rbac.single_member?(org_id)
-
-  defp last_owner?(org_id, user_id) do
-    owner_ids = Guard.Api.Rbac.org_owner_ids(org_id)
-    user_id in owner_ids and length(owner_ids) == 1
+        # Can't resolve the Owner role → can't prove deletion is safe → block.
+        {:error, _reason} ->
+          :ownership_unverified
+      end
+    end
   end
 
   @doc """

--- a/guard/lib/guard/store/organization.ex
+++ b/guard/lib/guard/store/organization.ex
@@ -50,8 +50,6 @@ defmodule Guard.Store.Organization do
 
   def no_of_members(org_id), do: Guard.Api.Rbac.no_of_members(org_id)
 
-  @owner_role_name "Owner"
-
   @doc """
   Returns the organizations that block deletion of the given user because the
   user is the sole member or the last Owner of them. Each entry is
@@ -64,27 +62,20 @@ defmodule Guard.Store.Organization do
     |> Enum.map(&{&1, org_name(&1)})
   end
 
+  # Decided from a member count and an owner-only lookup so we never enumerate
+  # every member of the org, which is prohibitively slow for large orgs on a
+  # request that carries a hard 30s deadline.
   defp blocks_user_deletion?(org_id, user_id) do
-    members = Guard.Api.Rbac.list_members(org_id)
-
-    member_ids = members |> Enum.map(& &1.subject.subject_id) |> Enum.uniq()
-
-    owner_ids =
-      members
-      |> Enum.filter(&owner?/1)
-      |> Enum.map(& &1.subject.subject_id)
-      |> Enum.uniq()
-
-    sole_member? = member_ids == [user_id]
-    last_owner? = user_id in owner_ids and length(owner_ids) == 1
-
-    sole_member? or last_owner?
+    sole_member?(org_id) or last_owner?(org_id, user_id)
   end
 
-  defp owner?(member) do
-    Enum.any?(member.subject_role_bindings, fn binding ->
-      binding.role && binding.role.name == @owner_role_name
-    end)
+  # The user is known to be a member of the org (it came from their accessible
+  # orgs), so a total of one member means that member is the user.
+  defp sole_member?(org_id), do: Guard.Api.Rbac.no_of_members(org_id) == 1
+
+  defp last_owner?(org_id, user_id) do
+    owner_ids = Guard.Api.Rbac.org_owner_ids(org_id)
+    user_id in owner_ids and length(owner_ids) == 1
   end
 
   defp org_name(org_id) do

--- a/guard/lib/guard/store/organization.ex
+++ b/guard/lib/guard/store/organization.ex
@@ -50,6 +50,50 @@ defmodule Guard.Store.Organization do
 
   def no_of_members(org_id), do: Guard.Api.Rbac.no_of_members(org_id)
 
+  @owner_role_name "Owner"
+
+  @doc """
+  Returns the organizations that block deletion of the given user because the
+  user is the sole member or the last Owner of them. Each entry is
+  `{org_id, org_name}`. An empty list means the user can be deleted.
+  """
+  def orgs_blocking_user_deletion(user_id) do
+    user_id
+    |> Guard.Api.Rbac.list_accessible_org_ids()
+    |> Enum.filter(&blocks_user_deletion?(&1, user_id))
+    |> Enum.map(&{&1, org_name(&1)})
+  end
+
+  defp blocks_user_deletion?(org_id, user_id) do
+    members = Guard.Api.Rbac.list_members(org_id)
+
+    member_ids = members |> Enum.map(& &1.subject.subject_id) |> Enum.uniq()
+
+    owner_ids =
+      members
+      |> Enum.filter(&owner?/1)
+      |> Enum.map(& &1.subject.subject_id)
+      |> Enum.uniq()
+
+    sole_member? = member_ids == [user_id]
+    last_owner? = user_id in owner_ids and length(owner_ids) == 1
+
+    sole_member? or last_owner?
+  end
+
+  defp owner?(member) do
+    Enum.any?(member.subject_role_bindings, fn binding ->
+      binding.role && binding.role.name == @owner_role_name
+    end)
+  end
+
+  defp org_name(org_id) do
+    case get_by_id(org_id) do
+      {:ok, org} -> org.name
+      _ -> org_id
+    end
+  end
+
   @doc """
   Creates a new organization.
   Returns {:ok, organization} if successful, or {:error, changeset} if validation fails.

--- a/guard/lib/guard/store/user.ex
+++ b/guard/lib/guard/store/user.ex
@@ -244,7 +244,7 @@ defmodule Guard.Store.User do
       {:ok, _} = __MODULE__.update(user_id, %{blocked_at: nil})
     end
 
-    def delete_with_owned_orgs(user_id) do
+    def delete_user(user_id) do
       result =
         Ecto.Multi.new()
         |> Ecto.Multi.run(:get_user, fn repo, _changes ->

--- a/guard/test/guard/api/rbac_test.exs
+++ b/guard/test/guard/api/rbac_test.exs
@@ -28,15 +28,7 @@ defmodule Guard.Api.RbacTest do
       members =
         all_ids
         |> Enum.slice(offset, @page_size)
-        |> Enum.map(fn id ->
-          RBAC.ListMembersResponse.Member.new(
-            subject:
-              RBAC.Subject.new(
-                subject_id: id,
-                subject_type: RBAC.SubjectType.value(:USER)
-              )
-          )
-        end)
+        |> Enum.map(&member/1)
 
       total_pages = div(total + @page_size - 1, @page_size)
       {:ok, RBAC.ListMembersResponse.new(members: members, total_pages: total_pages)}
@@ -55,5 +47,44 @@ defmodule Guard.Api.RbacTest do
         assert Enum.uniq(ids) == ids
       end
     end
+
+    test "single_member? is true only for exactly one member (#{convention} backend)" do
+      with_mock RBAC.RBAC.Stub, list_members: list_members_responder(1, unquote(convention)) do
+        assert Rbac.single_member?(@org_id)
+      end
+    end
+
+    test "single_member? is false for more than one member (#{convention} backend)" do
+      with_mock RBAC.RBAC.Stub, list_members: list_members_responder(2, unquote(convention)) do
+        refute Rbac.single_member?(@org_id)
+      end
+    end
+
+    test "single_member? is false for a multi-page org (#{convention} backend)" do
+      with_mock RBAC.RBAC.Stub, list_members: list_members_responder(150, unquote(convention)) do
+        refute Rbac.single_member?(@org_id)
+      end
+    end
+  end
+
+  test "single_member? dedups repeated subject rows on the first page (ce)" do
+    # CE returns one row per role assignment, so a single user with several org
+    # roles appears multiple times on page 0 but must still count as one member.
+    responder = fn _channel, req, _opts ->
+      members =
+        if req.page.page_no == 0, do: Enum.map(1..3, fn _ -> member("user-1") end), else: []
+
+      {:ok, RBAC.ListMembersResponse.new(members: members, total_pages: 1)}
+    end
+
+    with_mock RBAC.RBAC.Stub, list_members: responder do
+      assert Rbac.single_member?(@org_id)
+    end
+  end
+
+  defp member(id) do
+    RBAC.ListMembersResponse.Member.new(
+      subject: RBAC.Subject.new(subject_id: id, subject_type: RBAC.SubjectType.value(:USER))
+    )
   end
 end

--- a/guard/test/guard/api/rbac_test.exs
+++ b/guard/test/guard/api/rbac_test.exs
@@ -145,6 +145,36 @@ defmodule Guard.Api.RbacTest do
     end
   end
 
+  test "org_owner_ids expands owner groups through the groups endpoint, not the rbac one" do
+    test_pid = self()
+    groups_endpoint = "groups.internal:50051"
+    rbac_endpoint = Application.fetch_env!(:guard, :rbac_grpc_endpoint)
+    original = Application.get_env(:guard, :groups_grpc_endpoint)
+    Application.put_env(:guard, :groups_grpc_endpoint, groups_endpoint)
+    on_exit(fn -> Application.put_env(:guard, :groups_grpc_endpoint, original) end)
+
+    members = fn channel, req, _opts ->
+      send(test_pid, {:rbac_channel, channel})
+      owner_members_responder(users: [], groups: ["group-1"]).(channel, req, [])
+    end
+
+    groups = fn channel, req, _opts ->
+      send(test_pid, {:groups_channel, channel})
+      groups_responder(%{"group-1" => ["user-alice"]}).(channel, req, [])
+    end
+
+    with_mock GRPC.Stub, [:passthrough], connect: fn endpoint -> {:ok, {:channel, endpoint}} end do
+      with_mock RBAC.RBAC.Stub, list_roles: list_roles_with_owner_fn(), list_members: members do
+        with_mock InternalApi.Groups.Groups.Stub, list_groups: groups do
+          assert {:ok, ["user-alice"]} = Rbac.org_owner_ids(@org_id)
+        end
+      end
+    end
+
+    assert_received {:rbac_channel, {:channel, ^rbac_endpoint}}
+    assert_received {:groups_channel, {:channel, ^groups_endpoint}}
+  end
+
   test "org_owner_ids fails closed when expanding an owner group fails" do
     failing_groups = fn _channel, _req, _opts ->
       {:error, %GRPC.RPCError{status: 14, message: "unavailable"}}

--- a/guard/test/guard/api/rbac_test.exs
+++ b/guard/test/guard/api/rbac_test.exs
@@ -113,6 +113,93 @@ defmodule Guard.Api.RbacTest do
     assert log =~ "member lookup failed"
   end
 
+  test "org_owner_ids includes users owning through a group next to direct owners" do
+    with_mock RBAC.RBAC.Stub,
+      list_roles: list_roles_with_owner_fn(),
+      list_members: owner_members_responder(users: ["user-direct"], groups: ["group-1"]) do
+      with_mock InternalApi.Groups.Groups.Stub,
+        list_groups: groups_responder(%{"group-1" => ["user-alice", "user-direct"]}) do
+        assert {:ok, ids} = Rbac.org_owner_ids(@org_id)
+        assert Enum.sort(ids) == ["user-alice", "user-direct"]
+      end
+    end
+  end
+
+  test "org_owner_ids resolves owners held only through a group" do
+    with_mock RBAC.RBAC.Stub,
+      list_roles: list_roles_with_owner_fn(),
+      list_members: owner_members_responder(users: [], groups: ["group-1"]) do
+      with_mock InternalApi.Groups.Groups.Stub,
+        list_groups: groups_responder(%{"group-1" => ["user-alice", "user-bob"]}) do
+        assert {:ok, ids} = Rbac.org_owner_ids(@org_id)
+        assert Enum.sort(ids) == ["user-alice", "user-bob"]
+      end
+    end
+  end
+
+  test "org_owner_ids stays direct-only when the backend reports no owner groups" do
+    with_mock RBAC.RBAC.Stub,
+      list_roles: list_roles_with_owner_fn(),
+      list_members: owner_members_responder(users: ["user-direct"], groups: []) do
+      assert Rbac.org_owner_ids(@org_id) == {:ok, ["user-direct"]}
+    end
+  end
+
+  test "org_owner_ids fails closed when expanding an owner group fails" do
+    failing_groups = fn _channel, _req, _opts ->
+      {:error, %GRPC.RPCError{status: 14, message: "unavailable"}}
+    end
+
+    log =
+      capture_log(fn ->
+        with_mock RBAC.RBAC.Stub,
+          list_roles: list_roles_with_owner_fn(),
+          list_members: owner_members_responder(users: ["user-direct"], groups: ["group-1"]) do
+          with_mock InternalApi.Groups.Groups.Stub, list_groups: failing_groups do
+            assert Rbac.org_owner_ids(@org_id) == {:error, :ownership_unverified}
+          end
+        end
+      end)
+
+    assert log =~ "owner lookup failed"
+  end
+
+  # ListMembers responder keyed by the requested member_type: owner users for
+  # :USER, owner groups for :GROUP (single short page each, like both backends).
+  defp owner_members_responder(users: user_ids, groups: group_ids) do
+    fn _channel, req, _opts ->
+      ids =
+        cond do
+          req.member_type == RBAC.SubjectType.value(:USER) -> user_ids
+          req.member_type == RBAC.SubjectType.value(:GROUP) -> group_ids
+        end
+
+      members = if req.page.page_no in [0, 1], do: Enum.map(ids, &member/1), else: []
+      {:ok, RBAC.ListMembersResponse.new(members: members, total_pages: 1)}
+    end
+  end
+
+  defp groups_responder(members_by_group) do
+    fn _channel, req, _opts ->
+      groups =
+        case Map.fetch(members_by_group, req.group_id) do
+          {:ok, member_ids} ->
+            [InternalApi.Groups.Group.new(id: req.group_id, member_ids: member_ids)]
+
+          :error ->
+            []
+        end
+
+      {:ok, InternalApi.Groups.ListGroupsResponse.new(groups: groups)}
+    end
+  end
+
+  defp list_roles_with_owner_fn do
+    fn _channel, _req, _opts ->
+      {:ok, RBAC.ListRolesResponse.new(roles: [RBAC.Role.new(id: "role-owner", name: "Owner")])}
+    end
+  end
+
   test "org_owner_ids returns an error when the owner lookup fails" do
     list_roles_with_owner = fn _channel, _req, _opts ->
       {:ok, RBAC.ListRolesResponse.new(roles: [RBAC.Role.new(id: "role-owner", name: "Owner")])}

--- a/guard/test/guard/api/rbac_test.exs
+++ b/guard/test/guard/api/rbac_test.exs
@@ -2,6 +2,7 @@ defmodule Guard.Api.RbacTest do
   use ExUnit.Case, async: false
 
   import Mock
+  import ExUnit.CaptureLog
 
   alias Guard.Api.Rbac
   alias InternalApi.RBAC
@@ -80,6 +81,21 @@ defmodule Guard.Api.RbacTest do
     with_mock RBAC.RBAC.Stub, list_members: responder do
       assert Rbac.single_member?(@org_id)
     end
+  end
+
+  test "org_owner_ids returns [] and warns when the Owner role cannot be resolved" do
+    list_roles_without_owner = fn _channel, _req, _opts ->
+      {:ok, RBAC.ListRolesResponse.new(roles: [RBAC.Role.new(id: "role-admin", name: "Admin")])}
+    end
+
+    log =
+      capture_log(fn ->
+        with_mock RBAC.RBAC.Stub, list_roles: list_roles_without_owner do
+          assert Rbac.org_owner_ids(@org_id) == []
+        end
+      end)
+
+    assert log =~ "Owner role not found"
   end
 
   defp member(id) do

--- a/guard/test/guard/api/rbac_test.exs
+++ b/guard/test/guard/api/rbac_test.exs
@@ -1,0 +1,59 @@
+defmodule Guard.Api.RbacTest do
+  use ExUnit.Case, async: false
+
+  import Mock
+
+  alias Guard.Api.Rbac
+  alias InternalApi.RBAC
+
+  @org_id "11111111-1111-1111-1111-111111111111"
+  @page_size 100
+
+  # Mimics a ListMembers backend holding `total` members under either edition's
+  # pagination convention, so the guard client is exercised the way prod behaves:
+  #
+  #   * :ee -> 0-based, offset = page_no * size
+  #   * :ce -> 1-based, page_no 0 is coerced to 1, offset = (page_no - 1) * size
+  #            (so page_no 0 and 1 both return the first page)
+  defp list_members_responder(total, convention) do
+    all_ids = Enum.map(1..total, &"user-#{&1}")
+
+    fn _channel, req, _opts ->
+      offset =
+        case convention do
+          :ee -> req.page.page_no * @page_size
+          :ce -> (max(req.page.page_no, 1) - 1) * @page_size
+        end
+
+      members =
+        all_ids
+        |> Enum.slice(offset, @page_size)
+        |> Enum.map(fn id ->
+          RBAC.ListMembersResponse.Member.new(
+            subject:
+              RBAC.Subject.new(
+                subject_id: id,
+                subject_type: RBAC.SubjectType.value(:USER)
+              )
+          )
+        end)
+
+      total_pages = div(total + @page_size - 1, @page_size)
+      {:ok, RBAC.ListMembersResponse.new(members: members, total_pages: total_pages)}
+    end
+  end
+
+  for convention <- [:ee, :ce] do
+    test "no_of_members and list_members are exact across pages (#{convention} backend)" do
+      total = 250
+
+      with_mock RBAC.RBAC.Stub, list_members: list_members_responder(total, unquote(convention)) do
+        assert Rbac.no_of_members(@org_id) == total
+
+        ids = Rbac.list_members(@org_id) |> Enum.map(& &1.subject.subject_id)
+        assert length(ids) == total
+        assert Enum.uniq(ids) == ids
+      end
+    end
+  end
+end

--- a/guard/test/guard/api/rbac_test.exs
+++ b/guard/test/guard/api/rbac_test.exs
@@ -83,7 +83,7 @@ defmodule Guard.Api.RbacTest do
     end
   end
 
-  test "org_owner_ids returns [] and warns when the Owner role cannot be resolved" do
+  test "org_owner_ids returns an error and warns when the Owner role cannot be resolved" do
     list_roles_without_owner = fn _channel, _req, _opts ->
       {:ok, RBAC.ListRolesResponse.new(roles: [RBAC.Role.new(id: "role-admin", name: "Admin")])}
     end
@@ -91,7 +91,7 @@ defmodule Guard.Api.RbacTest do
     log =
       capture_log(fn ->
         with_mock RBAC.RBAC.Stub, list_roles: list_roles_without_owner do
-          assert Rbac.org_owner_ids(@org_id) == []
+          assert Rbac.org_owner_ids(@org_id) == {:error, :owner_role_unresolved}
         end
       end)
 

--- a/guard/test/guard/api/rbac_test.exs
+++ b/guard/test/guard/api/rbac_test.exs
@@ -51,19 +51,19 @@ defmodule Guard.Api.RbacTest do
 
     test "single_member? is true only for exactly one member (#{convention} backend)" do
       with_mock RBAC.RBAC.Stub, list_members: list_members_responder(1, unquote(convention)) do
-        assert Rbac.single_member?(@org_id)
+        assert Rbac.single_member?(@org_id) == {:ok, true}
       end
     end
 
     test "single_member? is false for more than one member (#{convention} backend)" do
       with_mock RBAC.RBAC.Stub, list_members: list_members_responder(2, unquote(convention)) do
-        refute Rbac.single_member?(@org_id)
+        assert Rbac.single_member?(@org_id) == {:ok, false}
       end
     end
 
     test "single_member? is false for a multi-page org (#{convention} backend)" do
       with_mock RBAC.RBAC.Stub, list_members: list_members_responder(150, unquote(convention)) do
-        refute Rbac.single_member?(@org_id)
+        assert Rbac.single_member?(@org_id) == {:ok, false}
       end
     end
   end
@@ -79,7 +79,7 @@ defmodule Guard.Api.RbacTest do
     end
 
     with_mock RBAC.RBAC.Stub, list_members: responder do
-      assert Rbac.single_member?(@org_id)
+      assert Rbac.single_member?(@org_id) == {:ok, true}
     end
   end
 
@@ -96,6 +96,42 @@ defmodule Guard.Api.RbacTest do
       end)
 
     assert log =~ "Owner role not found"
+  end
+
+  test "single_member? returns an error when the member lookup fails" do
+    failing = fn _channel, _req, _opts ->
+      {:error, %GRPC.RPCError{status: 14, message: "unavailable"}}
+    end
+
+    log =
+      capture_log(fn ->
+        with_mock RBAC.RBAC.Stub, list_members: failing do
+          assert Rbac.single_member?(@org_id) == {:error, :ownership_unverified}
+        end
+      end)
+
+    assert log =~ "member lookup failed"
+  end
+
+  test "org_owner_ids returns an error when the owner lookup fails" do
+    list_roles_with_owner = fn _channel, _req, _opts ->
+      {:ok, RBAC.ListRolesResponse.new(roles: [RBAC.Role.new(id: "role-owner", name: "Owner")])}
+    end
+
+    failing_members = fn _channel, _req, _opts ->
+      {:error, %GRPC.RPCError{status: 14, message: "unavailable"}}
+    end
+
+    log =
+      capture_log(fn ->
+        with_mock RBAC.RBAC.Stub,
+          list_roles: list_roles_with_owner,
+          list_members: failing_members do
+          assert Rbac.org_owner_ids(@org_id) == {:error, :ownership_unverified}
+        end
+      end)
+
+    assert log =~ "owner lookup failed"
   end
 
   defp member(id) do

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -835,11 +835,10 @@ defmodule Guard.GrpcServers.UserServerTest do
     end
   end
 
-  # Simulates the real RBAC ListMembers: pagination is 0-based (page 0 is the
-  # first page), and the server-side role filter returns only the owner ids for
-  # the owner-role query, or every USER member otherwise. Requesting any page
-  # other than 0 (these fixtures fit in one page) yields no members, exactly as
-  # the backend's `offset(page_no * page_size)` does.
+  # Single-page ListMembers stub: these fixtures fit in one page, so only the
+  # first page carries members and the server-side role filter returns the owner
+  # ids for the owner-role query or every USER member otherwise. Cross-edition
+  # pagination is covered directly in Guard.Api.RbacTest.
   defp list_members_mock(member_ids, owner_ids) do
     fn _channel, req, _opts ->
       ids =

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -719,6 +719,71 @@ defmodule Guard.GrpcServers.UserServerTest do
       end
     end
 
+    test "delete_with_owned_orgs should reject when user is the last owner through a group", %{
+      grpc_channel: channel
+    } do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      {:ok, other} = Support.Factories.RbacUser.insert()
+
+      org = Support.Factories.Organization.insert!(name: "Acme", username: "acme-group-owner")
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: accessible_orgs_mock([org.id]),
+          list_roles: list_roles_mock(),
+          list_members: list_members_mock([user.id, other.id], [], ["owners-group"]) do
+          with_mock InternalApi.Groups.Groups.Stub,
+            list_groups: list_groups_mock(%{"owners-group" => [user.id]}) do
+            {:error, grpc_error} = channel |> Stub.delete_with_owned_orgs(request)
+
+            assert %GRPC.RPCError{status: status, message: message} = grpc_error
+            assert status == GRPC.Status.failed_precondition()
+            assert message =~ "You are the last owner of Acme."
+
+            refute is_nil(FrontRepo.get(FrontRepo.User, user.id))
+          end
+        end
+      end
+    end
+
+    test "delete_with_owned_orgs should allow deletion when the owner group has another member",
+         %{grpc_channel: channel} do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      {:ok, other} = Support.Factories.RbacUser.insert()
+
+      org = Support.Factories.Organization.insert!(name: "Shared", username: "group-coowner")
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: accessible_orgs_mock([org.id]),
+          list_roles: list_roles_mock(),
+          list_members: list_members_mock([user.id, other.id], [], ["owners-group"]) do
+          with_mock InternalApi.Groups.Groups.Stub,
+            list_groups: list_groups_mock(%{"owners-group" => [user.id, other.id]}) do
+            {:ok, response} = channel |> Stub.delete_with_owned_orgs(request)
+
+            id = user.id
+            assert %User.User{id: ^id} = response
+            assert is_nil(FrontRepo.get(FrontRepo.User, id))
+          end
+        end
+      end
+    end
+
     test "delete_with_owned_orgs pluralizes the message when blocking multiple orgs", %{
       grpc_channel: channel
     } do
@@ -1011,13 +1076,18 @@ defmodule Guard.GrpcServers.UserServerTest do
 
   # Single-page ListMembers stub: these fixtures fit in one page, so only the
   # first page carries members and the server-side role filter returns the owner
-  # ids for the owner-role query or every USER member otherwise. Cross-edition
-  # pagination is covered directly in Guard.Api.RbacTest.
-  defp list_members_mock(member_ids, owner_ids) do
+  # ids for the owner-role query or every USER member otherwise. GROUP-typed
+  # queries return the groups holding the owner role. Cross-edition pagination
+  # is covered directly in Guard.Api.RbacTest.
+  defp list_members_mock(member_ids, owner_ids, owner_group_ids \\ []) do
     fn _channel, req, _opts ->
+      group_query? = req.member_type == InternalApi.RBAC.SubjectType.value(:GROUP)
+
       ids =
         cond do
           req.page.page_no != 0 -> []
+          group_query? and req.member_has_role == @owner_role_id -> owner_group_ids
+          group_query? -> []
           req.member_has_role == @owner_role_id -> owner_ids
           true -> member_ids
         end
@@ -1027,6 +1097,21 @@ defmodule Guard.GrpcServers.UserServerTest do
          members: Enum.map(ids, &rbac_member/1),
          total_pages: 1
        )}
+    end
+  end
+
+  defp list_groups_mock(members_by_group) do
+    fn _channel, req, _opts ->
+      groups =
+        case Map.fetch(members_by_group, req.group_id) do
+          {:ok, member_ids} ->
+            [InternalApi.Groups.Group.new(id: req.group_id, member_ids: member_ids)]
+
+          :error ->
+            []
+        end
+
+      {:ok, InternalApi.Groups.ListGroupsResponse.new(groups: groups)}
     end
   end
 

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -700,25 +700,11 @@ defmodule Guard.GrpcServers.UserServerTest do
 
       request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
 
-      with_mock InternalApi.Projecthub.ProjectService.Stub,
-        list: fn _channel, _req, _opts ->
-          {:ok,
-           InternalApi.Projecthub.ListResponse.new(
-             metadata: InternalApi.Projecthub.ResponseMeta.new(status: %{code: 0}),
-             projects: []
-           )}
-        end do
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
         with_mock InternalApi.RBAC.RBAC.Stub,
-          list_accessible_orgs: fn _channel, _req, _opts ->
-            {:ok, InternalApi.RBAC.ListAccessibleOrgsResponse.new(org_ids: [org.id])}
-          end,
-          list_members: fn _channel, _req, _opts ->
-            {:ok,
-             InternalApi.RBAC.ListMembersResponse.new(
-               members: [owner_member(user.id), plain_member(other.id)],
-               total_pages: 1
-             )}
-          end do
+          list_accessible_orgs: accessible_orgs_mock([org.id]),
+          list_roles: list_roles_mock(),
+          list_members: list_members_mock([user.id, other.id], [user.id]) do
           {:error, grpc_error} = channel |> Stub.delete_with_owned_orgs(request)
 
           assert %GRPC.RPCError{status: status, message: message} = grpc_error
@@ -745,25 +731,12 @@ defmodule Guard.GrpcServers.UserServerTest do
 
       request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
 
-      with_mock InternalApi.Projecthub.ProjectService.Stub,
-        list: fn _channel, _req, _opts ->
-          {:ok,
-           InternalApi.Projecthub.ListResponse.new(
-             metadata: InternalApi.Projecthub.ResponseMeta.new(status: %{code: 0}),
-             projects: []
-           )}
-        end do
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
+        # list_roles is intentionally not stubbed: a sole-member org must be
+        # decided by the member count alone and short-circuit the owner lookup.
         with_mock InternalApi.RBAC.RBAC.Stub,
-          list_accessible_orgs: fn _channel, _req, _opts ->
-            {:ok, InternalApi.RBAC.ListAccessibleOrgsResponse.new(org_ids: [org.id])}
-          end,
-          list_members: fn _channel, _req, _opts ->
-            {:ok,
-             InternalApi.RBAC.ListMembersResponse.new(
-               members: [plain_member(user.id)],
-               total_pages: 1
-             )}
-          end do
+          list_accessible_orgs: accessible_orgs_mock([org.id]),
+          list_members: list_members_mock([user.id], []) do
           {:error, grpc_error} = channel |> Stub.delete_with_owned_orgs(request)
 
           assert %GRPC.RPCError{status: status, message: message} = grpc_error
@@ -790,25 +763,41 @@ defmodule Guard.GrpcServers.UserServerTest do
 
       request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
 
-      with_mock InternalApi.Projecthub.ProjectService.Stub,
-        list: fn _channel, _req, _opts ->
-          {:ok,
-           InternalApi.Projecthub.ListResponse.new(
-             metadata: InternalApi.Projecthub.ResponseMeta.new(status: %{code: 0}),
-             projects: []
-           )}
-        end do
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
         with_mock InternalApi.RBAC.RBAC.Stub,
-          list_accessible_orgs: fn _channel, _req, _opts ->
-            {:ok, InternalApi.RBAC.ListAccessibleOrgsResponse.new(org_ids: [org.id])}
-          end,
-          list_members: fn _channel, _req, _opts ->
-            {:ok,
-             InternalApi.RBAC.ListMembersResponse.new(
-               members: [owner_member(user.id), owner_member(other.id)],
-               total_pages: 1
-             )}
-          end do
+          list_accessible_orgs: accessible_orgs_mock([org.id]),
+          list_roles: list_roles_mock(),
+          list_members: list_members_mock([user.id, other.id], [user.id, other.id]) do
+          {:ok, response} = channel |> Stub.delete_with_owned_orgs(request)
+
+          id = user.id
+          assert %User.User{id: ^id} = response
+          assert is_nil(FrontRepo.get(FrontRepo.User, id))
+        end
+      end
+    end
+
+    test "delete_with_owned_orgs should allow deletion when user is a plain member of an org", %{
+      grpc_channel: channel
+    } do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      {:ok, owner} = Support.Factories.RbacUser.insert()
+      {:ok, teammate} = Support.Factories.RbacUser.insert()
+
+      org = Support.Factories.Organization.insert!(name: "BigCo", username: "acme-plain-member")
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: accessible_orgs_mock([org.id]),
+          list_roles: list_roles_mock(),
+          list_members: list_members_mock([user.id, owner.id, teammate.id], [owner.id]) do
           {:ok, response} = channel |> Stub.delete_with_owned_orgs(request)
 
           id = user.id
@@ -819,21 +808,54 @@ defmodule Guard.GrpcServers.UserServerTest do
     end
   end
 
-  defp owner_member(subject_id), do: rbac_member(subject_id, "Owner")
-  defp plain_member(subject_id), do: rbac_member(subject_id, "Member")
+  @owner_role_id "11111111-1111-1111-1111-111111111111"
 
-  defp rbac_member(subject_id, role_name) do
+  defp projecthub_list_mock do
+    fn _channel, _req, _opts ->
+      {:ok,
+       InternalApi.Projecthub.ListResponse.new(
+         metadata: InternalApi.Projecthub.ResponseMeta.new(status: %{code: 0}),
+         projects: []
+       )}
+    end
+  end
+
+  defp accessible_orgs_mock(org_ids) do
+    fn _channel, _req, _opts ->
+      {:ok, InternalApi.RBAC.ListAccessibleOrgsResponse.new(org_ids: org_ids)}
+    end
+  end
+
+  defp list_roles_mock do
+    fn _channel, _req, _opts ->
+      {:ok,
+       InternalApi.RBAC.ListRolesResponse.new(
+         roles: [InternalApi.RBAC.Role.new(id: @owner_role_id, name: "Owner")]
+       )}
+    end
+  end
+
+  # Simulates the server-side role filter: the owner-role query returns only the
+  # owner ids, any other query returns every USER member.
+  defp list_members_mock(member_ids, owner_ids) do
+    fn _channel, req, _opts ->
+      ids = if req.member_has_role == @owner_role_id, do: owner_ids, else: member_ids
+
+      {:ok,
+       InternalApi.RBAC.ListMembersResponse.new(
+         members: Enum.map(ids, &rbac_member/1),
+         total_pages: 1
+       )}
+    end
+  end
+
+  defp rbac_member(subject_id) do
     InternalApi.RBAC.ListMembersResponse.Member.new(
       subject:
         InternalApi.RBAC.Subject.new(
           subject_id: subject_id,
           subject_type: InternalApi.RBAC.SubjectType.value(:USER)
-        ),
-      subject_role_bindings: [
-        InternalApi.RBAC.SubjectRoleBinding.new(
-          role: InternalApi.RBAC.Role.new(id: Ecto.UUID.generate(), name: role_name)
         )
-      ]
     )
   end
 

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -835,11 +835,19 @@ defmodule Guard.GrpcServers.UserServerTest do
     end
   end
 
-  # Simulates the server-side role filter: the owner-role query returns only the
-  # owner ids, any other query returns every USER member.
+  # Simulates the real RBAC ListMembers: pagination is 0-based (page 0 is the
+  # first page), and the server-side role filter returns only the owner ids for
+  # the owner-role query, or every USER member otherwise. Requesting any page
+  # other than 0 (these fixtures fit in one page) yields no members, exactly as
+  # the backend's `offset(page_no * page_size)` does.
   defp list_members_mock(member_ids, owner_ids) do
     fn _channel, req, _opts ->
-      ids = if req.member_has_role == @owner_role_id, do: owner_ids, else: member_ids
+      ids =
+        cond do
+          req.page.page_no != 0 -> []
+          req.member_has_role == @owner_role_id -> owner_ids
+          true -> member_ids
+        end
 
       {:ok,
        InternalApi.RBAC.ListMembersResponse.new(

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -598,22 +598,27 @@ defmodule Guard.GrpcServers.UserServerTest do
              projects: []
            )}
         end do
-        {:ok, response} = channel |> Stub.delete_with_owned_orgs(request)
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: fn _channel, _req, _opts ->
+            {:ok, InternalApi.RBAC.ListAccessibleOrgsResponse.new(org_ids: [])}
+          end do
+          {:ok, response} = channel |> Stub.delete_with_owned_orgs(request)
 
-        id = user.id
-        assert %User.User{id: ^id} = response
+          id = user.id
+          assert %User.User{id: ^id} = response
 
-        # check if the user is deleted
-        assert nil == FrontRepo.get(FrontRepo.User, id)
-        assert nil == FrontRepo.get(FrontRepo.RepoHostAccount, repo_host_account.id)
-        assert nil == FrontRepo.get(FrontRepo.Member, member.id)
+          # check if the user is deleted
+          assert nil == FrontRepo.get(FrontRepo.User, id)
+          assert nil == FrontRepo.get(FrontRepo.RepoHostAccount, repo_host_account.id)
+          assert nil == FrontRepo.get(FrontRepo.Member, member.id)
 
-        receive do
-          {:user_deleted_test, received_message} ->
-            user_deleted = User.UserDeleted.decode(received_message)
-            assert user_deleted.user_id == user.id
-        after
-          5000 -> flunk("Timeout: Message not received within 5 seconds")
+          receive do
+            {:user_deleted_test, received_message} ->
+              user_deleted = User.UserDeleted.decode(received_message)
+              assert user_deleted.user_id == user.id
+          after
+            5000 -> flunk("Timeout: Message not received within 5 seconds")
+          end
         end
       end
     end
@@ -679,6 +684,157 @@ defmodule Guard.GrpcServers.UserServerTest do
 
       assert response.id == random_user_id
     end
+
+    test "delete_with_owned_orgs should reject when user is the last owner of an org", %{
+      grpc_channel: channel
+    } do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      {:ok, other} = Support.Factories.RbacUser.insert()
+
+      org = Support.Factories.Organization.insert!(name: "Acme", username: "acme-last-owner")
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub,
+        list: fn _channel, _req, _opts ->
+          {:ok,
+           InternalApi.Projecthub.ListResponse.new(
+             metadata: InternalApi.Projecthub.ResponseMeta.new(status: %{code: 0}),
+             projects: []
+           )}
+        end do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: fn _channel, _req, _opts ->
+            {:ok, InternalApi.RBAC.ListAccessibleOrgsResponse.new(org_ids: [org.id])}
+          end,
+          list_members: fn _channel, _req, _opts ->
+            {:ok,
+             InternalApi.RBAC.ListMembersResponse.new(
+               members: [owner_member(user.id), plain_member(other.id)],
+               total_pages: 1
+             )}
+          end do
+          {:error, grpc_error} = channel |> Stub.delete_with_owned_orgs(request)
+
+          assert %GRPC.RPCError{status: status, message: message} = grpc_error
+          assert status == GRPC.Status.failed_precondition()
+          assert message =~ "Acme"
+          assert message =~ "Transfer ownership"
+
+          # user must NOT be deleted
+          refute is_nil(FrontRepo.get(FrontRepo.User, user.id))
+        end
+      end
+    end
+
+    test "delete_with_owned_orgs should reject when user is the sole member of an org", %{
+      grpc_channel: channel
+    } do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      org = Support.Factories.Organization.insert!(name: "Solo", username: "acme-sole")
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub,
+        list: fn _channel, _req, _opts ->
+          {:ok,
+           InternalApi.Projecthub.ListResponse.new(
+             metadata: InternalApi.Projecthub.ResponseMeta.new(status: %{code: 0}),
+             projects: []
+           )}
+        end do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: fn _channel, _req, _opts ->
+            {:ok, InternalApi.RBAC.ListAccessibleOrgsResponse.new(org_ids: [org.id])}
+          end,
+          list_members: fn _channel, _req, _opts ->
+            {:ok,
+             InternalApi.RBAC.ListMembersResponse.new(
+               members: [plain_member(user.id)],
+               total_pages: 1
+             )}
+          end do
+          {:error, grpc_error} = channel |> Stub.delete_with_owned_orgs(request)
+
+          assert %GRPC.RPCError{status: status, message: message} = grpc_error
+          assert status == GRPC.Status.failed_precondition()
+          assert message =~ "Solo"
+
+          refute is_nil(FrontRepo.get(FrontRepo.User, user.id))
+        end
+      end
+    end
+
+    test "delete_with_owned_orgs should allow deletion when org has another owner", %{
+      grpc_channel: channel
+    } do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      {:ok, other} = Support.Factories.RbacUser.insert()
+
+      org = Support.Factories.Organization.insert!(name: "Shared", username: "acme-coowner")
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub,
+        list: fn _channel, _req, _opts ->
+          {:ok,
+           InternalApi.Projecthub.ListResponse.new(
+             metadata: InternalApi.Projecthub.ResponseMeta.new(status: %{code: 0}),
+             projects: []
+           )}
+        end do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: fn _channel, _req, _opts ->
+            {:ok, InternalApi.RBAC.ListAccessibleOrgsResponse.new(org_ids: [org.id])}
+          end,
+          list_members: fn _channel, _req, _opts ->
+            {:ok,
+             InternalApi.RBAC.ListMembersResponse.new(
+               members: [owner_member(user.id), owner_member(other.id)],
+               total_pages: 1
+             )}
+          end do
+          {:ok, response} = channel |> Stub.delete_with_owned_orgs(request)
+
+          id = user.id
+          assert %User.User{id: ^id} = response
+          assert is_nil(FrontRepo.get(FrontRepo.User, id))
+        end
+      end
+    end
+  end
+
+  defp owner_member(subject_id), do: rbac_member(subject_id, "Owner")
+  defp plain_member(subject_id), do: rbac_member(subject_id, "Member")
+
+  defp rbac_member(subject_id, role_name) do
+    InternalApi.RBAC.ListMembersResponse.Member.new(
+      subject:
+        InternalApi.RBAC.Subject.new(
+          subject_id: subject_id,
+          subject_type: InternalApi.RBAC.SubjectType.value(:USER)
+        ),
+      subject_role_bindings: [
+        InternalApi.RBAC.SubjectRoleBinding.new(
+          role: InternalApi.RBAC.Role.new(id: Ecto.UUID.generate(), name: role_name)
+        )
+      ]
+    )
   end
 
   describe "regenerate_token" do

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -667,7 +667,7 @@ defmodule Guard.GrpcServers.UserServerTest do
 
         assert %GRPC.RPCError{
                  status: GRPC.Status.invalid_argument(),
-                 message: "User #{user.id} is owner of projects."
+                 message: "You still own projects — transfer or delete them first."
                } == grpc_error
       end
     end

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -840,9 +840,75 @@ defmodule Guard.GrpcServers.UserServerTest do
         end
       end
     end
+
+    test "delete_with_owned_orgs allows deletion when the only owned org is soft-deleted", %{
+      grpc_channel: channel
+    } do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      org = Support.Factories.Organization.insert!(name: "Gone", username: "soft-del-only")
+      soft_delete!(org)
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: accessible_orgs_mock([org.id]),
+          list_roles: list_roles_mock(),
+          list_members: list_members_mock([user.id], [user.id]) do
+          {:ok, response} = channel |> Stub.delete_with_owned_orgs(request)
+
+          id = user.id
+          assert %User.User{id: ^id} = response
+          assert is_nil(FrontRepo.get(FrontRepo.User, id))
+        end
+      end
+    end
+
+    test "delete_with_owned_orgs blocks only on the active org, ignoring soft-deleted ones", %{
+      grpc_channel: channel
+    } do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      active = Support.Factories.Organization.insert!(name: "Live", username: "mix-active")
+      gone = Support.Factories.Organization.insert!(name: "Gone", username: "mix-soft")
+      soft_delete!(gone)
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: accessible_orgs_mock([active.id, gone.id]),
+          list_roles: list_roles_mock(),
+          list_members: list_members_mock([user.id], [user.id]) do
+          {:error, grpc_error} = channel |> Stub.delete_with_owned_orgs(request)
+
+          assert %GRPC.RPCError{status: status, message: message} = grpc_error
+          assert status == GRPC.Status.failed_precondition()
+          assert message =~ "Live"
+          refute message =~ "Gone"
+
+          refute is_nil(FrontRepo.get(FrontRepo.User, user.id))
+        end
+      end
+    end
   end
 
   @owner_role_id "11111111-1111-1111-1111-111111111111"
+
+  defp soft_delete!(org) do
+    org
+    |> Ecto.Changeset.change(deleted_at: DateTime.utc_now() |> DateTime.truncate(:second))
+    |> Guard.FrontRepo.update!()
+  end
 
   defp projecthub_list_mock do
     fn _channel, _req, _opts ->

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -931,6 +931,38 @@ defmodule Guard.GrpcServers.UserServerTest do
         end
       end
     end
+
+    test "delete_with_owned_orgs rejects when ownership can't be verified due to an RBAC error",
+         %{grpc_channel: channel} do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      org = Support.Factories.Organization.insert!(name: "Foggy", username: "rbac-unavailable")
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      rbac_unavailable = fn _channel, _req, _opts ->
+        {:error, %GRPC.RPCError{status: 14, message: "unavailable"}}
+      end
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: accessible_orgs_mock([org.id]),
+          list_members: rbac_unavailable do
+          {:error, grpc_error} = channel |> Stub.delete_with_owned_orgs(request)
+
+          assert %GRPC.RPCError{status: status, message: message} = grpc_error
+          assert status == GRPC.Status.failed_precondition()
+          assert message =~ "couldn't verify ownership"
+          assert message =~ "Foggy"
+
+          refute is_nil(FrontRepo.get(FrontRepo.User, user.id))
+        end
+      end
+    end
   end
 
   @owner_role_id "11111111-1111-1111-1111-111111111111"

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -709,10 +709,44 @@ defmodule Guard.GrpcServers.UserServerTest do
 
           assert %GRPC.RPCError{status: status, message: message} = grpc_error
           assert status == GRPC.Status.failed_precondition()
-          assert message =~ "Acme"
-          assert message =~ "Transfer ownership"
+          assert message =~ "You are the last owner of Acme."
+          assert message =~ "delete it first"
+          refute message =~ "these organizations"
 
           # user must NOT be deleted
+          refute is_nil(FrontRepo.get(FrontRepo.User, user.id))
+        end
+      end
+    end
+
+    test "delete_with_owned_orgs pluralizes the message when blocking multiple orgs", %{
+      grpc_channel: channel
+    } do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      {:ok, other} = Support.Factories.RbacUser.insert()
+
+      org_a = Support.Factories.Organization.insert!(name: "Acme", username: "plural-acme")
+      org_b = Support.Factories.Organization.insert!(name: "Globex", username: "plural-globex")
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: accessible_orgs_mock([org_a.id, org_b.id]),
+          list_roles: list_roles_mock(),
+          list_members: list_members_mock([user.id, other.id], [user.id]) do
+          {:error, grpc_error} = channel |> Stub.delete_with_owned_orgs(request)
+
+          assert %GRPC.RPCError{status: status, message: message} = grpc_error
+          assert status == GRPC.Status.failed_precondition()
+          assert message =~ "these organizations: Acme, Globex"
+          assert message =~ "delete them first"
+
           refute is_nil(FrontRepo.get(FrontRepo.User, user.id))
         end
       end

--- a/guard/test/guard/grpc_servers/user_server_test.exs
+++ b/guard/test/guard/grpc_servers/user_server_test.exs
@@ -900,6 +900,37 @@ defmodule Guard.GrpcServers.UserServerTest do
         end
       end
     end
+
+    test "delete_with_owned_orgs rejects when the Owner role cannot be resolved for a multi-member org",
+         %{grpc_channel: channel} do
+      alias Guard.FrontRepo
+
+      {:ok, user} = Support.Factories.RbacUser.insert()
+      {:ok, _oidc_user} = Support.Factories.OIDCUser.insert(user.id)
+      {:ok, _} = Support.Members.insert_user(id: user.id, email: user.email, name: user.name)
+
+      {:ok, other} = Support.Factories.RbacUser.insert()
+
+      org = Support.Factories.Organization.insert!(name: "Mystery", username: "no-owner-role")
+
+      request = User.DeleteWithOwnedOrgsRequest.new(user_id: user.id)
+
+      with_mock InternalApi.Projecthub.ProjectService.Stub, list: projecthub_list_mock() do
+        with_mock InternalApi.RBAC.RBAC.Stub,
+          list_accessible_orgs: accessible_orgs_mock([org.id]),
+          list_roles: list_roles_without_owner_mock(),
+          list_members: list_members_mock([user.id, other.id], []) do
+          {:error, grpc_error} = channel |> Stub.delete_with_owned_orgs(request)
+
+          assert %GRPC.RPCError{status: status, message: message} = grpc_error
+          assert status == GRPC.Status.failed_precondition()
+          assert message =~ "couldn't verify ownership"
+          assert message =~ "Mystery"
+
+          refute is_nil(FrontRepo.get(FrontRepo.User, user.id))
+        end
+      end
+    end
   end
 
   @owner_role_id "11111111-1111-1111-1111-111111111111"
@@ -931,6 +962,17 @@ defmodule Guard.GrpcServers.UserServerTest do
       {:ok,
        InternalApi.RBAC.ListRolesResponse.new(
          roles: [InternalApi.RBAC.Role.new(id: @owner_role_id, name: "Owner")]
+       )}
+    end
+  end
+
+  # An org whose roles do not include one named "Owner" — get_role_id/1 returns
+  # nil, so ownership can't be verified.
+  defp list_roles_without_owner_mock do
+    fn _channel, _req, _opts ->
+      {:ok,
+       InternalApi.RBAC.ListRolesResponse.new(
+         roles: [InternalApi.RBAC.Role.new(id: "role-admin", name: "Admin")]
        )}
     end
   end

--- a/guard/test/guard/id/api_test.exs
+++ b/guard/test/guard/id/api_test.exs
@@ -833,7 +833,8 @@ defmodule Guard.Id.Api.Test do
       Application.put_env(:guard, :oidc, %{
         discovery_url: disc_url,
         client_id: "test_client_id",
-        client_secret: "test_client_secret"
+        client_secret: "test_client_secret",
+        manage_url: "http://localhost/manage"
       })
 
       on_exit(fn ->
@@ -871,7 +872,8 @@ defmodule Guard.Id.Api.Test do
       Application.put_env(:guard, :oidc, %{
         discovery_url: disc_url,
         client_id: "test_client_id",
-        client_secret: "test_client_secret"
+        client_secret: "test_client_secret",
+        manage_url: "http://localhost/manage"
       })
 
       on_exit(fn ->


### PR DESCRIPTION
## 📝 Description
block account deletion for the sole member / last owner of an organization

A user who was the only member or last Owner of an organization could delete their own account (via `DeleteWithOwnedOrgs`, which only checked project ownership), leaving the org with zero members and no Owner — permanently orphaned and never collected by the cleaner. 

This adds a precondition in guard's `UserServer.delete_with_owned_orgs/2` that rejects deletion with `:failed_precondition` when the user is the sole member or last Owner of any org, computed from RBAC (edition-agnostic, fail-closed on RBAC errors). 

The front app now surfaces that specific message so users are told to transfer ownership or delete the organization first, and the account/people "Danger Zone" copy is corrected since deletion no longer cascades owned orgs.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
