### PR TITLE
Allow disable Github webhook members using ENV

### DIFF
--- a/github_hooks/app/controllers/projects_controller.rb
+++ b/github_hooks/app/controllers/projects_controller.rb
@@ -100,12 +100,7 @@ class ProjectsController < ApplicationController
         end
 
         if webhook_filter.member_webhook?
-          Watchman.increment("repo_host_post_commit_hooks.controller.member_webhook")
-          logger.info("Member Webhook")
-
-          Semaphore::Events::ProjectCollaboratorsChanged.emit(project.id)
-          repository_remote_id = project.repository.remote_id
-          Semaphore::GithubApp::Collaborators::Worker.perform_async(project.repo_owner_and_name, repository_remote_id)
+          handle_member_webhook(project, logger)
 
           next
         end
@@ -160,6 +155,23 @@ class ProjectsController < ApplicationController
   end
 
   private
+
+  # Sync a repo's collaborators on a GitHub "member" webhook. When
+  # DISABLE_COLLABORATOR_WEBHOOK_SYNC is set, the sync and the changed event are
+  # both suppressed, so this kill switch also covers member events.
+  def handle_member_webhook(project, logger)
+    Watchman.increment("repo_host_post_commit_hooks.controller.member_webhook")
+    logger.info("Member Webhook")
+
+    if App.disable_collaborator_webhook_sync
+      Watchman.increment("repo_host_post_commit_hooks.controller.collaborator_webhook_sync_disabled")
+      logger.info("Collaborator webhook sync disabled via env; skipping member webhook sync")
+      return
+    end
+
+    Semaphore::Events::ProjectCollaboratorsChanged.emit(project.id)
+    Semaphore::GithubApp::Collaborators::Worker.perform_async(project.repo_owner_and_name, project.repository.remote_id)
+  end
 
   # Re-syncs the installation's repository list on every webhook. When
   # DISABLE_COLLABORATOR_WEBHOOK_SYNC is set, the list is still synced — only the

--- a/github_hooks/lib/semaphore/github_app/credentials.rb
+++ b/github_hooks/lib/semaphore/github_app/credentials.rb
@@ -19,15 +19,15 @@ module Semaphore::GithubApp::Credentials
   end
 
   def self.github_client_id
-    @github_client_id ||=  InstanceConfigClient.github_client_id || Local.github_client_id
+    @github_client_id ||= Local.github_client_id || InstanceConfigClient.github_client_id
   end
 
   def self.github_client_secret
-    @github_client_secret ||= InstanceConfigClient.github_client_secret || Local.github_client_secret
+    @github_client_secret ||= Local.github_client_secret || InstanceConfigClient.github_client_secret
   end
 
   def self.github_app_webhook_secret
-    @github_app_webhook_secret ||= InstanceConfigClient.github_app_webhook_secret || Local.github_app_webhook_secret
+    @github_app_webhook_secret ||= Local.github_app_webhook_secret || InstanceConfigClient.github_app_webhook_secret
   end
 
   class Local

--- a/github_hooks/spec/controllers/projects_controller_spec.rb
+++ b/github_hooks/spec/controllers/projects_controller_spec.rb
@@ -561,16 +561,29 @@ RSpec.describe ProjectsController, :type => :controller do
           end
         end
 
-        context "and a member webhook arrives (not gated)" do
+        context "and a member webhook arrives" do
           let(:event) { "member" }
 
-          it "still enqueues the collaborator sync" do
+          def stub_member_project
             repository = double("Repository", :id => "repo-123", :remote_id => "")
             project = double(Project, :id => "96b0a57c-d9ae-453f-b56f-3b154eb10cda", :organization => @organization,
                                       :repo_owner_and_name => "foo/bar", :repository => repository)
             expect(Project).to receive(:find_by).and_return(project)
+          end
 
-            expect(Semaphore::GithubApp::Collaborators::Worker).to receive(:perform_async)
+          it "skips the collaborator sync and the changed event" do
+            stub_member_project
+
+            expect(Semaphore::Events::ProjectCollaboratorsChanged).not_to receive(:emit)
+            expect(Semaphore::GithubApp::Collaborators::Worker).not_to receive(:perform_async)
+
+            post_payload(RepoHost::Github::Responses::Payload.post_receive_hook_member)
+          end
+
+          it "increments the disabled metric" do
+            stub_member_project
+
+            expect(Watchman).to receive(:increment).with("repo_host_post_commit_hooks.controller.collaborator_webhook_sync_disabled").and_call_original
 
             post_payload(RepoHost::Github::Responses::Payload.post_receive_hook_member)
           end

--- a/github_hooks/spec/controllers/projects_controller_spec.rb
+++ b/github_hooks/spec/controllers/projects_controller_spec.rb
@@ -568,7 +568,7 @@ RSpec.describe ProjectsController, :type => :controller do
             repository = double("Repository", :id => "repo-123", :remote_id => "")
             project = double(Project, :id => "96b0a57c-d9ae-453f-b56f-3b154eb10cda", :organization => @organization,
                                       :repo_owner_and_name => "foo/bar", :repository => repository)
-            expect(Project).to receive(:find_by).and_return(project)
+            allow(Project).to receive(:find_by).and_return(project)
           end
 
           it "skips the collaborator sync and the changed event" do

--- a/github_hooks/spec/lib/repo_host/github/client_spec.rb
+++ b/github_hooks/spec/lib/repo_host/github/client_spec.rb
@@ -28,7 +28,16 @@ RSpec.describe RepoHost::Github::Client do
   end
 
   describe "#app_client" do
-    it "gets credentials from Semaphore::GithubApp::Credentials::InstanceConfigClient when instance config credentials are set" do
+    before do
+      # Credentials prefer Local (env/App config), so clear it — and the memoized
+      # values — to exercise the InstanceConfig fallback.
+      Semaphore::GithubApp::Credentials.instance_variable_set(:@github_client_id, nil)
+      Semaphore::GithubApp::Credentials.instance_variable_set(:@github_client_secret, nil)
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_client_id).and_return(nil)
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_client_secret).and_return(nil)
+    end
+
+    it "falls back to InstanceConfigClient credentials when local config is unset" do
       client = RepoHost::Github::Client.new(token)
       app_client = client.send(:app_client)
 

--- a/github_hooks/spec/lib/repo_host/github/client_spec.rb
+++ b/github_hooks/spec/lib/repo_host/github/client_spec.rb
@@ -33,8 +33,7 @@ RSpec.describe RepoHost::Github::Client do
       # values — to exercise the InstanceConfig fallback.
       Semaphore::GithubApp::Credentials.instance_variable_set(:@github_client_id, nil)
       Semaphore::GithubApp::Credentials.instance_variable_set(:@github_client_secret, nil)
-      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_client_id).and_return(nil)
-      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_client_secret).and_return(nil)
+      allow(Semaphore::GithubApp::Credentials::Local).to receive_messages(:github_client_id => nil, :github_client_secret => nil)
     end
 
     it "falls back to InstanceConfigClient credentials when local config is unset" do

--- a/github_hooks/spec/lib/semaphore/github_app/credentials_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/credentials_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Semaphore::GithubApp::Credentials do
     Semaphore::GithubApp::Credentials.instance_variable_set(:@private_key, nil)
     Semaphore::GithubApp::Credentials.instance_variable_set(:@github_application_url, nil)
     Semaphore::GithubApp::Credentials.instance_variable_set(:@github_application_id, nil)
+    Semaphore::GithubApp::Credentials.instance_variable_set(:@github_client_id, nil)
+    Semaphore::GithubApp::Credentials.instance_variable_set(:@github_client_secret, nil)
+    Semaphore::GithubApp::Credentials.instance_variable_set(:@github_app_webhook_secret, nil)
   end
 
   context "when the local file exists" do
@@ -118,6 +121,117 @@ RSpec.describe Semaphore::GithubApp::Credentials do
 
     it "returns nil if both fallbacks are unavailable" do
       expect(Semaphore::GithubApp::Credentials.github_application_id).to be_nil
+    end
+  end
+
+  context "when the local client id exists" do
+    before do
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_client_id).and_return("local_client_id")
+      allow(Semaphore::GithubApp::Credentials::InstanceConfigClient).to receive(:github_client_id).and_return(nil)
+    end
+
+    it "returns the local value and caches it" do
+      expect(Semaphore::GithubApp::Credentials.github_client_id).to eq("local_client_id")
+      expect(Semaphore::GithubApp::Credentials.github_client_id).to eq("local_client_id")
+      expect(Semaphore::GithubApp::Credentials::Local).to have_received(:github_client_id).once
+    end
+  end
+
+  context "when the local client id does not exist" do
+    before do
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_client_id).and_return(nil)
+      allow(Semaphore::GithubApp::Credentials::InstanceConfigClient).to receive(:github_client_id).and_return("instance_client_id")
+    end
+
+    it "falls back to InstanceConfigClient and caches the value" do
+      expect(Semaphore::GithubApp::Credentials.github_client_id).to eq("instance_client_id")
+      expect(Semaphore::GithubApp::Credentials.github_client_id).to eq("instance_client_id")
+      expect(Semaphore::GithubApp::Credentials::InstanceConfigClient).to have_received(:github_client_id).once
+    end
+  end
+
+  context "when both the local client id and InstanceConfigClient fail" do
+    before do
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_client_id).and_return(nil)
+      allow(Semaphore::GithubApp::Credentials::InstanceConfigClient).to receive(:github_client_id).and_return(nil)
+    end
+
+    it "returns nil if both fallbacks are unavailable" do
+      expect(Semaphore::GithubApp::Credentials.github_client_id).to be_nil
+    end
+  end
+
+  context "when the local client secret exists" do
+    before do
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_client_secret).and_return("local_client_secret")
+      allow(Semaphore::GithubApp::Credentials::InstanceConfigClient).to receive(:github_client_secret).and_return(nil)
+    end
+
+    it "returns the local value and caches it" do
+      expect(Semaphore::GithubApp::Credentials.github_client_secret).to eq("local_client_secret")
+      expect(Semaphore::GithubApp::Credentials.github_client_secret).to eq("local_client_secret")
+      expect(Semaphore::GithubApp::Credentials::Local).to have_received(:github_client_secret).once
+    end
+  end
+
+  context "when the local client secret does not exist" do
+    before do
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_client_secret).and_return(nil)
+      allow(Semaphore::GithubApp::Credentials::InstanceConfigClient).to receive(:github_client_secret).and_return("instance_client_secret")
+    end
+
+    it "falls back to InstanceConfigClient and caches the value" do
+      expect(Semaphore::GithubApp::Credentials.github_client_secret).to eq("instance_client_secret")
+      expect(Semaphore::GithubApp::Credentials.github_client_secret).to eq("instance_client_secret")
+      expect(Semaphore::GithubApp::Credentials::InstanceConfigClient).to have_received(:github_client_secret).once
+    end
+  end
+
+  context "when both the local client secret and InstanceConfigClient fail" do
+    before do
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_client_secret).and_return(nil)
+      allow(Semaphore::GithubApp::Credentials::InstanceConfigClient).to receive(:github_client_secret).and_return(nil)
+    end
+
+    it "returns nil if both fallbacks are unavailable" do
+      expect(Semaphore::GithubApp::Credentials.github_client_secret).to be_nil
+    end
+  end
+
+  context "when the local webhook secret exists" do
+    before do
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_app_webhook_secret).and_return("local_webhook_secret")
+      allow(Semaphore::GithubApp::Credentials::InstanceConfigClient).to receive(:github_app_webhook_secret).and_return(nil)
+    end
+
+    it "returns the local value and caches it" do
+      expect(Semaphore::GithubApp::Credentials.github_app_webhook_secret).to eq("local_webhook_secret")
+      expect(Semaphore::GithubApp::Credentials.github_app_webhook_secret).to eq("local_webhook_secret")
+      expect(Semaphore::GithubApp::Credentials::Local).to have_received(:github_app_webhook_secret).once
+    end
+  end
+
+  context "when the local webhook secret does not exist" do
+    before do
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_app_webhook_secret).and_return(nil)
+      allow(Semaphore::GithubApp::Credentials::InstanceConfigClient).to receive(:github_app_webhook_secret).and_return("instance_webhook_secret")
+    end
+
+    it "falls back to InstanceConfigClient and caches the value" do
+      expect(Semaphore::GithubApp::Credentials.github_app_webhook_secret).to eq("instance_webhook_secret")
+      expect(Semaphore::GithubApp::Credentials.github_app_webhook_secret).to eq("instance_webhook_secret")
+      expect(Semaphore::GithubApp::Credentials::InstanceConfigClient).to have_received(:github_app_webhook_secret).once
+    end
+  end
+
+  context "when both the local webhook secret and InstanceConfigClient fail" do
+    before do
+      allow(Semaphore::GithubApp::Credentials::Local).to receive(:github_app_webhook_secret).and_return(nil)
+      allow(Semaphore::GithubApp::Credentials::InstanceConfigClient).to receive(:github_app_webhook_secret).and_return(nil)
+    end
+
+    it "returns nil if both fallbacks are unavailable" do
+      expect(Semaphore::GithubApp::Credentials.github_app_webhook_secret).to be_nil
     end
   end
 end


### PR DESCRIPTION
## 📝 Description

- Disable member webhook with DISABLE_COLLABORATOR_WEBHOOK_SYNC ENV 
- fetch GitHub credentials from Local config and then fallback to InstanceConfigClient

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~
