### PR TITLE
Add Postgres 18 to list of available images

### DIFF
--- a/docs/docs/using-semaphore/containers/container-registry.md
+++ b/docs/docs/using-semaphore/containers/container-registry.md
@@ -48,12 +48,12 @@ With:
 FROM registry.semaphoreci.com/node:20
 ```
 
-Service images can be used with [sem-service](../../reference/toolbox#sem-service). For example, the following command starts a PostgreSQL v16 container in your job:
+Service images can be used with [sem-service](../../reference/toolbox#sem-service). For example, the following command starts a PostgreSQL v18 container in your job:
 
 ```shell title="Job commands"
-$ sem-service start postgres 16
+$ sem-service start postgres 18
 Starting postgres...done.
-PostgreSQL 16 is running at 0.0.0.0:5432
+PostgreSQL 18 is running at 0.0.0.0:5432
 To access it use username 'postgres' and blank password.
 ```
 
@@ -503,6 +503,9 @@ This section lists utility images for [sem-service](../../reference/toolbox#sem-
 | postgres:16 | `registry.semaphoreci.com/postgres:16` |  
 | postgres:17 | `registry.semaphoreci.com/postgres:17` |  
 | postgres:17.2 | `registry.semaphoreci.com/postgres:17.2` |  
+| postgres:17.6 | `registry.semaphoreci.com/postgres:17.6` |  
+| postgres:18 | `registry.semaphoreci.com/postgres:18` |  
+| postgres:18.1 | `registry.semaphoreci.com/postgres:18.1` |  
 
 </div>
 </details>


### PR DESCRIPTION
## 📝 Description

I noticed that Postgres 18 is missing from the docs, even though it seems to be supported.

I validated this by running `sem-service start postgres 18`, which worked, and double verified by running `sem-service start postgres 19`, which helpfully prints the full list of available versions:

```
sem-service start postgres 19
Starting postgres...[error] sem-service doesn't support 'postgres' with version '19'.

Available options for 'postgres' are:

  - sem-version start postgres 9.4.26 9.4 9.5.15 9.5.23 9.5 9.6.6 9.6.11 9.6.18 9.6.19 9.6 9 10.0 10.5 10.6 10.7 10.11 10.12 10.13 10.14 10.16 10 11.0 11.2 11.5 11.6 11.7 11.8 11.9 11.11 11 12.1 12.2 12.3 12.4 12.6 12 13.0 13.2 13 14 15.1 15 16 17.2 17.6 17 18.1 18
```

## ✅ Checklist
- [x] ~I have tested this change~
- [x] ~This change requires documentation update~

Since this change IS a documentation update, I don't know if these apply.