### PR TITLE
fix(front): pick workflow editor default machine type from available agent types

### DIFF
--- a/front/assets/.eslintrc.js
+++ b/front/assets/.eslintrc.js
@@ -24,7 +24,12 @@ module.exports = {
     tsconfigRootDir: __dirname,
     sourceType: "module",
   },
-  ignorePatterns: ["*.js", "*.json"],
+  ignorePatterns: [
+    "*.js",
+    "*.json",
+    "!js/workflow_editor/models/agent.js",
+    "!js/workflow_editor/models/agent.spec.js",
+  ],
   rules: {},
  overrides: [
     {

--- a/front/assets/js/workflow_editor/models/agent.js
+++ b/front/assets/js/workflow_editor/models/agent.js
@@ -249,20 +249,20 @@ export class Agent {
 
     switch(newType) {
       case Agent.ENVIRONMENT_TYPE_LINUX_VM:
-        this.type = "e1-standard-2"
+        this.type = this.defaultMachineTypeFor("LINUX")
         this.osImage = this.defaultOSImage(this.type)
         this.containers = []
         break
 
       case Agent.ENVIRONMENT_TYPE_MAC_VM:
-        this.type = "a1-standard-4"
+        this.type = this.defaultMachineTypeFor("MAC")
         this.osImage = this.defaultOSImage(this.type)
         this.containers = []
         break
 
       case Agent.ENVIRONMENT_TYPE_DOCKER:
         const isOS = Features.isEnabled("isOS")
-        this.type = isOS ? this.defaultMachineTypeForOS() : "e1-standard-2"
+        this.type = isOS ? this.defaultMachineTypeForOS() : this.defaultMachineTypeFor("LINUX")
         this.osImage = isOS ? "" : this.defaultOSImage(this.type)
         this.containers = [
           new Container(this, {
@@ -285,11 +285,16 @@ export class Agent {
       return this.defaultMachineTypeForOS()
     }
 
-    if (_.includes(this.availableMachineTypes("LINUX"), "e1-standard-2")) {
-      return "e1-standard-2"
-    }
+    return this.defaultMachineTypeFor("LINUX")
+  }
 
-    return ""
+  defaultMachineTypeFor(platform) {
+    const bySize = _.sortBy(this.availableMachineTypes(platform), (type) => {
+      const size = parseInt(type.split("-").pop(), 10)
+      return _.isNaN(size) ? Number.MAX_SAFE_INTEGER : size
+    })
+
+    return bySize[0] || ""
   }
 
   defaultOSImage(type) {

--- a/front/assets/js/workflow_editor/models/agent.js
+++ b/front/assets/js/workflow_editor/models/agent.js
@@ -260,7 +260,7 @@ export class Agent {
         this.containers = []
         break
 
-      case Agent.ENVIRONMENT_TYPE_DOCKER:
+      case Agent.ENVIRONMENT_TYPE_DOCKER: {
         const isOS = Features.isEnabled("isOS")
         this.type = isOS ? this.defaultMachineTypeForOS() : this.defaultMachineTypeFor("LINUX")
         this.osImage = isOS ? "" : this.defaultOSImage(this.type)
@@ -271,6 +271,7 @@ export class Agent {
           })
         ]
         break
+      }
       case Agent.ENVIRONMENT_TYPE_SELF_HOSTED:
         this.type = this.availableMachineTypes("SELF_HOSTED")[0]
         this.osImage = ""

--- a/front/assets/js/workflow_editor/models/agent.spec.js
+++ b/front/assets/js/workflow_editor/models/agent.spec.js
@@ -359,6 +359,68 @@ describe("Agent", () => {
         expect(agent.environmentType()).to.equal(Agent.ENVIRONMENT_TYPE_SELF_HOSTED)
       })
     })
+
+    describe("when e1 and a1 machine types are not available", () => {
+      beforeEach(() => {
+        Agent.setValidAgentTypes({
+          agent_types: [
+            {
+              type: "e2-standard-4",
+              spec: "4 vCPU, 16 GB ram",
+              os_image: "ubuntu2404",
+              platform: "LINUX"
+            },
+            {
+              type: "e2-standard-2",
+              spec: "2 vCPU, 8 GB ram",
+              os_image: "ubuntu2404",
+              platform: "LINUX"
+            },
+            {
+              type: "a2-standard-4",
+              spec: "4 vCPU, 8 GB ram",
+              os_image: "macos-xcode16",
+              platform: "MAC"
+            }
+          ],
+          default_linux_os_image: "ubuntu2404",
+          default_mac_os_image: "macos-xcode16"
+        })
+
+        agent = new Agent(dummyParent, {})
+      })
+
+      afterEach(() => {
+        Agent.setupTestAgentTypes()
+      })
+
+      it("defaults to the smallest available linux machine type", () => {
+        expect(agent.type).to.equal("e2-standard-2")
+        expect(agent.osImage).to.equal("ubuntu2404")
+      })
+
+      it("changing to linux VM picks the smallest available linux machine type", () => {
+        agent.changeEnvironmentType(Agent.ENVIRONMENT_TYPE_LINUX_VM)
+
+        expect(agent.type).to.equal("e2-standard-2")
+        expect(agent.environmentType()).to.equal(Agent.ENVIRONMENT_TYPE_LINUX_VM)
+      })
+
+      it("changing to mac VM picks the smallest available mac machine type", () => {
+        agent.changeEnvironmentType(Agent.ENVIRONMENT_TYPE_MAC_VM)
+
+        expect(agent.type).to.equal("a2-standard-4")
+        expect(agent.osImage).to.equal("macos-xcode16")
+        expect(agent.environmentType()).to.equal(Agent.ENVIRONMENT_TYPE_MAC_VM)
+      })
+
+      it("changing to docker picks the smallest available linux machine type", () => {
+        agent.changeEnvironmentType(Agent.ENVIRONMENT_TYPE_DOCKER)
+
+        expect(agent.type).to.equal("e2-standard-2")
+        expect(agent.environmentType()).to.equal(Agent.ENVIRONMENT_TYPE_DOCKER)
+      })
+    })
   })
 
   describe("#changeMachineType", () => {


### PR DESCRIPTION
## 📝 Description

The workflow editor hardcodes `e1-standard-2` (Linux VM and Docker environments) and `a1-standard-4` (Mac VM) as default machine types in `front/assets/js/workflow_editor/models/agent.js`.

On organizations where those machine types are not available, this breaks the agent configuration panel: switching the environment type (or enabling a block-level agent override) sets a machine type that is not in the organization's agent type list. `environmentType()` then resolves to `unknown`, the machine type list renders empty, and the panel shows *"The machine type **e1-standard-2** is not available"* — re-selecting an environment type hardcodes the same invalid machine again, so there is no way out except editing the YAML by hand.

This PR removes the hardcoded machine types. `changeEnvironmentType()` and `defaultMachineType()` now pick the default from the organization's actual available agent types for the platform, ordered so the smallest machine (by the numeric size suffix, e.g. `-2` before `-4`) comes first. Behavior is unchanged for organizations where `e1-standard-2`/`a1-standard-4` are still available, since those are the smallest of their platform.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update

Ran `js/workflow_editor` mocha specs (163 passing), including new specs covering an organization without `e1`/`a1` machine types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)