### PR TITLE
fix(ee/rbac): exempt project init from change_owner gate in assign_role

### DIFF
--- a/ee/rbac/lib/rbac/grpc_servers/rbac_server.ex
+++ b/ee/rbac/lib/rbac/grpc_servers/rbac_server.ex
@@ -64,17 +64,20 @@ defmodule Rbac.GrpcServers.RbacServer do
       validate_role_assignment_arguments(req.role_assignment)
       authorize!(req.requester_id, org_id, project_id)
 
-      if owner_role?(role_id) or currently_owner?(subject_id, org_id),
+      # Project initialization bypasses authorization entirely (see authorize!/3): it is
+      # a system operation with no requester_id, so it must be exempt from every
+      # requester-based check below, not just the held-permissions one.
+      initializing? =
+        project_id != "" and Rbac.Models.Project.project_being_initialized?(project_id)
+
+      if not initializing? and (owner_role?(role_id) or currently_owner?(subject_id, org_id)),
         do: Rbac.Utils.Grpc.authorize!(@change_owner_permission, req.requester_id, org_id)
 
       # The Owner role is fully gated by @change_owner_permission above; every other
       # role must pass the held-permissions check so a requester cannot escalate by
-      # assigning a role that grants permissions they do not hold themselves. Skip the
-      # check for project initialization, which bypasses authorization entirely (see
-      # authorize!/3) and has no requester to compare permissions against.
-      unless owner_role?(role_id) or
-               (project_id != "" and Rbac.Models.Project.project_being_initialized?(project_id)),
-             do: authorize_holds_role_permissions!(req.requester_id, org_id, project_id, role_id)
+      # assigning a role that grants permissions they do not hold themselves.
+      unless owner_role?(role_id) or initializing?,
+        do: authorize_holds_role_permissions!(req.requester_id, org_id, project_id, role_id)
 
       {:ok, rbi} = RBI.new(user_id: subject_id, org_id: org_id, project_id: project_id)
 

--- a/ee/rbac/test/rbac/grpc_servers/rbac_server_test.exs
+++ b/ee/rbac/test/rbac/grpc_servers/rbac_server_test.exs
@@ -384,6 +384,27 @@ defmodule Rbac.GrpcServers.RbacServer.Test do
       assert ProjectAccess.get_list_of_projects(@user_id, @org_id) == [@project_id]
     end
 
+    test "project role is assigned during initialization even when subject is the org Owner and no requester is passed",
+         state do
+      alias Rbac.Store.ProjectAccess
+
+      # Regression test for the project-creation outage: projecthub assigns the creator
+      # the project Admin role during init with an empty requester_id. When the creator is
+      # also the org Owner, currently_owner?/2 is true, so the change_owner gate must still
+      # be skipped during initialization (just like the held-permissions check below it),
+      # otherwise the empty requester fails authorization and project creation times out.
+      Support.Rbac.assign_org_role_by_name(@org_id, @user_id, "Owner")
+      {:ok, proj_role} = Rbac.Repo.RbacRole.get_role_by_name("Admin", "project_scope", @org_id)
+      register_project_api_response(:INITIALIZING)
+
+      req =
+        gen_assign_role_req(@user_id, proj_role.id, @org_id, @project_id)
+        |> Map.replace(:requester_id, "")
+
+      {:ok, _} = state.grpc_channel |> Stub.assign_role(req)
+      assert ProjectAccess.get_list_of_projects(@user_id, @org_id) == [@project_id]
+    end
+
     test "Assign a global role to an 'insider'", state do
       alias Rbac.Repo.RbacRole
       alias Rbac.Store.{UserPermissions, ProjectAccess}


### PR DESCRIPTION
## Problem

Project creation times out for org owners. #1029 added an owner-gate to `assign_role`:

```elixir
if owner_role?(role_id) or currently_owner?(subject_id, org_id),
  do: Rbac.Utils.Grpc.authorize!(@change_owner_permission, req.requester_id, org_id)
```

During project initialization, `projecthub` calls `assign_role` to grant the creator the project `Admin` role with an **empty `requester_id`** (which `RBI.new` converts to `user_id: nil`). When the creator is the org **Owner**, `currently_owner?/2` returns true, so the gate calls `authorize!("organization.change_owner", "", org_id)` — a nil user has no permissions, so it raises `permission_denied` / "User unauthorized".

`setup_permissions` then fails on every retry until the 20-minute init timeout fires, and the project ends up in `ERROR` / "Project initialization timeout."

## Fix

The project-init bypass (`authorize!/3` → `project_being_initialized?`) was applied only to the sibling held-permissions check, **not** to the `change_owner` gate. This computes `initializing?` once and exempts **both** requester-based checks from it, so project init — a system operation with no requester — is not gated. (This also dedupes the `project_being_initialized?` callback to projecthub.)

## Test

Adds a regression test: `assign_role` during initialization succeeds when the subject is the org **Owner** and no `requester_id` is passed. Verified it fails on the pre-fix code (reproducing the exact `nil user_id` / `Missing permision "organization.change_owner"` log) and passes with the fix. Full `rbac_server_test.exs` suite: 78 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)