### PR TITLE
feat(guard): extend MCP OAuth token TTL to 24h

### DIFF
--- a/guard/config/config.exs
+++ b/guard/config/config.exs
@@ -88,6 +88,10 @@ config :guard, session_secret_key_base: System.get_env("SESSION_SECRET_KEY_BASE"
 config :guard, session_key: System.get_env("SESSION_COOKIE_NAME")
 
 config :guard,
+  mcp_oauth_access_token_ttl_seconds:
+    String.to_integer(System.get_env("MCP_OAUTH_ACCESS_TOKEN_TTL_SECONDS") || "86400")
+
+config :guard,
   oidc: [
     discovery_url: System.get_env("OIDC_DISCOVERY_URL"),
     client_id: System.get_env("OIDC_CLIENT_ID"),

--- a/guard/config/runtime.exs
+++ b/guard/config/runtime.exs
@@ -68,6 +68,10 @@ config :guard, session_secret_key_base: System.get_env("SESSION_SECRET_KEY_BASE"
 config :guard, session_key: System.get_env("SESSION_COOKIE_NAME")
 
 config :guard,
+  mcp_oauth_access_token_ttl_seconds:
+    String.to_integer(System.get_env("MCP_OAUTH_ACCESS_TOKEN_TTL_SECONDS") || "86400")
+
+config :guard,
   github_app_redirect_url:
     "https://id.#{System.get_env("BASE_DOMAIN")}/github_app_manifest_callback"
 

--- a/guard/lib/guard/mcp_oauth/jwt.ex
+++ b/guard/lib/guard/mcp_oauth/jwt.ex
@@ -57,11 +57,6 @@ defmodule Guard.McpOAuth.JWT do
   end
 
   @doc """
-  Returns the default token TTL in seconds.
-  """
-  def default_token_ttl_seconds, do: @default_token_ttl_seconds
-
-  @doc """
   Returns the OAuth issuer URL.
   """
   @spec issuer() :: String.t()

--- a/guard/lib/guard/mcp_oauth/jwt.ex
+++ b/guard/lib/guard/mcp_oauth/jwt.ex
@@ -17,13 +17,11 @@ defmodule Guard.McpOAuth.JWT do
 
   require Logger
 
-  @default_token_ttl_seconds 3600
-
   @doc """
   Creates a signed JWT for an MCP grant.
 
   ## Options
-  - `:ttl_seconds` - Token TTL in seconds (default: 3600)
+  - `:ttl_seconds` - Token TTL in seconds (defaults to `default_token_ttl_seconds/0`)
 
   ## Returns
   - `{:ok, token}` on success
@@ -33,7 +31,7 @@ defmodule Guard.McpOAuth.JWT do
   def create_token(params, opts \\ []) do
     with {:ok, signer} <- get_signer() do
       now = DateTime.utc_now() |> DateTime.to_unix()
-      ttl = Keyword.get(opts, :ttl_seconds, @default_token_ttl_seconds)
+      ttl = Keyword.get(opts, :ttl_seconds, default_token_ttl_seconds())
 
       claims = %{
         "iss" => issuer(),
@@ -54,6 +52,14 @@ defmodule Guard.McpOAuth.JWT do
     e ->
       Logger.error("[McpOAuth.JWT] Error creating token: #{inspect(e)}")
       {:error, :token_creation_failed}
+  end
+
+  @doc """
+  Returns the default token TTL in seconds.
+  """
+  @spec default_token_ttl_seconds() :: pos_integer()
+  def default_token_ttl_seconds do
+    Application.fetch_env!(:guard, :mcp_oauth_access_token_ttl_seconds)
   end
 
   @doc """

--- a/guard/lib/guard/mcp_oauth/token.ex
+++ b/guard/lib/guard/mcp_oauth/token.ex
@@ -11,8 +11,6 @@ defmodule Guard.McpOAuth.Token do
   alias Guard.Store.McpOAuthAuthCode
   alias Guard.McpOAuth.{JWT, PKCE}
 
-  @access_token_ttl_seconds 86_400
-
   @doc """
   Exchanges an authorization code for an access token.
 
@@ -123,16 +121,20 @@ defmodule Guard.McpOAuth.Token do
   end
 
   defp create_token(auth_code) do
-    JWT.create_token(%{user_id: auth_code.user_id}, ttl_seconds: @access_token_ttl_seconds)
+    JWT.create_token(%{user_id: auth_code.user_id}, ttl_seconds: access_token_ttl_seconds())
   end
 
   defp build_response(token) do
     %{
       "access_token" => token,
       "token_type" => "Bearer",
-      "expires_in" => @access_token_ttl_seconds,
+      "expires_in" => access_token_ttl_seconds(),
       "scope" => "mcp"
     }
+  end
+
+  defp access_token_ttl_seconds do
+    Application.fetch_env!(:guard, :mcp_oauth_access_token_ttl_seconds)
   end
 
   defp error_response(error, description) do

--- a/guard/lib/guard/mcp_oauth/token.ex
+++ b/guard/lib/guard/mcp_oauth/token.ex
@@ -121,20 +121,16 @@ defmodule Guard.McpOAuth.Token do
   end
 
   defp create_token(auth_code) do
-    JWT.create_token(%{user_id: auth_code.user_id}, ttl_seconds: access_token_ttl_seconds())
+    JWT.create_token(%{user_id: auth_code.user_id})
   end
 
   defp build_response(token) do
     %{
       "access_token" => token,
       "token_type" => "Bearer",
-      "expires_in" => access_token_ttl_seconds(),
+      "expires_in" => JWT.default_token_ttl_seconds(),
       "scope" => "mcp"
     }
-  end
-
-  defp access_token_ttl_seconds do
-    Application.fetch_env!(:guard, :mcp_oauth_access_token_ttl_seconds)
   end
 
   defp error_response(error, description) do

--- a/guard/lib/guard/mcp_oauth/token.ex
+++ b/guard/lib/guard/mcp_oauth/token.ex
@@ -11,6 +11,8 @@ defmodule Guard.McpOAuth.Token do
   alias Guard.Store.McpOAuthAuthCode
   alias Guard.McpOAuth.{JWT, PKCE}
 
+  @access_token_ttl_seconds 86_400
+
   @doc """
   Exchanges an authorization code for an access token.
 
@@ -121,14 +123,14 @@ defmodule Guard.McpOAuth.Token do
   end
 
   defp create_token(auth_code) do
-    JWT.create_token(%{user_id: auth_code.user_id})
+    JWT.create_token(%{user_id: auth_code.user_id}, ttl_seconds: @access_token_ttl_seconds)
   end
 
   defp build_response(token) do
     %{
       "access_token" => token,
       "token_type" => "Bearer",
-      "expires_in" => JWT.default_token_ttl_seconds(),
+      "expires_in" => @access_token_ttl_seconds,
       "scope" => "mcp"
     }
   end

--- a/guard/test/guard/mcp_oauth/server_test.exs
+++ b/guard/test/guard/mcp_oauth/server_test.exs
@@ -359,6 +359,37 @@ defmodule Guard.McpOAuth.Server.Test do
       assert claims["exp"] - claims["iat"] == 86_400
     end
 
+    test "token exchange honors configured TTL", %{user_id: user_id} do
+      original = Application.fetch_env!(:guard, :mcp_oauth_access_token_ttl_seconds)
+      Application.put_env(:guard, :mcp_oauth_access_token_ttl_seconds, 120)
+
+      on_exit(fn ->
+        Application.put_env(:guard, :mcp_oauth_access_token_ttl_seconds, original)
+      end)
+
+      client = create_test_client()
+      auth_code = create_test_auth_code(user_id, client.client_id)
+
+      body =
+        URI.encode_query(%{
+          "grant_type" => "authorization_code",
+          "code" => auth_code.code,
+          "redirect_uri" => @redirect_uri,
+          "client_id" => client.client_id,
+          "code_verifier" => @code_verifier
+        })
+
+      {:ok, response} = HTTPoison.post(mcp_oauth_url("/token"), body, form_headers())
+
+      assert response.status_code == 200
+      result = Jason.decode!(response.body)
+      assert result["expires_in"] == 120
+
+      signer = Joken.Signer.create("HS256", System.get_env("MCP_OAUTH_JWT_KEYS"))
+      assert {:ok, claims} = Joken.verify(result["access_token"], signer)
+      assert claims["exp"] - claims["iat"] == 120
+    end
+
     test "invalid grant_type returns error" do
       body =
         URI.encode_query(%{

--- a/guard/test/guard/mcp_oauth/server_test.exs
+++ b/guard/test/guard/mcp_oauth/server_test.exs
@@ -351,8 +351,12 @@ defmodule Guard.McpOAuth.Server.Test do
       result = Jason.decode!(response.body)
       assert is_binary(result["access_token"])
       assert result["token_type"] == "Bearer"
-      assert is_integer(result["expires_in"])
+      assert result["expires_in"] == 86_400
       assert result["scope"] == "mcp"
+
+      signer = Joken.Signer.create("HS256", System.get_env("MCP_OAUTH_JWT_KEYS"))
+      assert {:ok, claims} = Joken.verify(result["access_token"], signer)
+      assert claims["exp"] - claims["iat"] == 86_400
     end
 
     test "invalid grant_type returns error" do


### PR DESCRIPTION
## 📝 Description

Extends the MCP OAuth access token TTL from 1 hour to 24 hours in guard, the OAuth authorization server for mcp.<domain>. 

The token endpoint now passes an explicit ttl_seconds to JWT.create_token/2 and returns the same value in expires_in, keeping the JWT exp claim and the response field in lockstep so clients schedule re-authentication correctly. 

Since the flow issues no refresh tokens, this reduces full browser re-auth for MCP clients from hourly to at most once a day — a stopgap until refresh-token support lands separately.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
