### PR TITLE
fix(deps): resolve dependency audit failures (websocket-driver, decimal)

### DIFF
--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -487,7 +487,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/plumber/spec/mix.lock
+++ b/plumber/spec/mix.lock
@@ -1,7 +1,6 @@
 %{
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "credo": {:hex, :credo, "1.7.5", "643213503b1c766ec0496d828c90c424471ea54da77c8a168c725686377b9545", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "f799e9b5cd1891577d8c773d245668aa74a2fcd15eb277f51a0131690ebfb3fd"},
-  "decimal": {:hex, :decimal, "2.1.1", "5611dca5d4b2c3dd497dec8f68751f1f1a54755e8ed2a966c2633cf885973ad6", [:mix], [], "hexpm", "53cfe5f497ed0e7771ae1a475575603d77425099ba5faef9394932b35020ffcc"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.8.1", "d4cf78f318e7eea9ed173b4bb74b24a2d1601a7da5b5a857c07fe3d5da8f7fb6", [:mix], [], "hexpm", "4c870cfd422f6f5f4a6944cffde8eff029ba27b7f4783d94ed0f97ace27811d1"},
   "file_system": {:hex, :file_system, "1.0.0", "b689cc7dcee665f774de94b5a832e578bd7963c8e637ef940cd44327db7de2cd", [:mix], [], "hexpm", "6752092d66aec5a10e662aefeed8ddb9531d79db0bc145bb8c40325ca1d8536d"},
   "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},


### PR DESCRIPTION
## What

Fixes the `Check dependencies` (`check.ex.deps` / `check.ruby.deps`) failures currently blocking PRs that touch `plumber/spec` or `github_hooks`.

- **github_hooks**: bump `websocket-driver` 0.8.0 → 0.8.2 (transitive, via actioncable). Fixes CVE-2026-54463, CVE-2026-54464, CVE-2026-54465 and GHSA-2x63-gw47-w4mm — memory-exhaustion / DoS vectors in the protocol parser. Lockfile-only change (`bundle lock --update=websocket-driver`).
- **plumber/spec**: remove the stale `decimal` 2.1.1 entry from `mix.lock`, flagged by GHSA-rhv4-8758-jx7v (unbounded exponent DoS, patched only in 3.0.0). Nothing in the app requires decimal — it is only an optional dependency of jason — so the leftover lock entry is dropped instead of bumped. `mix deps.get --check-locked` passes without it.

## Verification

- `bundler-audit check --update` in `github_hooks`: **No vulnerabilities found** (advisory DB 2026-07-08)
- `mix_audit` in `plumber/spec` (elixir:1.16 container): **No vulnerabilities found**, and `mix deps.get --check-locked` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)