### PR TITLE
Update Linux machine generations and specifications

### DIFF
--- a/docs/docs/reference/machine-types.md
+++ b/docs/docs/reference/machine-types.md
@@ -22,63 +22,14 @@ As a result, you may notice that identical jobs sometimes complete faster than p
 
 ## Linux machines {#linux}
 
-Linux machines are provided in four generations. The following table shows what operating systems each generation supports and if they support [Docker environments](../using-semaphore/pipelines#docker-environments).
+Linux machines are provided in two generations. The following table shows what operating systems each generation supports and if they support [Docker environments](../using-semaphore/pipelines#docker-environments).
 
 | Generation | Arch | OS Supported | Docker environments |
 |--|--|--|--|
-| [E1](#e1) | Intel x86_64 | [Ubuntu 22.04](./os-ubuntu-images/ubuntu-2204-image)<br/>[Ubuntu 24.04](./os-ubuntu-images/ubuntu-2404-image) |  Yes |
-| [E2](#e2) | Intel x86_64 | [Ubuntu 22.04](./os-ubuntu-images/ubuntu-2204-image)<br/>[Ubuntu 24.04](./os-ubuntu-images/ubuntu-2404-image) | Yes |
 | [F1](#f1) | Intel x86_64 | [Ubuntu 22.04](./os-ubuntu-images/ubuntu-2204-image)<br/>[Ubuntu 24.04](./os-ubuntu-images/ubuntu-2404-image) | Yes |
 | [R1](#r1) | ARM | [Ubuntu 24.04 ARM](./os-ubuntu-images/ubuntu-2404-arm-image) | No |
 
-
-
-### E1 generation (legacy) {#e1}
-
-This is the entry-level, cost-effective machine type. E1s are a good choice for less compute and memory intensive tasks.
-
-Implementation details:
-
-- **CPU**: hyperthreaded on a 3.4GHz Max Turbo 4.0GHz Intel® Core™ i7
-- **Memory**: DDR4 RAM
-- **Disk**: RAM drive (DDR4)
-
-The E1 generation is presented in the following types:
-
-| Type | Virtual CPUs | Memory (GB) | Disk (GB) |
-|--|--|--|--|
-| `e1-standard-2` | 2 | 4 | 25 |
-| `e1-standard-4` | 4 | 8 | 35 |
-| `e1-standard-8` | 8 | 16 | 45 |
-
-E1 Generation machine types can be paired with:
-
-- [`ubuntu2204`](../reference/os-ubuntu-images/ubuntu-2204-image)
-- [`ubuntu2404`](../reference/os-ubuntu-images/ubuntu-2404-image)
-- [Docker-based environment](../using-semaphore/pipelines#docker-environments).
-
-### E2 generation (legacy) {#e2}
-
-The E2 generation balances power with cost. It is a good choice for most tasks.
-
-Implementation details:
-
-- **CPU**: hyperthreaded on a 3.6GHZ [AMD Ryzen 5 3600](https://www.amd.com/en/product/8456)
-- **Memory**: DDR4 RAM
-- **Disk**: NvME storage
-
-The E2 generation is presented in the following types:
-
-| Type | Virtual CPUs | Memory (GB) | Disk (GB) |
-|--|--|--|--|
-| `e2-standard-2` | 2 | 8 | 45 |
-| `e2-standard-4` | 4 | 16 | 65 |
-
-E2 machines can also be paired with:
-
-- [`ubuntu2204`](../reference/os-ubuntu-images/ubuntu-2204-image)
-- [`ubuntu2404`](../reference/os-ubuntu-images/ubuntu-2404-image)
-- [Docker-based environments](../using-semaphore/pipelines#docker-environments).
+For legacy machine generations still supported for existing usage, see [Legacy Linux generations](#legacy-linux).
 
 ### F1 generation {#f1}
 
@@ -125,6 +76,58 @@ R1 Generation machine types can only be paired with:
 
 - [`ubuntu2404`](../reference/os-ubuntu-images/ubuntu-2404-arm-image) ARM version
 
+## Legacy Linux generations {#legacy-linux}
+
+The E1 and E2 generations are legacy machine types. They remain documented here for existing usage, but F1 and R1 are the recommended machine types for Linux workloads on Semaphore Cloud.
+
+| Generation | Arch | OS Supported | Docker environments |
+|--|--|--|--|
+| [E1](#e1) | Intel x86_64 | [Ubuntu 22.04](./os-ubuntu-images/ubuntu-2204-image)<br/>[Ubuntu 24.04](./os-ubuntu-images/ubuntu-2404-image) | Yes |
+| [E2](#e2) | Intel x86_64 | [Ubuntu 22.04](./os-ubuntu-images/ubuntu-2204-image)<br/>[Ubuntu 24.04](./os-ubuntu-images/ubuntu-2404-image) | Yes |
+
+### E1 generation (legacy) {#e1}
+
+Implementation details:
+
+- **CPU**: hyperthreaded on a 3.4GHz Max Turbo 4.0GHz Intel® Core™ i7
+- **Memory**: DDR4 RAM
+- **Disk**: RAM drive (DDR4)
+
+The E1 generation is presented in the following types:
+
+| Type | Virtual CPUs | Memory (GB) | Disk (GB) |
+|--|--|--|--|
+| `e1-standard-2` | 2 | 4 | 25 |
+| `e1-standard-4` | 4 | 8 | 35 |
+| `e1-standard-8` | 8 | 16 | 45 |
+
+E1 Generation machine types can be paired with:
+
+- [`ubuntu2204`](../reference/os-ubuntu-images/ubuntu-2204-image)
+- [`ubuntu2404`](../reference/os-ubuntu-images/ubuntu-2404-image)
+- [Docker-based environment](../using-semaphore/pipelines#docker-environments).
+
+### E2 generation (legacy) {#e2}
+
+Implementation details:
+
+- **CPU**: hyperthreaded on a 3.6GHZ [AMD Ryzen 5 3600](https://www.amd.com/en/product/8456)
+- **Memory**: DDR4 RAM
+- **Disk**: NvME storage
+
+The E2 generation is presented in the following types:
+
+| Type | Virtual CPUs | Memory (GB) | Disk (GB) |
+|--|--|--|--|
+| `e2-standard-2` | 2 | 8 | 45 |
+| `e2-standard-4` | 4 | 16 | 65 |
+
+E2 machines can also be paired with:
+
+- [`ubuntu2204`](../reference/os-ubuntu-images/ubuntu-2204-image)
+- [`ubuntu2404`](../reference/os-ubuntu-images/ubuntu-2404-image)
+- [Docker-based environments](../using-semaphore/pipelines#docker-environments).
+
 ## Apple machines {#macos}
 
 Semaphore Cloud provides the following Apple machine types:
@@ -144,4 +147,3 @@ A2 machines can be paired with:
 - [Self-hosted agents](../using-semaphore/self-hosted)
 - [Linux Ubuntu images reference](./os-ubuntu)
 - [Apple macOS images reference](./os-apple)
-


### PR DESCRIPTION
## 📝 Description
Structure of the page is changed. Legacy machine types section is introduced.
E1 and E2 machine types are moved to the legacy section.
Linux machines table and supporting text is changed too. 

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
