### PR TITLE
Address new decimal and websocket-driver dependency advisories

### DIFF
--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -487,7 +487,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.1)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -487,7 +487,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
     websocket (1.2.11)
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/plumber/spec/.mix-audit.txt
+++ b/plumber/spec/.mix-audit.txt
@@ -1,0 +1,7 @@
+# decimal — unbounded exponent in Decimal.new enables an unauthenticated DoS
+# (GHSA-rhv4-8758-jx7v, moderate). Patched in decimal 3.0.0, but this app's
+# jason 1.4.1 (`decimal ~> 1.0 or ~> 2.0`) pins decimal to < 3.0, so adopting
+# it forces an out-of-scope jason bump. decimal is not called anywhere in lib/
+# (grep `Decimal.` returns no hits) — it is only jason's optional transitive.
+# Same advisory is accepted with the same rationale in ../ppl/.mix-audit.txt.
+GHSA-rhv4-8758-jx7v


### PR DESCRIPTION
Two advisories landed in today's advisory-DB refresh and fail `Check dependencies` on any branch whose changes wake the affected blocks:

- **websocket-driver 0.8.0** (github_hooks, transitive): CVE-2026-54463 / CVE-2026-54464 — patched upstream, bumped to 0.8.1 (existing `>= 0.6.1` constraint already allows it).
- **decimal 2.1.1** (plumber/spec, transitive via jason): GHSA-rhv4-8758-jx7v — patched only in decimal 3.0, which jason pins out. Added `plumber/spec/.mix-audit.txt` accepting it with the same rationale already ratified in `plumber/ppl/.mix-audit.txt` (decimal unused in app code). The spec app never had this file because its CI block hadn't run until a recent branch touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)