### PR TITLE
chore(deps): fix Check dependencies failures — drop unused decimal lock entry (plumber/spec), bump websocket-driver (github_hooks)

### DIFF
--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -487,7 +487,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/plumber/spec/mix.lock
+++ b/plumber/spec/mix.lock
@@ -1,7 +1,6 @@
 %{
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "credo": {:hex, :credo, "1.7.5", "643213503b1c766ec0496d828c90c424471ea54da77c8a168c725686377b9545", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "f799e9b5cd1891577d8c773d245668aa74a2fcd15eb277f51a0131690ebfb3fd"},
-  "decimal": {:hex, :decimal, "2.1.1", "5611dca5d4b2c3dd497dec8f68751f1f1a54755e8ed2a966c2633cf885973ad6", [:mix], [], "hexpm", "53cfe5f497ed0e7771ae1a475575603d77425099ba5faef9394932b35020ffcc"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.8.1", "d4cf78f318e7eea9ed173b4bb74b24a2d1601a7da5b5a857c07fe3d5da8f7fb6", [:mix], [], "hexpm", "4c870cfd422f6f5f4a6944cffde8eff029ba27b7f4783d94ed0f97ace27811d1"},
   "file_system": {:hex, :file_system, "1.0.0", "b689cc7dcee665f774de94b5a832e578bd7963c8e637ef940cd44327db7de2cd", [:mix], [], "hexpm", "6752092d66aec5a10e662aefeed8ddb9531d79db0bc145bb8c40325ca1d8536d"},
   "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},


### PR DESCRIPTION
## 📝 Description

Two newly published advisories currently fail the `Check dependencies` precondition jobs on any branch touching `plumber/spec` or `github_hooks`:

- **plumber/spec**: `mix_audit` flags `decimal 2.1.1` (GHSA-rhv4-8758-jx7v — unbounded exponent in `Decimal.new`, unauthenticated DoS; first patched in 3.0.0). The lock entry is a stale leftover: nothing in `plumber/spec` depends on decimal — it is only an *optional* dependency of jason, so mix never fetches it. This PR removes the entry (equivalent to `mix deps.unlock --unused`); bumping instead is not possible since jason 1.4.1 constrains decimal to `~> 1.0 or ~> 2.0`.
- **github_hooks**: `bundler-audit` flags `websocket-driver 0.8.0` (CVE-2026-54463 memory exhaustion via protocol length headers, CVE-2026-54464 resource-limit bypass via message compression; both fixed in 0.8.1). Bundle-locked to 0.8.2, the latest patched release. It is a transitive dependency of actioncable with a `>= 0.6.1` constraint, so no Gemfile change is needed.

Verified locally in the same `registry.semaphoreci.com/ruby:3` image CI uses: `Policy::BundlerAudit` passes with the updated Gemfile.lock. The MixAudit policy could not be exercised locally (mix_audit escript install fails on arm64), so the Spec precondition job on this PR is the authoritative check.

Heads-up (separate issue, not addressed here): when a policy fails to *install* (e.g. `Error constructing Policy::MixAudit`), `security-toolbox/dependencies` exits 0 and the check silently passes. That likely explains why sibling apps with the same `decimal 2.1.1` lock entry (plumber/ppl, plumber/block) intermittently pass this check.

## ✅ Checklist

- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)