### PR TITLE
fix(security-toolbox): fail MixAudit when the advisory database cannot be synced

### DIFF
--- a/security-toolbox/policies/dependencies/mix_audit.rb
+++ b/security-toolbox/policies/dependencies/mix_audit.rb
@@ -8,6 +8,8 @@ class Policy::MixAudit < Policy
   end
 
   def test
+    return false unless synchronize_advisory_db
+
     command = [
       "~/.mix/escripts/mix_audit"
     ]
@@ -26,6 +28,25 @@ class Policy::MixAudit < Policy
 
   def reason
     @output
+  end
+
+  def synchronize_advisory_db
+    db_path = File.join(Dir.home, ".local", "share", "elixir-security-advisories-mirego")
+
+    if File.directory?(db_path)
+      synced = system("git", "-C", db_path, "pull", "--rebase", "--quiet", "origin", "main")
+    else
+      synced = system("git", "clone", "--quiet", "https://github.com/mirego/elixir-security-advisories.git", db_path)
+    end
+
+    advisory_count = Dir.glob(File.join(db_path, "packages", "**", "*.yml")).length
+
+    if !synced || advisory_count == 0
+      @output = "Could not synchronize the advisory database at #{db_path} (synced=#{!!synced}, advisories=#{advisory_count}). Without it, mix_audit reports 'No vulnerabilities found' from an empty database."
+      return false
+    end
+
+    true
   end
 
   def dependencies


### PR DESCRIPTION
## 📝 Description

mix_audit ignores the exit status of the `git clone`/`git pull` that fetches its advisory database (mirego/mix_audit `lib/mix_audit/repo.ex` discards the `System.cmd` results). When that fetch fails — offline runner, GitHub flake, throttling — it scans against an empty (or stale) database and prints **"No vulnerabilities found"** with **exit 0**. The `Check dependencies` gate then passes without having audited anything, and nothing in the job output makes that obvious.

Reproduced locally by running `Policy::MixAudit` in a network-less container against `plumber/ppl`'s lockfile (which carries known accepted advisories): the git error goes to stderr and mix_audit happily reports no vulnerabilities.

`Policy::MixAudit` now synchronizes the database itself before invoking mix_audit — clone when absent, `pull --rebase` when present — and fails the policy when the sync fails or yields zero advisory files. A sync failure is deliberately a hard failure even when a stale database is present: a security gate that silently audits against yesterday's advisories is the same bug in a milder form, and a retry is cheap.

Verified in the `elixir:1.18-alpine` + ruby container across four paths:

| scenario | before | after |
|---|---|---|
| online, lockfile with live advisory | FAIL (correct) | FAIL, advisory listed |
| online, clean lockfile | PASS | PASS |
| offline, no local DB | **PASS (silent)** | FAIL with explicit reason |
| offline, stale local DB | **PASS (silent/stale)** | FAIL with explicit reason |

BundlerAudit is not affected: `bundle-audit check --update` hard-fails when its database is missing. Worth an upstream report/PR to mirego/mix_audit separately.

## ✅ Checklist

- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)