### PR TITLE
fix(github_hooks): update grpc gem to forked version to patch auth_context leak

### DIFF
--- a/github_hooks/Dockerfile
+++ b/github_hooks/Dockerfile
@@ -47,10 +47,27 @@ RUN apt-get update && apt-get install --no-install-recommends -y --allow-downgra
 ENV BUNDLE_JOBS=4 \
   BUNDLE_RETRY=3
 
+# ---------------------------------------------------------------------------
+# grpc-gem: compile the forked grpc C-core (clone -> submodule init -> native
+# build) ONCE into an isolated, cacheable layer. Its only cache key is
+# docker/grpc.Gemfile, so it is rebuilt only when the grpc fork ref changes --
+# unrelated Gemfile.lock churn no longer triggers the ~20-40 min recompile. The
+# compiled gem lands in $BUNDLE_PATH and is copied forward by the stages below.
+# ---------------------------------------------------------------------------
+FROM builder AS grpc-gem
+
+WORKDIR /grpc-build
+
+COPY docker/grpc.Gemfile Gemfile
+RUN bundle install --jobs=${BUNDLE_JOBS} && rm -f "$BUNDLE_PATH/config"
+
 FROM builder AS dev
 
 WORKDIR /app
 
+# Reuse the pre-compiled grpc from the cached grpc-gem layer, so this stage's
+# bundle install skips the C-core build and only installs the remaining gems.
+COPY --from=grpc-gem ${BUNDLE_PATH} ${BUNDLE_PATH}
 COPY Gemfile Gemfile.lock ./
 RUN bundle install --jobs=${BUNDLE_JOBS}
 
@@ -67,6 +84,8 @@ FROM builder as production-builder
 
 WORKDIR /app
 
+# Reuse the pre-compiled grpc from the cached grpc-gem layer (see dev stage).
+COPY --from=grpc-gem ${BUNDLE_PATH} ${BUNDLE_PATH}
 COPY Gemfile Gemfile.lock ./
 RUN bundle config set --local deployment true && \
     bundle config set --local without 'development test' && \

--- a/github_hooks/Dockerfile
+++ b/github_hooks/Dockerfile
@@ -53,13 +53,33 @@ ENV BUNDLE_JOBS=4 \
 # docker/grpc.Gemfile, so it is rebuilt only when the grpc fork ref changes --
 # unrelated Gemfile.lock churn no longer triggers the ~20-40 min recompile. The
 # compiled gem lands in $BUNDLE_PATH and is copied forward by the stages below.
+#
+# After building, strip the build-only tree from the installed git gem. A
+# git-source native gem otherwise leaves the whole monorepo (~4GB) in the
+# bundle: the .git clone (~1.4G), C/C++ core sources under src/ (~2.0G), all
+# third_party submodules (~440M), headers, tests and object files -- none
+# needed at runtime, which needs only src/ruby + the compiled grpc_c.so (~9M).
+# This is what keeps the dev/production images at a normal size (~4.0GB -> ~85MB
+# of bundle). Verified: grpc still loads and the consuming stages' bundle
+# install reuses the slimmed gem without recompiling.
 # ---------------------------------------------------------------------------
 FROM builder AS grpc-gem
 
 WORKDIR /grpc-build
 
 COPY docker/grpc.Gemfile Gemfile
-RUN bundle install --jobs=${BUNDLE_JOBS} && rm -f "$BUNDLE_PATH/config"
+RUN bundle install --jobs=${BUNDLE_JOBS} && \
+    GEMDIR="$(ls -d "$BUNDLE_PATH"/ruby/*/bundler/gems/grpc-* | head -1)" && \
+    test -n "$GEMDIR" && \
+    rm -rf \
+      "$GEMDIR/.git" "$GEMDIR/third_party" "$GEMDIR/test" \
+      "$GEMDIR/src/core" "$GEMDIR/src/cpp" "$GEMDIR/src/python" "$GEMDIR/src/php" \
+      "$GEMDIR/src/csharp" "$GEMDIR/src/objective-c" "$GEMDIR/src/proto" "$GEMDIR/src/android" \
+      "$GEMDIR/include" "$GEMDIR/examples" "$GEMDIR/doc" "$GEMDIR/tools" \
+      "$GEMDIR/bazel" "$GEMDIR/cmake" "$GEMDIR/templates" "$GEMDIR/summerofcode" && \
+    find "$GEMDIR" -type f \( -name '*.o' -o -name '*.a' \) -delete && \
+    find "$BUNDLE_PATH"/ruby/*/extensions -type f -name '*.o' -delete && \
+    rm -f "$BUNDLE_PATH/config"
 
 FROM builder AS dev
 

--- a/github_hooks/Gemfile
+++ b/github_hooks/Gemfile
@@ -16,8 +16,8 @@ gem 'net-imap', '~> 0.5.15'
 # Forked grpc: patches an auth_context object leak (grpc_auth_context not
 # released on the unauthenticated / no-cert early-return paths in rb_call.c).
 # Built from source, so the C-core + third_party submodules are compiled at
-# bundle-install time. See https://github.com/dexyk/grpc/tree/ruby-v1.62.1-auth-context-leak-fix
-gem "grpc", "~> 1.62.1", :github => "dexyk/grpc", :branch => "ruby-v1.62.1-auth-context-leak-fix", :submodules => true
+# bundle-install time. See https://github.com/renderedtext/grpc/tree/ruby-v1.62.1-auth-context-leak-fix
+gem "grpc", "~> 1.62.1", :github => "renderedtext/grpc", :branch => "ruby-v1.62.1-auth-context-leak-fix", :submodules => true
 gem "googleapis-common-protos-types", "~> 1.18.0"
 gem "httparty", "~> 0.24.0"
 gem "httpclient"

--- a/github_hooks/Gemfile
+++ b/github_hooks/Gemfile
@@ -16,8 +16,8 @@ gem 'net-imap', '~> 0.5.15'
 # Forked grpc: patches an auth_context object leak (grpc_auth_context not
 # released on the unauthenticated / no-cert early-return paths in rb_call.c).
 # Built from source, so the C-core + third_party submodules are compiled at
-# bundle-install time. See https://github.com/renderedtext/grpc/tree/ruby-v1.62.1-auth-context-leak-fix
-gem "grpc", "~> 1.62.1", :github => "renderedtext/grpc", :branch => "ruby-v1.62.1-auth-context-leak-fix", :submodules => true
+# bundle-install time. See https://github.com/renderedtext/grpc/tree/ruby-v1.62.3-auth-context-leak-fix
+gem "grpc", "~> 1.62.3", :github => "renderedtext/grpc", :branch => "ruby-v1.62.3-auth-context-leak-fix", :submodules => true
 gem "googleapis-common-protos-types", "~> 1.18.0"
 gem "httparty", "~> 0.24.0"
 gem "httpclient"

--- a/github_hooks/Gemfile
+++ b/github_hooks/Gemfile
@@ -13,7 +13,11 @@ gem "app"
 gem "bunny"
 gem "net-http" # https://github.com/ruby/net-imap/issues/16#issuecomment-803086765
 gem 'net-imap', '~> 0.5.15'
-gem "grpc", "~> 1.62.1"
+# Forked grpc: patches an auth_context object leak (grpc_auth_context not
+# released on the unauthenticated / no-cert early-return paths in rb_call.c).
+# Built from source, so the C-core + third_party submodules are compiled at
+# bundle-install time. See https://github.com/dexyk/grpc/tree/ruby-v1.62.1-auth-context-leak-fix
+gem "grpc", "~> 1.62.1", :github => "dexyk/grpc", :branch => "ruby-v1.62.1-auth-context-leak-fix", :submodules => true
 gem "googleapis-common-protos-types", "~> 1.18.0"
 gem "httparty", "~> 0.24.0"
 gem "httpclient"

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/renderedtext/grpc.git
-  revision: d2bfbfab64b64643280a116fc957107db43d7727
-  branch: ruby-v1.62.1-auth-context-leak-fix
+  revision: 80d88be7ca316e8b6a60aa9af6d7774500955e77
+  branch: ruby-v1.62.3-auth-context-leak-fix
   submodules: true
   specs:
-    grpc (1.62.1)
+    grpc (1.62.3)
       google-protobuf (~> 3.25)
       googleapis-common-protos-types (~> 1.0)
 
@@ -519,7 +519,7 @@ DEPENDENCIES
   factory_bot_rails (< 5)
   faraday (>= 2.14.3)
   googleapis-common-protos-types (~> 1.18.0)
-  grpc (~> 1.62.1)!
+  grpc (~> 1.62.3)!
   grpc-tools
   httparty (~> 0.24.0)
   httpclient

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/dexyk/grpc.git
+  revision: d2bfbfab64b64643280a116fc957107db43d7727
+  branch: ruby-v1.62.1-auth-context-leak-fix
+  submodules: true
+  specs:
+    grpc (1.62.1)
+      google-protobuf (~> 3.25)
+      googleapis-common-protos-types (~> 1.0)
+
+GIT
   remote: https://github.com/renderedtext/watchman.git
   revision: 74530687a232aea678b6738114c82dfc163657cd
   ref: 74530687a232aea678b6738114c82dfc163657cd
@@ -167,18 +177,6 @@ GEM
     google-protobuf (3.25.8-x86_64-linux)
     googleapis-common-protos-types (1.18.0)
       google-protobuf (>= 3.18, < 5.a)
-    grpc (1.62.3)
-      google-protobuf (~> 3.25)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.62.3-aarch64-linux)
-      google-protobuf (~> 3.25)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.62.3-arm64-darwin)
-      google-protobuf (~> 3.25)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.62.3-x86_64-linux)
-      google-protobuf (~> 3.25)
-      googleapis-common-protos-types (~> 1.0)
     grpc-tools (1.74.1)
     hashdiff (1.2.0)
     httparty (0.24.2)
@@ -521,7 +519,7 @@ DEPENDENCIES
   factory_bot_rails (< 5)
   faraday (>= 2.14.3)
   googleapis-common-protos-types (~> 1.18.0)
-  grpc (~> 1.62.1)
+  grpc (~> 1.62.1)!
   grpc-tools
   httparty (~> 0.24.0)
   httpclient

--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/dexyk/grpc.git
+  remote: https://github.com/renderedtext/grpc.git
   revision: d2bfbfab64b64643280a116fc957107db43d7727
   branch: ruby-v1.62.1-auth-context-leak-fix
   submodules: true

--- a/github_hooks/Makefile
+++ b/github_hooks/Makefile
@@ -88,7 +88,7 @@ check.ruby.code:
 	$(MAKE) check.code LANGUAGE=ruby
 
 check.ruby.deps:
-	$(MAKE) check.deps LANGUAGE=ruby CHECK_DEPS_OPTS="-w app,rt-watchman"
+	$(MAKE) check.deps LANGUAGE=ruby CHECK_DEPS_OPTS="-w app,rt-watchman,grpc"
 
 pb.gen:
 	bash ./protobuffer/regenerate.sh

--- a/github_hooks/docker/grpc.Gemfile
+++ b/github_hooks/docker/grpc.Gemfile
@@ -1,0 +1,19 @@
+# Standalone Gemfile used ONLY by the `grpc-gem` build stage in ../Dockerfile.
+#
+# Its sole job is to compile the forked grpc C-core (clone + submodule init +
+# native build) exactly once into a cacheable Docker layer. Because this stage's
+# cache key is *this file* (not the full Gemfile.lock), unrelated gem bumps no
+# longer trigger the ~20-40 min grpc recompile.
+#
+# KEEP THIS IN SYNC WITH ../Gemfile and ../Gemfile.lock:
+#   - the :ref below must equal the `revision:` of the grpc GIT block in
+#     Gemfile.lock (currently d2bfbfab64b64643280a116fc957107db43d7727).
+# If it drifts, nothing breaks — the main `bundle install` just recompiles grpc
+# that one build instead of reusing the cached layer.
+source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+gem "grpc", "1.62.1",
+    :github     => "dexyk/grpc",
+    :ref        => "d2bfbfab64b64643280a116fc957107db43d7727",
+    :submodules => true

--- a/github_hooks/docker/grpc.Gemfile
+++ b/github_hooks/docker/grpc.Gemfile
@@ -7,13 +7,13 @@
 #
 # KEEP THIS IN SYNC WITH ../Gemfile and ../Gemfile.lock:
 #   - the :ref below must equal the `revision:` of the grpc GIT block in
-#     Gemfile.lock (currently d2bfbfab64b64643280a116fc957107db43d7727).
+#     Gemfile.lock (currently 80d88be7ca316e8b6a60aa9af6d7774500955e77).
 # If it drifts, nothing breaks — the main `bundle install` just recompiles grpc
 # that one build instead of reusing the cached layer.
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-gem "grpc", "1.62.1",
+gem "grpc", "1.62.3",
     :github     => "renderedtext/grpc",
-    :ref        => "d2bfbfab64b64643280a116fc957107db43d7727",
+    :ref        => "80d88be7ca316e8b6a60aa9af6d7774500955e77",
     :submodules => true

--- a/github_hooks/docker/grpc.Gemfile
+++ b/github_hooks/docker/grpc.Gemfile
@@ -14,6 +14,6 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem "grpc", "1.62.1",
-    :github     => "dexyk/grpc",
+    :github     => "renderedtext/grpc",
     :ref        => "d2bfbfab64b64643280a116fc957107db43d7727",
     :submodules => true


### PR DESCRIPTION
## 📝 Description

**Problem** - grpc's Ruby gem leaks a native `grpc_auth_context` on every RPC from an unauthenticated peer (`rb_call.c` skips `grpc_auth_context_release` on the no-cert early-return paths; our internal gRPC is plaintext -> leaks ~every request -> memory growth toward OOM on this image).

**Fix** - `grpc` now [from `renderedtext/grpc`](https://github.com/renderedtext/grpc/tree/ruby-v1.62.3-auth-context-leak-fix) @ `v1.62.3` + fix (branch `ruby-v1.62.3-auth-context-leak-fix`, commit [[80d88be](https://github.com/renderedtext/grpc/commit/80d88be7ca316e8b6a60aa9af6d7774500955e77)](https://github.com/renderedtext/grpc/commit/80d88be7ca316e8b6a60aa9af6d7774500955e77), `submodules: true`), built from source; `docker/grpc.Gemfile` + a cached `grpc-gem` Docker stage compile the C-core once and strip the build tree, keeping the image size low.

**Verification (preprod)** - ~1.19M RPCs: grpc live memory flat (~0.4 MB) vs +570 MB churn -> auth_context released, no accumulation.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
