### PR TITLE
fix(plumber): preserve task verdicts when stopping blocks to avoid unnecessary re-runs

### DIFF
--- a/plumber/block/.mix-audit.txt
+++ b/plumber/block/.mix-audit.txt
@@ -1,6 +1,8 @@
 # Advisories ignored here are transitive, unreachable in this app, and only
-# fixable by an out-of-scope major bump of a core dependency. hackney is NOT
-# ignored — it is bumped to a patched version (~> 1.24) in mix.exs instead.
+# fixable by an out-of-scope major bump of a core dependency. hackney is bumped
+# forward to the latest 1.x (~> 1.24, resolves 1.25.0) in mix.exs, which cleared
+# the older pool-leak/SSRF advisories; the newer 2026 hackney advisories (at the
+# end of this file) are only fixed in 4.0.1 and are accepted.
 
 # decimal — unbounded exponent in Decimal.new enables an unauthenticated DoS
 # (GHSA-rhv4-8758-jx7v, moderate). Patched in decimal 3.0.0, but this app's
@@ -34,3 +36,16 @@ GHSA-jfc2-q6qh-g5x8
 GHSA-32p9-57cr-4x65
 GHSA-84f2-rp86-235p
 GHSA-hv23-4qp7-8c8r
+
+# hackney — four 2026 advisories, all first patched in hackney 4.0.1. hackney is already bumped to
+# the latest 1.x (~> 1.24 -> 1.25.0) in mix.exs, which cleared the older pool-leak/SSRF advisories;
+# 4.0.1 is a major bump blocked by httpoison 0.13 (`hackney ~> 1.8`). Not reachable: block does not
+# call HTTPoison/hackney from lib/ at all — hackney is only a transitive httpoison dependency.
+#   GHSA-gp9c-pm5m-5cxr — ssl:connect/2 post-handshake upgrade has no timeout
+#   GHSA-j9wq-vxxc-94wf — CR/LF injection in query parameter
+#   GHSA-mp55-p8c9-rfw2 — CRLF/header injection via unvalidated domain/path options
+#   GHSA-pj7v-xfvx-wmjq — SSRF allowlist bypass via percent-encoded host
+GHSA-gp9c-pm5m-5cxr
+GHSA-j9wq-vxxc-94wf
+GHSA-mp55-p8c9-rfw2
+GHSA-pj7v-xfvx-wmjq

--- a/plumber/block/lib/block/blocks/stm_handler/stopping_state.ex
+++ b/plumber/block/lib/block/blocks/stm_handler/stopping_state.ex
@@ -27,6 +27,18 @@ defmodule Block.Blocks.STMHandler.StoppingState do
     |> determin_state_transition(blk)
   end
 
+  # The task reached a real verdict (passed/failed) before the stop took effect — mirror it
+  # (as RunningState does) instead of forcing "stopped", so passed work is not relabelled.
+  defp determin_state_transition({:ok, %{state: "done", result: result, result_reason: nil}}, _blke)
+       when result in ["passed", "failed"],
+    do: {:ok, fn _, _ -> {:ok, %{state: "done", result: result}} end}
+
+  defp determin_state_transition({:ok, %{state: "done", result: result, result_reason: reason}}, _blke)
+       when result in ["passed", "failed"],
+    do: {:ok, fn _, _ -> {:ok, %{state: "done", result: result, result_reason: reason}} end}
+
+  # Otherwise the task was actually interrupted (stopped/canceled) — record the block as
+  # stopped with the termination reason.
   defp determin_state_transition({:ok, %{state: "done"}}, blke) do
     reason = determin_reason(blke)
     {:ok, fn _, _ -> {:ok, %{state: "done", result: "stopped", result_reason: reason}} end}

--- a/plumber/block/lib/block/tasks/stm_handler/stopping_state.ex
+++ b/plumber/block/lib/block/tasks/stm_handler/stopping_state.ex
@@ -37,10 +37,11 @@ defmodule Block.Tasks.STMHandler.StoppingState do
   end
 
   defp handle_description({:ok, {:ok, description}}, task) do
-    with {:ok, task_desc}  <- Map.fetch(description, :task),
-         {:ok, state}      <- Map.fetch(task_desc, :state),
-         {:ok, state}      <- decode_status(state)
-    do determin_state_transition(state, description, task)
+    with {:ok, task_desc}        <- Map.fetch(description, :task),
+         {:ok, state}            <- Map.fetch(task_desc, :state),
+         {:ok, result}           <- Map.fetch(task_desc, :result),
+         {:ok, [state, result]}  <- decode_status([state, result])
+    do determin_state_transition({state, result}, description, task)
     else
       e  -> handle_description({:error, inspect(e)}, task)
     end
@@ -51,19 +52,29 @@ defmodule Block.Tasks.STMHandler.StoppingState do
     {:ok, fn _, _ -> {:error, %{description: desc}} end}
   end
 
-  defp determin_state_transition("done", desc, task) do
+  # The jobs finished with a real verdict before the stop took effect — preserve it.
+  # Zebra is the source of truth here: if the task actually passed/failed, do not relabel
+  # it "stopped", otherwise the block is needlessly re-run.
+  # Mirrors RunningState's result handling.
+  defp determin_state_transition({"done", "passed"}, desc, _task),
+    do: {:ok, fn _, _ -> {:ok, %{state: "done", description: desc, result: "passed"}} end}
+
+  defp determin_state_transition({"done", "failed"}, desc, _task),
+    do: {:ok, fn _, _ -> {:ok, %{state: "done", description: desc, result: "failed", result_reason: "test"}} end}
+
+  # The task was actually interrupted — record it as stopped with the termination reason.
+  defp determin_state_transition({"done", _result}, desc, task) do
     reason = determin_reason(task)
     {:ok, fn _, _ -> {:ok, %{state: "done", description: desc, result: "stopped", result_reason: reason}} end}
   end
 
   # If it is not "done" we treat it as "stopping"
-  defp determin_state_transition(state, _desc, _task) when is_binary(state) ,
+  defp determin_state_transition({state, _result}, _desc, _task) when is_binary(state) ,
     do: {:ok, fn _, _ -> {:ok, %{state: "stopping"}} end}
 
-  defp decode_status(:FINISHED), do: {:ok, "done"}
-  defp decode_status(status) do
-    {:ok, status |> Atom.to_string() |> String.downcase()}
-  end
+  defp decode_status([:FINISHED, result]), do: decode_status([:DONE, result])
+  defp decode_status(status) when is_list(status),
+    do: {:ok, Enum.map(status, &(String.downcase(Atom.to_string(&1))))}
 
   defp determin_reason(%{terminate_request_desc: "API call"}), do: "user"
   defp determin_reason(%{terminate_request_desc: "strategy"}), do: "strategy"

--- a/plumber/block/priv/repos/19_fail_fast_stop/.semaphore/semaphore.yml
+++ b/plumber/block/priv/repos/19_fail_fast_stop/.semaphore/semaphore.yml
@@ -9,17 +9,22 @@ fail_fast:
     when: "true"
   cancel:
     when: "true"
+# A and B keep a command AFTER the sleep on purpose: the local task referent only honours a
+# stop BETWEEN commands, so the trailing command is where the fast_failing stop takes effect
+# and the job is recorded STOPPED (mirroring a real agent killing a still-running job). Without
+# it the jobs would run to completion and pass - which is the correct result for completed work,
+# but then this fixture would no longer exercise the "running block gets stopped" path.
 blocks:
   - name: A
     dependencies: []
     task:
       jobs:
-        - commands: [echo A, sleep 5]
+        - commands: [echo A, sleep 5, echo A done]
   - name: B
     dependencies: []
     task:
       jobs:
-        - commands: [echo B, sleep 5]
+        - commands: [echo B, sleep 5, echo B done]
   - name: C
     dependencies: []
     task:

--- a/plumber/block/test/blocks/stm_handler/termination_test.exs
+++ b/plumber/block/test/blocks/stm_handler/termination_test.exs
@@ -4,7 +4,7 @@ defmodule Block.Blocks.Termination.Test do
   alias Block.Blocks.Model.{Blocks, BlocksQueries}
   alias Block.BlockRequests.Model.BlockRequestsQueries
   alias Block.BlockSubppls.Model.BlockSubpplsQueries
-  alias Block.Tasks.Model.TasksQueries
+  alias Block.Tasks.Model.{Tasks, TasksQueries}
   alias Block.EctoRepo, as: Repo
   alias Test.Helpers
 
@@ -55,6 +55,56 @@ defmodule Block.Blocks.Termination.Test do
     assert_terminated(blk, t_params, handler, desired_result, 3_000)
   end
 
+  # When a block is being stopped (e.g. fast-failing of a sibling block)
+  # but its task had already finished, the block must keep the task's real verdict
+  # instead of being relabelled "stopped" — otherwise a partial rebuild needlessly re-runs
+  # an already-passed block.
+  test "stopping a block whose task already passed records the block as passed", ctx do
+    blk = Map.get(ctx, :blk)
+
+    {:ok, _task} = insert_done_task(blk.block_id, "passed", nil)
+    {:ok, blk} = put_in_stopping(blk, "API call")
+
+    {:ok, pid} = Block.Blocks.STMHandler.StoppingState.start_link()
+    args = [blk, {"done", "passed", nil}, [pid]]
+    Helpers.assert_finished_for_less_than(__MODULE__, :check_state?, args, 3_000)
+  end
+
+  test "stopping a block whose task already failed records the block as failed", ctx do
+    blk = Map.get(ctx, :blk)
+
+    {:ok, _task} = insert_done_task(blk.block_id, "failed", "test")
+    {:ok, blk} = put_in_stopping(blk, "API call")
+
+    {:ok, pid} = Block.Blocks.STMHandler.StoppingState.start_link()
+    args = [blk, {"done", "failed", "test"}, [pid]]
+    Helpers.assert_finished_for_less_than(__MODULE__, :check_state?, args, 3_000)
+  end
+
+  test "stopping a block whose task was interrupted records it as stopped", ctx do
+    blk = Map.get(ctx, :blk)
+
+    {:ok, _task} = insert_done_task(blk.block_id, "stopped", "user")
+    {:ok, blk} = put_in_stopping(blk, "API call")
+
+    {:ok, pid} = Block.Blocks.STMHandler.StoppingState.start_link()
+    args = [blk, {"done", "stopped", "user"}, [pid]]
+    Helpers.assert_finished_for_less_than(__MODULE__, :check_state?, args, 3_000)
+  end
+
+  # A task terminated before it ran ends up "canceled"; the stopped block must still be
+  # recorded "stopped" (only real passed/failed verdicts are preserved), not "canceled".
+  test "stopping a block whose task was canceled records it as stopped", ctx do
+    blk = Map.get(ctx, :blk)
+
+    {:ok, _task} = insert_done_task(blk.block_id, "canceled", "user")
+    {:ok, blk} = put_in_stopping(blk, "API call")
+
+    {:ok, pid} = Block.Blocks.STMHandler.StoppingState.start_link()
+    args = [blk, {"done", "stopped", "user"}, [pid]]
+    Helpers.assert_finished_for_less_than(__MODULE__, :check_state?, args, 3_000)
+  end
+
   @tag :integration
   test "stop blk in running state", ctx do
     blk = Map.get(ctx, :blk)
@@ -98,6 +148,19 @@ defmodule Block.Blocks.Termination.Test do
   defp terminate_blk(blk, t_req, t_desc) do
     blk
     |> Blocks.changeset(%{terminate_request: t_req, terminate_request_desc: t_desc})
+    |> Repo.update()
+  end
+
+  defp insert_done_task(block_id, result, result_reason) do
+    params = %{block_id: block_id, state: "done", result: result, result_reason: result_reason,
+               in_scheduling: false, build_request_id: UUID.uuid4()}
+
+    %Tasks{} |> Tasks.changeset(params) |> Repo.insert()
+  end
+
+  defp put_in_stopping(blk, t_desc) do
+    blk
+    |> Blocks.changeset(%{state: "stopping", terminate_request: "stop", terminate_request_desc: t_desc})
     |> Repo.update()
   end
 

--- a/plumber/block/test/tasks/stm_handler/stopping_state_test.exs
+++ b/plumber/block/test/tasks/stm_handler/stopping_state_test.exs
@@ -1,0 +1,47 @@
+defmodule Block.Tasks.STMHandler.StoppingStateTest do
+  @moduledoc """
+  Unit tests for how a task that is being stopped resolves its final result.
+
+  If the jobs actually finished (passed/failed) before the stop took effect, that verdict
+  must be preserved instead of being overwritten with "stopped" — otherwise the block above
+  is relabelled and re-run on a partial rebuild.
+  """
+  use ExUnit.Case
+  import Mock
+
+  alias Block.Tasks.STMHandler.StoppingState
+  alias Block.TaskApiClient.GrpcClient, as: TaskApiClient
+
+  # Runs the real scheduling_handler/1 with the task-api describe response stubbed, and
+  # returns the state map the task would be persisted with (the raw description is dropped
+  # from the assertion for readability).
+  defp resolve(zebra_state, zebra_result, task) do
+    description = %{task: %{state: zebra_state, result: zebra_result}}
+
+    with_mock TaskApiClient, [describe: fn _task_id, _url -> {:ok, description} end] do
+      assert {:ok, transition} = StoppingState.scheduling_handler(task)
+      assert {:ok, result} = transition.(nil, nil)
+      Map.delete(result, :description)
+    end
+  end
+
+  @task %{task_id: "task-1", terminate_request_desc: "API call"}
+
+  test "a task that finished passed before the stop is kept as passed" do
+    assert resolve(:FINISHED, :PASSED, @task) == %{state: "done", result: "passed"}
+  end
+
+  test "a task that finished failed is kept as failed" do
+    assert resolve(:FINISHED, :FAILED, @task) ==
+             %{state: "done", result: "failed", result_reason: "test"}
+  end
+
+  test "a task that was actually stopped is recorded stopped" do
+    assert resolve(:FINISHED, :STOPPED, @task) ==
+             %{state: "done", result: "stopped", result_reason: "user"}
+  end
+
+  test "while the task has not finished the task stays in stopping" do
+    assert resolve(:STOPPING, :RESULT_UNSPECIFIED, @task) == %{state: "stopping"}
+  end
+end

--- a/plumber/definition_validator/.mix-audit.txt
+++ b/plumber/definition_validator/.mix-audit.txt
@@ -5,3 +5,15 @@
 # jason bump. decimal is not called anywhere in lib/ (grep `Decimal.` returns
 # no hits), so Decimal.new is never invoked on untrusted input.
 GHSA-rhv4-8758-jx7v
+
+# hackney — four 2026 advisories, all first patched in hackney 4.0.1 (major bump blocked by
+# httpoison 0.13 `hackney ~> 1.8`). hackney is only a transitive httpoison dependency (1.25.0) and
+# is not called anywhere in lib/ — no user-controlled input reaches hackney.
+#   GHSA-gp9c-pm5m-5cxr — ssl:connect/2 post-handshake upgrade has no timeout
+#   GHSA-j9wq-vxxc-94wf — CR/LF injection in query parameter
+#   GHSA-mp55-p8c9-rfw2 — CRLF/header injection via unvalidated domain/path options
+#   GHSA-pj7v-xfvx-wmjq — SSRF allowlist bypass via percent-encoded host
+GHSA-gp9c-pm5m-5cxr
+GHSA-j9wq-vxxc-94wf
+GHSA-mp55-p8c9-rfw2
+GHSA-pj7v-xfvx-wmjq

--- a/plumber/ppl/.mix-audit.txt
+++ b/plumber/ppl/.mix-audit.txt
@@ -1,6 +1,8 @@
 # Advisories ignored here are transitive, unreachable in this app, and only
-# fixable by an out-of-scope major bump of a core dependency. hackney is NOT
-# ignored — it is bumped to a patched version (~> 1.24) in mix.exs instead.
+# fixable by an out-of-scope major bump of a core dependency. hackney is bumped
+# forward to the latest 1.x (~> 1.24, resolves 1.25.0) in mix.exs, which cleared
+# the older pool-leak/SSRF advisories; the newer 2026 hackney advisories (at the
+# end of this file) are only fixed in 4.0.1 and are accepted.
 
 # decimal — unbounded exponent in Decimal.new enables an unauthenticated DoS
 # (GHSA-rhv4-8758-jx7v, moderate). Patched in decimal 3.0.0, but this app's
@@ -34,3 +36,17 @@ GHSA-jfc2-q6qh-g5x8
 GHSA-32p9-57cr-4x65
 GHSA-84f2-rp86-235p
 GHSA-hv23-4qp7-8c8r
+
+# hackney — four 2026 advisories, all first patched in hackney 4.0.1. hackney is already bumped to
+# the latest 1.x (~> 1.24 -> 1.25.0) in mix.exs, which cleared the older pool-leak/SSRF advisories;
+# 4.0.1 is a major bump blocked by httpoison 0.13 (`hackney ~> 1.8`). Not reachable: this app's only
+# outbound HTTP is HTTPoison.get on the internal artifacthub download URL (from
+# $INTERNAL_API_URL_ARTIFACTHUB) — no user-controlled host/domain/path/query is fed to hackney.
+#   GHSA-gp9c-pm5m-5cxr — ssl:connect/2 post-handshake upgrade has no timeout
+#   GHSA-j9wq-vxxc-94wf — CR/LF injection in query parameter
+#   GHSA-mp55-p8c9-rfw2 — CRLF/header injection via unvalidated domain/path options
+#   GHSA-pj7v-xfvx-wmjq — SSRF allowlist bypass via percent-encoded host
+GHSA-gp9c-pm5m-5cxr
+GHSA-j9wq-vxxc-94wf
+GHSA-mp55-p8c9-rfw2
+GHSA-pj7v-xfvx-wmjq

--- a/plumber/ppl/lib/ppl/ppl_blocks/stm_handler/stopping_state.ex
+++ b/plumber/ppl/lib/ppl/ppl_blocks/stm_handler/stopping_state.ex
@@ -27,6 +27,20 @@ defmodule Ppl.PplBlocks.STMHandler.StoppingState do
     |> determin_state_transition(ppl_blk)
   end
 
+  # The block reached a real verdict (passed/failed) before the stop took effect — preserve
+  # it. Relabelling passed work as "stopped" would make a partial rebuild needlessly re-run
+  # Mirrors RunningState's result handling.
+  defp determin_state_transition({:ok, %{state: "done", result: result, result_reason: nil}}, _ppl_blk)
+       when result in ["passed", "failed"],
+    do: {:ok, fn _, _ -> {:ok, %{state: "done", result: result}} end}
+
+  defp determin_state_transition({:ok, %{state: "done", result: result, result_reason: reason}}, _ppl_blk)
+       when result in ["passed", "failed"],
+    do: {:ok, fn _, _ -> {:ok, %{state: "done", result: result, result_reason: reason}} end}
+
+  # Otherwise the block was actually interrupted (stopped/canceled) — record it as stopped
+  # and recompute the termination reason here so fast_failing/user/strategy is reported
+  # (the block-service block only knows it was an "API call" termination).
   defp determin_state_transition({:ok, %{state: "done"}}, ppl_blk) do
     reason = determin_reason(ppl_blk)
     {:ok, fn _, _ -> {:ok, %{state: "done", result: "stopped", result_reason: reason}} end}

--- a/plumber/ppl/test/ppl_blocks/stm_handler/stopping_state_test.exs
+++ b/plumber/ppl/test/ppl_blocks/stm_handler/stopping_state_test.exs
@@ -1,0 +1,64 @@
+defmodule Ppl.PplBlocks.STMHandler.StoppingStateTest do
+  @moduledoc """
+  Unit tests for how a pipeline block that is being stopped resolves its final result.
+
+  When a block is force-stopped (e.g. fast_failing of a sibling block) but the underlying
+  block had already finished, the real verdict must be preserved. Otherwise a partial
+  rebuild — which only reuses blocks whose result is "passed" — needlessly re-runs.
+  """
+  use ExUnit.Case
+  import Mock
+
+  alias Ppl.PplBlocks.STMHandler.StoppingState
+
+  # Runs the real scheduling_handler/1 with Block.status/1 stubbed to the given block status,
+  # and returns the state map the ppl-block would be persisted with.
+  defp resolve(block_status, ppl_blk) do
+    with_mock Block, [status: fn _block_id -> {:ok, block_status} end] do
+      assert {:ok, transition} = StoppingState.scheduling_handler(ppl_blk)
+      assert {:ok, result} = transition.(nil, nil)
+      result
+    end
+  end
+
+  @fast_failing %{block_id: "blk-1", terminate_request_desc: "fast_failing"}
+
+  test "a block that already passed is kept as passed, not relabelled stopped" do
+    status = %{state: "done", result: "passed", result_reason: nil}
+    assert resolve(status, @fast_failing) == %{state: "done", result: "passed"}
+  end
+
+  test "a block that already failed is kept as failed" do
+    status = %{state: "done", result: "failed", result_reason: "test"}
+
+    assert resolve(status, @fast_failing) ==
+             %{state: "done", result: "failed", result_reason: "test"}
+  end
+
+  test "a genuinely stopped block is recorded stopped with the fast_failing reason" do
+    status = %{state: "done", result: "stopped", result_reason: "internal"}
+
+    assert resolve(status, @fast_failing) ==
+             %{state: "done", result: "stopped", result_reason: "fast_failing"}
+  end
+
+  test "a canceled block is recorded stopped (only real verdicts are preserved)" do
+    status = %{state: "done", result: "canceled", result_reason: "internal"}
+
+    assert resolve(status, @fast_failing) ==
+             %{state: "done", result: "stopped", result_reason: "fast_failing"}
+  end
+
+  test "a user-initiated stop keeps the user reason" do
+    ppl_blk = %{block_id: "blk-1", terminate_request_desc: "API call"}
+    status = %{state: "done", result: "stopped", result_reason: "internal"}
+
+    assert resolve(status, ppl_blk) ==
+             %{state: "done", result: "stopped", result_reason: "user"}
+  end
+
+  test "while the block is not done yet the ppl-block stays in stopping" do
+    status = %{state: "running", result: nil, result_reason: nil}
+    assert resolve(status, @fast_failing) == %{state: "stopping"}
+  end
+end


### PR DESCRIPTION
## 📝 Description

With `fail_fast: stop`, plumber's stopping-state machines overwrote a block's result with `stopped` even when its jobs had already passed, so partial rebuilds re-ran work that had actually succeeded. This preserves the real `passed`/`failed` verdict across all three stopping layers (ppl_block, block, task) and records `stopped` only for genuinely-interrupted work, with the termination reason still computed at the pipeline-block level.

**mix_audit**: Ignores four 2026 hackney advisories in `ppl`/`block`/`definition_validator`. They're only fixed in hackney 4.0.1 (blocked by httpoison 0.13's `hackney ~> 1.8`), and hackney is a transitive dep never called from `lib/` with user-controlled input - so they're unreachable and accepted.

Let me sync the file.
## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
