### PR TITLE
Resolve copied-job logs, artifacts, and test results to the original job

### DIFF
--- a/front/assets/css/app.css
+++ b/front/assets/css/app.css
@@ -484,3 +484,6 @@ sem-popover {
 .material-symbols-outlined.md-24 { font-size: 24px; }
 .material-symbols-outlined.md-36 { font-size: 36px; }
 .material-symbols-outlined.md-48 { font-size: 48px; }
+
+.job-copied { opacity: 0.55; }
+.job-copied:hover { opacity: 0.85; }

--- a/front/assets/js/pollman.js
+++ b/front/assets/js/pollman.js
@@ -194,7 +194,19 @@ export var Pollman = {
       .then((body) => {
         if (Pollman.remembers(newFetch)) {
           this.withScrollSaved(document, () => {
-            $(node).replaceWith(body);
+            const $body = $(body);
+            $(node).replaceWith($body);
+
+            if (window.tippy) {
+              const targets = $body
+                .find("[data-tippy-content]")
+                .addBack("[data-tippy-content]")
+                .toArray();
+
+              if (targets.length > 0) {
+                window.tippy(targets, { duration: [150, 50] });
+              }
+            }
           });
         }
       })

--- a/front/lib/front/models/job.ex
+++ b/front/lib/front/models/job.ex
@@ -31,8 +31,11 @@ defmodule Front.Models.Job do
     :summary,
     :machine_type,
     :agent_name,
-    :is_debug_job
+    :is_debug_job,
+    :original_job_id
   ]
+
+  def source_job_id(%__MODULE__{original_job_id: original, id: id}), do: original || id
 
   def find(id, tracing_headers \\ nil) do
     with {:ok, channel} <- GRPC.Stub.connect(internal_endpoint()),
@@ -154,7 +157,8 @@ defmodule Front.Models.Job do
       self_hosted: raw.self_hosted,
       machine_type: raw.machine_type,
       agent_name: raw.agent_name,
-      is_debug_job: raw.is_debug_job
+      is_debug_job: raw.is_debug_job,
+      original_job_id: presence(Map.get(raw, :original_job_id))
     }
     |> preload_summary()
   end
@@ -186,6 +190,10 @@ defmodule Front.Models.Job do
 
   defp seconds(nil), do: nil
   defp seconds(time), do: time.seconds
+
+  defp presence(nil), do: nil
+  defp presence(""), do: nil
+  defp presence(value), do: value
 
   defp state(raw) do
     cond do

--- a/front/lib/front/models/job.ex
+++ b/front/lib/front/models/job.ex
@@ -164,7 +164,7 @@ defmodule Front.Models.Job do
   end
 
   def preload_summary(job) do
-    ListJobSummariesRequest.new(job_ids: [job.id])
+    ListJobSummariesRequest.new(job_ids: [source_job_id(job)])
     |> Clients.Velocity.list_job_summaries()
     |> case do
       {:ok, %{job_summaries: [job_summary]}} -> job_summary

--- a/front/lib/front/models/job.ex
+++ b/front/lib/front/models/job.ex
@@ -35,7 +35,7 @@ defmodule Front.Models.Job do
     :original_job_id
   ]
 
-  def source_job_id(%__MODULE__{original_job_id: original, id: id}), do: original || id
+  def source_job_id(%__MODULE__{original_job_id: original, id: id}), do: presence(original) || id
 
   def find(id, tracing_headers \\ nil) do
     with {:ok, channel} <- GRPC.Stub.connect(internal_endpoint()),

--- a/front/lib/front_web/controllers/artifacts_controller.ex
+++ b/front/lib/front_web/controllers/artifacts_controller.ex
@@ -109,7 +109,7 @@ defmodule FrontWeb.ArtifactsController do
       {:ok, workflow} = Async.await(fetch_workflow)
 
       source_kind = "jobs"
-      source_id = job.id
+      source_id = Front.Models.Job.source_job_id(job)
 
       badge_pollman = %{
         state: job.state,
@@ -118,7 +118,7 @@ defmodule FrontWeb.ArtifactsController do
 
       block =
         Enum.find(pipeline.blocks, fn block ->
-          Enum.any?(block.jobs, fn job -> job.id == source_id end)
+          Enum.any?(block.jobs, fn block_job -> block_job.id == job.id end)
         end)
 
       case Artifacthub.list(project.id, source_kind, source_id, conn.assigns.page_path) do
@@ -152,7 +152,7 @@ defmodule FrontWeb.ArtifactsController do
   end
 
   def jobs_download(conn, _params) do
-    download(conn, "jobs", conn.assigns.job.id)
+    download(conn, "jobs", Front.Models.Job.source_job_id(conn.assigns.job))
   end
 
   defp download(conn, source_kind, source_id) do

--- a/front/lib/front_web/controllers/job_controller.ex
+++ b/front/lib/front_web/controllers/job_controller.ex
@@ -64,6 +64,7 @@ defmodule FrontWeb.JobController do
     org_id = conn.assigns.organization_id
     user_id = conn |> extract_user_id()
     job_id = conn.assigns.job.id
+    source_job_id = Models.Job.source_job_id(conn.assigns.job)
     ppl_id = conn.assigns.job.ppl_id
     self_hosted = conn.assigns.job.self_hosted
     project = conn.assigns.project
@@ -80,8 +81,8 @@ defmodule FrontWeb.JobController do
 
     fetch_workflow = Async.run(fn -> find_workflow(pipeline.workflow_id) end)
     fetch_hook = Async.run(fn -> find_hook(pipeline.hook_id) end)
-    fetch_artifact_logs = Async.run(fn -> find_artifact_logs(project.id, job_id) end)
-    create_token = Async.run(fn -> generate_token(job_id, self_hosted) end)
+    fetch_artifact_logs = Async.run(fn -> find_artifact_logs(project.id, source_job_id) end)
+    create_token = Async.run(fn -> generate_token(source_job_id, self_hosted) end)
 
     {:ok, organization} = Async.await(fetch_organization)
     {:ok, hook} = Async.await(fetch_hook)
@@ -243,7 +244,7 @@ defmodule FrontWeb.JobController do
         nil ->
           token = params |> Map.get("token", "0") |> Integer.parse() |> elem(0)
 
-          case JobPage.Events.fetch_events(job.id, token) do
+          case JobPage.Events.fetch_events(Models.Job.source_job_id(job), token) do
             {:ok, events} ->
               conn
               |> put_resp_content_type("application/json")
@@ -293,9 +294,11 @@ defmodule FrontWeb.JobController do
           starting_event = params |> Map.get("starting_event", "0") |> Integer.parse() |> elem(0)
           take = params |> Map.get("take", "0") |> Integer.parse() |> elem(0)
 
+          source_job_id = Models.Job.source_job_id(job)
+
           if job.self_hosted do
             # The generated token should be valid for 1 minute only
-            case Models.Job.generate_token(job.id, 60) do
+            case Models.Job.generate_token(source_job_id, 60) do
               "" ->
                 conn
                 |> put_flash(:alert, "There was a problem finding the raw logs.")
@@ -305,12 +308,13 @@ defmodule FrontWeb.JobController do
                 conn
                 |> put_status(:temporary_redirect)
                 |> redirect(
-                  external: "https://#{conn.host}/api/v1/logs/#{job.id}?jwt=#{token}&raw=true"
+                  external:
+                    "https://#{conn.host}/api/v1/logs/#{source_job_id}?jwt=#{token}&raw=true"
                 )
             end
           else
             conn
-            |> text(JobPage.Events.raw_logs(job.id, starting_event, take))
+            |> text(JobPage.Events.raw_logs(source_job_id, starting_event, take))
           end
 
         message ->
@@ -332,7 +336,10 @@ defmodule FrontWeb.JobController do
 
           conn
           |> put_resp_content_type("application/json")
-          |> send_resp(200, JobPage.Events.raw_events(job.id, starting_event, take))
+          |> send_resp(
+            200,
+            JobPage.Events.raw_events(Models.Job.source_job_id(job), starting_event, take)
+          )
 
         message ->
           conn

--- a/front/lib/front_web/controllers/report_controller.ex
+++ b/front/lib/front_web/controllers/report_controller.ex
@@ -182,7 +182,12 @@ defmodule FrontWeb.ReportController do
   end
 
   defp fetch_report_from_context(project, "job", job) do
-    Artifacthub.signed_url(project.id, "jobs", job.id, ".semaphore/REPORT.md")
+    Artifacthub.signed_url(
+      project.id,
+      "jobs",
+      Front.Models.Job.source_job_id(job),
+      ".semaphore/REPORT.md"
+    )
   end
 
   defp fetch_report_from_context(project, "workflow", workflow) do

--- a/front/lib/front_web/controllers/test_results_controller.ex
+++ b/front/lib/front_web/controllers/test_results_controller.ex
@@ -43,7 +43,12 @@ defmodule FrontWeb.TestResultsController do
       fetch_junit_json_url =
         Async.run(
           fn ->
-            Artifacthub.signed_url(project.id, "jobs", job.id, "test-results/junit.json")
+            Artifacthub.signed_url(
+              project.id,
+              "jobs",
+              Front.Models.Job.source_job_id(job),
+              "test-results/junit.json"
+            )
           end,
           metric: "artifacts.artifact.signed_url"
         )

--- a/front/lib/front_web/templates/layout/job.html.eex
+++ b/front/lib/front_web/templates/layout/job.html.eex
@@ -72,6 +72,16 @@
     </div>
   </div>
 
+  <%= if @job.original_job_id do %>
+    <div class="flex items-center w-100 pv2 ph3 mv1 bg-washed-yellow br2 f6">
+      <span class="b mr1">Copied job</span>
+      <span>
+        — this job passed in a previous run and was not re-executed. Logs, artifacts, and test results shown here come from the
+        <%= link "original job", to: job_path(@conn, :show, @job.original_job_id) %>.
+      </span>
+    </div>
+  <% end %>
+
   <div class="f6 gray mb1">
     by <%= @hook.repo_host_username %>, <time-ago datetime="<%= Timex.format!(@workflow.created_at, "%FT%T%:z", :strftime) %>"><%= Timex.format!(@workflow.created_at, "%FT%T%:z", :strftime) %></time-ago>
   </div>

--- a/front/lib/front_web/templates/pipeline/_job.html.eex
+++ b/front/lib/front_web/templates/pipeline/_job.html.eex
@@ -18,12 +18,14 @@
           <svg class="mr2" height="16" width="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><title>icn-running</title><g fill="none" fill-rule="evenodd"><circle cx="8" cy="8" fill="#1570ff" r="8"/><g fill="#fff"><circle cx="5" cy="8" r="1"/><circle cx="8" cy="8" r="1"/><circle cx="11" cy="8" r="1"/></g></g></svg>
       <% end %>
       <%= @job.name %>
-      <%= if copied_job?(@job) do %>
-        <span class="f6 gray ml2">copied</span>
-      <% end %>
     </div>
 
-    <%= if job_timer_placeholder?(@job) do %>
+    <%= if copied_job?(@job) do %>
+      <span class="f6 gray flex items-center">
+        <svg class="mr1" height="13" width="13" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="currentColor" stroke-width="1.7"><rect x="5" y="2" width="9" height="9" rx="1.6"/><rect x="2" y="5" width="9" height="9" rx="1.6"/></g></svg>
+        copied
+      </span>
+    <% else %><%= if job_timer_placeholder?(@job) do %>
       <span class="f5 code gray">--:--</span>
     <% else %>
       <span
@@ -32,7 +34,7 @@
         seconds="<%= job_total_time(@job) %>">
         <%= job_timer_label(@job) %>
       </span>
-    <% end %>
+    <% end %><% end %>
   <% end %>
 <% else %>
   <div style="font-weight: normal;" class="link dark-gray flex items-center justify-between pv1 nh2 ph2 bt b--black-15 hover-bg-washed-gray">

--- a/front/lib/front_web/templates/pipeline/_job.html.eex
+++ b/front/lib/front_web/templates/pipeline/_job.html.eex
@@ -1,5 +1,5 @@
 <%= if Map.has_key?(@job, :state) do %>
-  <%= link to: "/jobs/#{@job.id}", data: job_data(@job, @conn), class: "link dark-gray flex items-center justify-between pv1 nh2 ph2 bt b--black-15 hover-bg-washed-gray#{if copied_job?(@job), do: " job-copied"}", style: "font-weight: normal;", title: (if copied_job?(@job), do: "This job passed in a previous run and was carried over as a copy — it was not re-executed.") do %>
+  <%= link to: "/jobs/#{@job.id}", data: job_data(@job, @conn), class: "link dark-gray flex items-center justify-between pv1 nh2 ph2 bt b--black-15 hover-bg-washed-gray#{if copied_job?(@job), do: " job-copied"}", style: "font-weight: normal;", "data-tippy-content": (if copied_job?(@job), do: "This job passed in a previous run and was carried over as a copy — it was not re-executed.") do %>
     <div class="flex items-center pr3">
       <%= case {@job.state, @job.result} do %>
         <% {:ENQUEUED, _} -> %>

--- a/front/lib/front_web/templates/pipeline/_job.html.eex
+++ b/front/lib/front_web/templates/pipeline/_job.html.eex
@@ -22,7 +22,7 @@
 
     <%= if copied_job?(@job) do %>
       <span class="f7 dark-gray flex items-center ba b--black-20 br-pill ph2 bg-white">
-        <img src="<%= assets_path() %>/images/icn-arrow-left-top.svg" width="11" class="mr1">
+        <img src="<%= assets_path() %>/images/icn-arrow-left-top.svg" width="11" class="mr1" alt="" aria-hidden="true">
         copied
       </span>
     <% else %><%= if job_timer_placeholder?(@job) do %>

--- a/front/lib/front_web/templates/pipeline/_job.html.eex
+++ b/front/lib/front_web/templates/pipeline/_job.html.eex
@@ -1,5 +1,5 @@
 <%= if Map.has_key?(@job, :state) do %>
-  <%= link to: "/jobs/#{@job.id}", data: job_data(@job, @conn), class: "link dark-gray flex items-center justify-between pv1 nh2 ph2 bt b--black-15 hover-bg-washed-gray#{if copied_job?(@job), do: " bg-washed-gray"}", style: "font-weight: normal;", title: (if copied_job?(@job), do: "This job passed in a previous run and was carried over as a copy — it was not re-executed.") do %>
+  <%= link to: "/jobs/#{@job.id}", data: job_data(@job, @conn), class: "link dark-gray flex items-center justify-between pv1 nh2 ph2 bt b--black-15 hover-bg-washed-gray#{if copied_job?(@job), do: " job-copied"}", style: "font-weight: normal;", title: (if copied_job?(@job), do: "This job passed in a previous run and was carried over as a copy — it was not re-executed.") do %>
     <div class="flex items-center pr3">
       <%= case {@job.state, @job.result} do %>
         <% {:ENQUEUED, _} -> %>
@@ -21,10 +21,7 @@
     </div>
 
     <%= if copied_job?(@job) do %>
-      <span class="f7 dark-gray flex items-center ba b--black-20 br-pill ph2 bg-white">
-        <img src="<%= assets_path() %>/images/icn-arrow-left-top.svg" width="11" class="mr1" alt="" aria-hidden="true">
-        copied
-      </span>
+      <span class="f6 gray">copied</span>
     <% else %><%= if job_timer_placeholder?(@job) do %>
       <span class="f5 code gray">--:--</span>
     <% else %>

--- a/front/lib/front_web/templates/pipeline/_job.html.eex
+++ b/front/lib/front_web/templates/pipeline/_job.html.eex
@@ -21,8 +21,8 @@
     </div>
 
     <%= if copied_job?(@job) do %>
-      <span class="f6 gray flex items-center">
-        <svg class="mr1" height="13" width="13" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="currentColor" stroke-width="1.7"><rect x="5" y="2" width="9" height="9" rx="1.6"/><rect x="2" y="5" width="9" height="9" rx="1.6"/></g></svg>
+      <span class="f7 dark-gray flex items-center ba b--black-20 br-pill ph2 bg-white">
+        <img src="<%= assets_path() %>/images/icn-arrow-left-top.svg" width="11" class="mr1">
         copied
       </span>
     <% else %><%= if job_timer_placeholder?(@job) do %>

--- a/front/lib/front_web/templates/pipeline/_job.html.eex
+++ b/front/lib/front_web/templates/pipeline/_job.html.eex
@@ -1,5 +1,5 @@
 <%= if Map.has_key?(@job, :state) do %>
-  <%= link to: "/jobs/#{@job.id}", data: job_data(@job, @conn), class: "link dark-gray flex items-center justify-between pv1 nh2 ph2 bt b--black-15 hover-bg-washed-gray", style: "font-weight: normal;" do %>
+  <%= link to: "/jobs/#{@job.id}", data: job_data(@job, @conn), class: "link dark-gray flex items-center justify-between pv1 nh2 ph2 bt b--black-15 hover-bg-washed-gray#{if copied_job?(@job), do: " bg-washed-gray"}", style: "font-weight: normal;", title: (if copied_job?(@job), do: "This job passed in a previous run and was carried over as a copy — it was not re-executed.") do %>
     <div class="flex items-center pr3">
       <%= case {@job.state, @job.result} do %>
         <% {:ENQUEUED, _} -> %>
@@ -18,6 +18,9 @@
           <svg class="mr2" height="16" width="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><title>icn-running</title><g fill="none" fill-rule="evenodd"><circle cx="8" cy="8" fill="#1570ff" r="8"/><g fill="#fff"><circle cx="5" cy="8" r="1"/><circle cx="8" cy="8" r="1"/><circle cx="11" cy="8" r="1"/></g></g></svg>
       <% end %>
       <%= @job.name %>
+      <%= if copied_job?(@job) do %>
+        <span class="f6 gray ml2">copied</span>
+      <% end %>
     </div>
 
     <%= if job_timer_placeholder?(@job) do %>

--- a/front/lib/front_web/views/job_view.ex
+++ b/front/lib/front_web/views/job_view.ex
@@ -22,7 +22,7 @@ defmodule FrontWeb.JobView do
 
   def logs_url(conn, job, _org) do
     if job.self_hosted do
-      "/api/v1/logs/#{job.id}"
+      "/api/v1/logs/#{Front.Models.Job.source_job_id(job)}"
     else
       job_path(conn, :logs, job.id)
     end

--- a/front/lib/front_web/views/pipeline_view.ex
+++ b/front/lib/front_web/views/pipeline_view.ex
@@ -576,6 +576,8 @@ defmodule FrontWeb.PipelineView do
   def pipeline_status_icon_name(:DONE, :STOPPED), do: "icn-stopped"
   def pipeline_status_icon_name(:DONE, :CANCELED), do: "icn-skipped"
 
+  def copied_job?(job), do: Map.get(job, :original_job_id, "") not in [nil, ""]
+
   def job_status_color(job), do: job_status_color(job.state, job.result)
   def job_status_color(:ENQUEUED, _), do: "light-gray"
   def job_status_color(:RUNNING, _), do: "indigo"

--- a/front/lib/internal_api/server_farm.job.pb.ex
+++ b/front/lib/internal_api/server_farm.job.pb.ex
@@ -40,7 +40,8 @@ defmodule InternalApi.ServerFarm.Job.Job do
           organization_id: String.t(),
           build_req_id: String.t(),
           agent_name: String.t(),
-          agent_id: String.t()
+          agent_id: String.t(),
+          original_job_id: String.t()
         }
   defstruct [
     :id,
@@ -68,7 +69,8 @@ defmodule InternalApi.ServerFarm.Job.Job do
     :organization_id,
     :build_req_id,
     :agent_name,
-    :agent_id
+    :agent_id,
+    :original_job_id
   ]
 
   field(:id, 1, type: :string)
@@ -97,6 +99,7 @@ defmodule InternalApi.ServerFarm.Job.Job do
   field(:build_req_id, 24, type: :string)
   field(:agent_name, 25, type: :string)
   field(:agent_id, 27, type: :string)
+  field(:original_job_id, 28, type: :string)
 end
 
 defmodule InternalApi.ServerFarm.Job.Job.Timeline do

--- a/front/test/front/models/job_test.exs
+++ b/front/test/front/models/job_test.exs
@@ -54,6 +54,22 @@ defmodule Front.Models.JobTest do
     end
   end
 
+  describe ".source_job_id" do
+    test "returns original_job_id for a copied job" do
+      original_id = UUID.uuid4()
+      job = %Job{id: UUID.uuid4(), original_job_id: original_id}
+
+      assert Job.source_job_id(job) == original_id
+    end
+
+    test "returns the job's own id when it is not a copy" do
+      id = UUID.uuid4()
+      job = %Job{id: id, original_job_id: nil}
+
+      assert Job.source_job_id(job) == id
+    end
+  end
+
   defp valid_job_spec do
     JobSpec.new(
       job_name: "RSpec 1/3",

--- a/front/test/front/models/job_test.exs
+++ b/front/test/front/models/job_test.exs
@@ -68,6 +68,13 @@ defmodule Front.Models.JobTest do
 
       assert Job.source_job_id(job) == id
     end
+
+    test "treats an empty-string lineage as not a copy" do
+      id = UUID.uuid4()
+      job = %Job{id: id, original_job_id: ""}
+
+      assert Job.source_job_id(job) == id
+    end
   end
 
   defp valid_job_spec do

--- a/front/test/front_web/controllers/job_controller_test.exs
+++ b/front/test/front_web/controllers/job_controller_test.exs
@@ -75,6 +75,45 @@ defmodule FrontWeb.JobControllerTest do
     end
   end
 
+  describe "show for a copied job" do
+    test "renders the copied-job banner linking to the original", %{conn: conn, job: job} do
+      original_job_id = UUID.uuid4()
+
+      GrpcMock.stub(InternalJobMock, :describe, fn req, _ ->
+        job = DB.find(:jobs, req.job_id)
+        task = DB.find(:tasks, job.task_id)
+        task_job = job |> DB.extract(:api_model)
+
+        DescribeResponse.new(
+          status:
+            InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+          job:
+            Job.new(
+              id: task_job.id,
+              project_id: task.project_id,
+              branch_id: task.branch_id,
+              hook_id: task.api_model.hook_id,
+              ppl_id: task.api_model.ppl_id,
+              timeline: Job.Timeline.new(),
+              state: Job.State.value(:FINISHED),
+              result: Job.Result.value(:PASSED),
+              machine_type: "e1-standard-2",
+              self_hosted: false,
+              name: task_job.name,
+              index: task_job.index,
+              original_job_id: original_job_id
+            )
+        )
+      end)
+
+      conn = get(conn, job_path(conn, :show, job.id))
+      html = html_response(conn, 200)
+
+      assert html =~ "Copied job"
+      assert html =~ "/jobs/#{original_job_id}"
+    end
+  end
+
   describe "status_badge" do
     test "renders badge", %{conn: conn, job: job} do
       conn = get(conn, job_path(conn, :status_badge, job.id))

--- a/front/test/front_web/controllers/job_controller_test.exs
+++ b/front/test/front_web/controllers/job_controller_test.exs
@@ -60,7 +60,8 @@ defmodule FrontWeb.JobControllerTest do
   describe "show" do
     test "displays job details", %{conn: conn, job: job} do
       conn = get(conn, job_path(conn, :show, job.id))
-      assert html_response(conn, 200)
+      html = html_response(conn, 200)
+      refute html =~ "Copied job"
     end
 
     test "redirects when accessing debug job", %{conn: conn, debug_job: debug_job, task: task} do
@@ -111,6 +112,42 @@ defmodule FrontWeb.JobControllerTest do
 
       assert html =~ "Copied job"
       assert html =~ "/jobs/#{original_job_id}"
+    end
+
+    test "fetches logs from the original job", %{conn: conn, job: job} do
+      original_job_id = "9e0a1b2c-3d4e-4f5a-8b6c-7d8e9f0a1b2c"
+
+      GrpcMock.stub(InternalJobMock, :describe, fn req, _ ->
+        job = DB.find(:jobs, req.job_id)
+        task = DB.find(:tasks, job.task_id)
+        task_job = job |> DB.extract(:api_model)
+        ts = Google.Protobuf.Timestamp.new(seconds: 1_739_285_890)
+
+        DescribeResponse.new(
+          status:
+            InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+          job:
+            Job.new(
+              id: task_job.id,
+              project_id: task.project_id,
+              branch_id: task.branch_id,
+              hook_id: task.api_model.hook_id,
+              ppl_id: task.api_model.ppl_id,
+              timeline: Job.Timeline.new(created_at: ts, started_at: ts, finished_at: ts),
+              state: Job.State.value(:FINISHED),
+              result: Job.Result.value(:PASSED),
+              machine_type: "e1-standard-2",
+              self_hosted: false,
+              name: task_job.name,
+              index: task_job.index,
+              original_job_id: original_job_id
+            )
+        )
+      end)
+
+      conn = get(conn, job_path(conn, :logs, job.id))
+
+      assert response(conn, 200) =~ "log-of-the-original-job"
     end
   end
 

--- a/front/test/front_web/controllers/job_controller_test.exs
+++ b/front/test/front_web/controllers/job_controller_test.exs
@@ -114,7 +114,7 @@ defmodule FrontWeb.JobControllerTest do
       assert html =~ "/jobs/#{original_job_id}"
     end
 
-    test "fetches logs from the original job", %{conn: conn, job: job} do
+    test "fetches plain logs from the original job", %{conn: conn, job: job} do
       original_job_id = "9e0a1b2c-3d4e-4f5a-8b6c-7d8e9f0a1b2c"
 
       GrpcMock.stub(InternalJobMock, :describe, fn req, _ ->
@@ -145,9 +145,9 @@ defmodule FrontWeb.JobControllerTest do
         )
       end)
 
-      conn = get(conn, job_path(conn, :logs, job.id))
+      conn = get(conn, job_path(conn, :plain_logs, job.id))
 
-      assert response(conn, 200) =~ "log-of-the-original-job"
+      assert text_response(conn, 200) =~ "log-of-the-original-job"
     end
   end
 

--- a/front/test/front_web/views/pipeline_view_test.exs
+++ b/front/test/front_web/views/pipeline_view_test.exs
@@ -460,6 +460,7 @@ defmodule FrontWeb.PipelineViewTest do
 
       assert html =~ "copied"
       assert html =~ "job-copied"
+      assert html =~ "data-tippy-content"
       assert html =~ "was not re-executed"
       refute html =~ "01:40"
     end

--- a/front/test/front_web/views/pipeline_view_test.exs
+++ b/front/test/front_web/views/pipeline_view_test.exs
@@ -459,6 +459,8 @@ defmodule FrontWeb.PipelineViewTest do
         render_graph_job(graph_job(%{original_job_id: "0561a1e6-e669-4b71-a752-a1e6a1a05a1e"}))
 
       assert html =~ "copied"
+      assert html =~ "br-pill"
+      assert html =~ "icn-arrow-left-top.svg"
       assert html =~ "hover-bg-washed-gray bg-washed-gray"
       assert html =~ "was not re-executed"
       refute html =~ "01:40"

--- a/front/test/front_web/views/pipeline_view_test.exs
+++ b/front/test/front_web/views/pipeline_view_test.exs
@@ -420,4 +420,62 @@ defmodule FrontWeb.PipelineViewTest do
       assert PipelineView.job_timer_label(job) == "01:40"
     end
   end
+
+  describe ".copied_job?" do
+    test "true only for jobs carrying original_job_id lineage" do
+      assert PipelineView.copied_job?(%{original_job_id: "0561a1e6-e669-4b71-a752-a1e6a1a05a1e"})
+      refute PipelineView.copied_job?(%{original_job_id: ""})
+      refute PipelineView.copied_job?(%{original_job_id: nil})
+      refute PipelineView.copied_job?(%{})
+    end
+  end
+
+  defp graph_job(attrs) do
+    %{
+      id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+      name: "unit tests",
+      state: :FINISHED,
+      result: :PASSED,
+      original_job_id: "",
+      started_at: %{seconds: 1_714_999_900},
+      finished_at: %{seconds: 1_715_000_000}
+    }
+    |> Map.merge(attrs)
+  end
+
+  defp render_graph_job(job) do
+    conn = build_conn() |> Plug.Conn.assign(:organization_id, "org-1")
+
+    render_to_string(PipelineView, "_job.html",
+      job: job,
+      conn: conn,
+      block_result_reason: nil
+    )
+  end
+
+  describe "_job.html copied-job rendering" do
+    test "a copied job renders the copied marker, tooltip, and grey background" do
+      html =
+        render_graph_job(graph_job(%{original_job_id: "0561a1e6-e669-4b71-a752-a1e6a1a05a1e"}))
+
+      assert html =~ ">copied</span>"
+      assert html =~ "hover-bg-washed-gray bg-washed-gray"
+      assert html =~ "was not re-executed"
+    end
+
+    test "a regular job renders without the copied marker" do
+      html = render_graph_job(graph_job(%{}))
+
+      refute html =~ ">copied</span>"
+      refute html =~ "hover-bg-washed-gray bg-washed-gray"
+      refute html =~ "was not re-executed"
+    end
+
+    test "a job without the lineage field renders without the copied marker" do
+      html = render_graph_job(graph_job(%{}) |> Map.delete(:original_job_id))
+
+      refute html =~ ">copied</span>"
+      refute html =~ "was not re-executed"
+    end
+  end
 end

--- a/front/test/front_web/views/pipeline_view_test.exs
+++ b/front/test/front_web/views/pipeline_view_test.exs
@@ -459,9 +459,7 @@ defmodule FrontWeb.PipelineViewTest do
         render_graph_job(graph_job(%{original_job_id: "0561a1e6-e669-4b71-a752-a1e6a1a05a1e"}))
 
       assert html =~ "copied"
-      assert html =~ "br-pill"
-      assert html =~ "icn-arrow-left-top.svg"
-      assert html =~ "hover-bg-washed-gray bg-washed-gray"
+      assert html =~ "job-copied"
       assert html =~ "was not re-executed"
       refute html =~ "01:40"
     end
@@ -471,7 +469,6 @@ defmodule FrontWeb.PipelineViewTest do
 
       assert html =~ "01:40"
       refute html =~ "copied"
-      refute html =~ "hover-bg-washed-gray bg-washed-gray"
       refute html =~ "was not re-executed"
     end
 

--- a/front/test/front_web/views/pipeline_view_test.exs
+++ b/front/test/front_web/views/pipeline_view_test.exs
@@ -458,15 +458,17 @@ defmodule FrontWeb.PipelineViewTest do
       html =
         render_graph_job(graph_job(%{original_job_id: "0561a1e6-e669-4b71-a752-a1e6a1a05a1e"}))
 
-      assert html =~ ">copied</span>"
+      assert html =~ "copied"
       assert html =~ "hover-bg-washed-gray bg-washed-gray"
       assert html =~ "was not re-executed"
+      refute html =~ "01:40"
     end
 
     test "a regular job renders without the copied marker" do
       html = render_graph_job(graph_job(%{}))
 
-      refute html =~ ">copied</span>"
+      assert html =~ "01:40"
+      refute html =~ "copied"
       refute html =~ "hover-bg-washed-gray bg-washed-gray"
       refute html =~ "was not re-executed"
     end
@@ -474,7 +476,8 @@ defmodule FrontWeb.PipelineViewTest do
     test "a job without the lineage field renders without the copied marker" do
       html = render_graph_job(graph_job(%{}) |> Map.delete(:original_job_id))
 
-      refute html =~ ">copied</span>"
+      assert html =~ "01:40"
+      refute html =~ "copied"
       refute html =~ "was not re-executed"
     end
   end

--- a/front/test/support/fake_services/loghub.ex
+++ b/front/test/support/fake_services/loghub.ex
@@ -16,6 +16,18 @@ defmodule Support.FakeServices.Loghub do
     )
   end
 
+  def get_log_events(%{job_id: "9e0a1b2c-3d4e-4f5a-8b6c-7d8e9f0a1b2c"}, _stream) do
+    events = [
+      ~s({"event":"cmd_output","timestamp":1739285892,"output":"log-of-the-original-job\\n"})
+    ]
+
+    GetLogEventsResponse.new(
+      status: InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+      events: events,
+      final: true
+    )
+  end
+
   def get_log_events(req, _stream) do
     events =
       File.read!("test/support/loghub/events")

--- a/zebra/lib/protos/internal_api/server_farm.job.pb.ex
+++ b/zebra/lib/protos/internal_api/server_farm.job.pb.ex
@@ -40,7 +40,8 @@ defmodule InternalApi.ServerFarm.Job.Job do
           organization_id: String.t(),
           build_req_id: String.t(),
           agent_name: String.t(),
-          agent_id: String.t()
+          agent_id: String.t(),
+          original_job_id: String.t()
         }
   defstruct [
     :id,
@@ -68,7 +69,8 @@ defmodule InternalApi.ServerFarm.Job.Job do
     :organization_id,
     :build_req_id,
     :agent_name,
-    :agent_id
+    :agent_id,
+    :original_job_id
   ]
 
   field(:id, 1, type: :string)
@@ -97,6 +99,7 @@ defmodule InternalApi.ServerFarm.Job.Job do
   field(:build_req_id, 24, type: :string)
   field(:agent_name, 25, type: :string)
   field(:agent_id, 27, type: :string)
+  field(:original_job_id, 28, type: :string)
 end
 
 defmodule InternalApi.ServerFarm.Job.Job.Timeline do

--- a/zebra/lib/zebra/apis/internal_job_api/serializer.ex
+++ b/zebra/lib/zebra/apis/internal_job_api/serializer.ex
@@ -53,7 +53,8 @@ defmodule Zebra.Apis.InternalJobApi.Serializer do
       self_hosted: Zebra.Models.Job.self_hosted?(job.machine_type),
       build_req_id: try_or(job.task, :build_request_id),
       agent_name: try_or(job, :agent_name),
-      agent_id: try_or(job, :agent_id)
+      agent_id: try_or(job, :agent_id),
+      original_job_id: try_or(job, :original_job_id)
     ]
     |> Zebra.Apis.Utils.remove_nils_from_keywordlist()
     |> Job.new()

--- a/zebra/test/zebra/apis/internal_job_api_test.exs
+++ b/zebra/test/zebra/apis/internal_job_api_test.exs
@@ -509,6 +509,26 @@ defmodule Zebra.Api.InternalJobApiTest do
                is_debug_job: false,
                self_hosted: false
              } = res.job
+
+      assert res.job.original_job_id == ""
+    end
+
+    test "copied job exposes original_job_id" do
+      alias InternalApi.ServerFarm.Job.Job
+      alias InternalApi.ServerFarm.Job.DescribeRequest, as: Request
+      alias InternalApi.ServerFarm.Job.JobService.Stub, as: Stub
+
+      original_job_id = Ecto.UUID.generate()
+
+      {:ok, job} = Support.Factories.Job.create(:finished, %{original_job_id: original_job_id})
+
+      {:ok, channel} = GRPC.Stub.connect("localhost:50051")
+
+      req = Request.new(job_id: job.id)
+      {:ok, res} = Stub.describe(channel, req)
+
+      assert res.status.code == InternalApi.ResponseStatus.Code.value(:OK)
+      assert %Job{original_job_id: ^original_job_id} = res.job
     end
 
     test "self hosted job is found" do


### PR DESCRIPTION
Read-path resolution for copied jobs. Stacked on #1095 (which is stacked on #1094). This is the documented blocker for enabling the job-level partial rerun feature flag.

Copied jobs produced by a job-level partial rerun are lightweight rows: their logs, artifacts, and test results live under the original job's id. This PR makes the UI resolve that lineage.

## Foundation
- `server_farm.job` vendored proto: additive `original_job_id` field (28) on the `Job` message (zebra + front copies; field 26 stays reserved)
- zebra: `InternalJobApi.Serializer` includes `original_job_id`, so job describe/list expose it
- front: `Models.Job` carries `original_job_id` and provides the single resolve rule `source_job_id/1` (`original_job_id || id`)

## Front indirection (all through `source_job_id/1`)
- job page: log events, raw logs (incl. the self-hosted loghub redirect + `logs_url`), agent log artifacts, loghub token generation
- artifacts tab: listing and downloads
- test results tab: `test-results/junit.json` signed URL
- velocity job summary preload

## Kept on the copy's own id (deliberate)
- status, badge, pollman polling, block lookup in the pipeline view
- artifact **destroy** — deleting from a copy's page must never delete the original's artifacts (it is a no-op on the copy's empty store)

## UI
- "Copied job" banner on the job page linking to the original job (member layout; the guest page renders without the layout and keeps current behavior)
- Copied badge in pipeline/block job *lists* is deferred: the pipeline describe payload carries no per-job lineage today

Storage services stay lineage-unaware: requesting a copy's id returns that id's (empty) data, and API consumers resolve via `original_job_id` from job describe themselves.

## Tests
- zebra: `.describe` round-trip for a copied job returns `original_job_id`; regular jobs return `""`
- front: `source_job_id/1` units; copied-job page renders the banner with a link to the original

🤖 Generated with [Claude Code](https://claude.com/claude-code)
