### PR TITLE
Allow Front repo pool size to be configured independently

### DIFF
--- a/ee/rbac/config/config.exs
+++ b/ee/rbac/config/config.exs
@@ -41,7 +41,7 @@ config :rbac, Rbac.FrontRepo,
       System.get_env("POSTGRES_FRONT_DB_POOL_SIZE") || System.get_env("POSTGRES_DB_POOL_SIZE") ||
         "1"
     ),
-  parameters: [application_name: "guard"],
+  parameters: [application_name: "rbac"],
   ssl: System.get_env("POSTGRES_DB_SSL") == "true" || false,
   ssl_opts: [verify: :verify_none]
 

--- a/ee/rbac/config/config.exs
+++ b/ee/rbac/config/config.exs
@@ -35,7 +35,12 @@ config :rbac, Rbac.FrontRepo,
   username: System.get_env("POSTGRES_DB_USER") || "postgres",
   password: System.get_env("POSTGRES_DB_PASSWORD") || "the-cake-is-a-lie",
   hostname: System.get_env("POSTGRES_DB_HOST") || "127.0.0.1",
-  pool_size: String.to_integer(System.get_env("POSTGRES_DB_POOL_SIZE") || "1"),
+  # Optional dedicated pool size for the Front repo; falls back to the shared pool size.
+  pool_size:
+    String.to_integer(
+      System.get_env("POSTGRES_FRONT_DB_POOL_SIZE") || System.get_env("POSTGRES_DB_POOL_SIZE") ||
+        "1"
+    ),
   parameters: [application_name: "guard"],
   ssl: System.get_env("POSTGRES_DB_SSL") == "true" || false,
   ssl_opts: [verify: :verify_none]

--- a/ee/rbac/config/runtime.exs
+++ b/ee/rbac/config/runtime.exs
@@ -25,7 +25,12 @@ config :rbac, Rbac.FrontRepo,
   username: System.get_env("POSTGRES_DB_USER") || "postgres",
   password: System.get_env("POSTGRES_DB_PASSWORD") || "the-cake-is-a-lie",
   hostname: System.get_env("POSTGRES_DB_HOST") || "127.0.0.1",
-  pool_size: String.to_integer(System.get_env("POSTGRES_DB_POOL_SIZE") || "1"),
+  # Optional dedicated pool size for the Front repo; falls back to the shared pool size.
+  pool_size:
+    String.to_integer(
+      System.get_env("POSTGRES_FRONT_DB_POOL_SIZE") || System.get_env("POSTGRES_DB_POOL_SIZE") ||
+        "1"
+    ),
   ssl: System.get_env("POSTGRES_DB_SSL") == "true" || false,
   ssl_opts: [verify: :verify_none]
 

--- a/guard/config/config.exs
+++ b/guard/config/config.exs
@@ -52,7 +52,12 @@ config :guard, Guard.FrontRepo,
   username: System.get_env("POSTGRES_DB_USER") || "postgres",
   password: System.get_env("POSTGRES_DB_PASSWORD") || "the-cake-is-a-lie",
   hostname: System.get_env("POSTGRES_DB_HOST") || "127.0.0.1",
-  pool_size: String.to_integer(System.get_env("POSTGRES_DB_POOL_SIZE") || "1"),
+  # Optional dedicated pool size for the Front repo; falls back to the shared pool size.
+  pool_size:
+    String.to_integer(
+      System.get_env("POSTGRES_FRONT_DB_POOL_SIZE") || System.get_env("POSTGRES_DB_POOL_SIZE") ||
+        "1"
+    ),
   parameters: [application_name: "guard"],
   ssl: System.get_env("POSTGRES_DB_SSL") == "true" || false
 

--- a/guard/config/runtime.exs
+++ b/guard/config/runtime.exs
@@ -34,7 +34,12 @@ config :guard, Guard.FrontRepo,
   username: System.get_env("POSTGRES_DB_USER") || "postgres",
   password: System.get_env("POSTGRES_DB_PASSWORD") || "the-cake-is-a-lie",
   hostname: System.get_env("POSTGRES_DB_HOST") || "127.0.0.1",
-  pool_size: String.to_integer(System.get_env("POSTGRES_DB_POOL_SIZE") || "1"),
+  # Optional dedicated pool size for the Front repo; falls back to the shared pool size.
+  pool_size:
+    String.to_integer(
+      System.get_env("POSTGRES_FRONT_DB_POOL_SIZE") || System.get_env("POSTGRES_DB_POOL_SIZE") ||
+        "1"
+    ),
   ssl: System.get_env("POSTGRES_DB_SSL") == "true" || false
 
 if System.get_env("START_INSTANCE_CONFIG") == "true" do


### PR DESCRIPTION
## What

Both `guard` and `rbac` run a secondary Ecto repo (`*.FrontRepo`) against the Front database, in addition to their primary repo. Until now both repos derived their connection pool size from the same `POSTGRES_DB_POOL_SIZE`, so the Front repo pool could not be tuned independently of the primary one.

This PR contains two changes:

1. **Configurable Front repo pool size** — add an optional `POSTGRES_FRONT_DB_POOL_SIZE` env var for the Front repos in guard and rbac. When unset it falls back to `POSTGRES_DB_POOL_SIZE`, so behavior is unchanged unless the new variable is provided.

2. **Correct application_name for the rbac Front repo** — the rbac Front repo connected with `application_name: "guard"`, so its connections were attributed to guard in Postgres connection stats and were indistinguishable from guard's own Front repo connections. It now reports `"rbac"`.

## Why

- Lets the low-traffic Front repo pool be sized separately from the primary repo pool.
- Makes Postgres connection stats (`pg_stat_activity.application_name`) reflect the service that actually owns each connection, which makes connection usage easier to attribute.

## Notes

- `guard` and `rbac` each define `FrontRepo` in both `config.exs` (compile-time) and `runtime.exs`; the pool change is applied in both. The `application_name` for the rbac Front repo is set in `config.exs`.
- No functional behavior changes unless `POSTGRES_FRONT_DB_POOL_SIZE` is set; `application_name` is a diagnostic label only.