### PR TITLE
front: align project-page memory request with observed usage

### DIFF
--- a/front/helm/values.yaml
+++ b/front/helm/values.yaml
@@ -22,7 +22,7 @@ projectPage:
       memory: 700Mi
     requests:
       cpu: '0.2'
-      memory: 300Mi
+      memory: 512Mi
 
 jobPage:
   replicas: 1


### PR DESCRIPTION
Align the `project-page` deployment's memory request with observed production usage.

The chart requests `300Mi` for project-page, but production monitoring shows the container's working set peaking around `466Mi` over a 7-day window — consistently above the request. When a container's real usage exceeds its request, the scheduler under-accounts for it and the pod becomes a candidate for eviction under node memory pressure.

This raises the request to `512Mi`, which covers the observed peak with a little headroom. The `700Mi` limit already accommodates the peak and is left unchanged, so this only affects scheduling/accounting, not the container's ceiling.

| Deployment | Old request | New request | Observed 7d peak | Limit |
|---|---|---|---|---|
| project-page | 300Mi | 512Mi | ~466Mi | 700Mi (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
