### PR TITLE
chore(front): update js-yaml and fast-uri versions to fix CVEs

### DIFF
--- a/front/assets/package-lock.json
+++ b/front/assets/package-lock.json
@@ -31,7 +31,7 @@
         "domurl": "2.3.0",
         "highlight.js": "^9.16.2",
         "jquery": ">= 3.1",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.0",
         "lodash": "4.18.1",
         "markdown-it": "^14.1.0",
         "markdown-it-textual-uml": "^0.17.1",
@@ -7668,9 +7668,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -8964,9 +8964,10 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -9233,9 +9234,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",

--- a/front/assets/package.json
+++ b/front/assets/package.json
@@ -39,7 +39,7 @@
     "domurl": "2.3.0",
     "highlight.js": "^9.16.2",
     "jquery": ">= 3.1",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^3.15.0",
     "lodash": "4.18.1",
     "markdown-it": "^14.1.0",
     "markdown-it-textual-uml": "^0.17.1",
@@ -116,7 +116,8 @@
     "uglify-js-brunch": "2.10.0"
   },
   "overrides": {
-    "fast-uri": "^3.1.1",
+    "fast-uri": "^3.1.4",
+    "linkify-it": "^5.0.2",
     "lodash-es": "4.18.1",
     "dagre-d3": {
       "d3-color": "3.1.0"


### PR DESCRIPTION
## 📝 Description

Bumps three npm packages in `front/assets` to patched releases, clearing 4 HIGH advisories from the JS dependency scan:

| Package | Change | How | CVEs |
|---|---|---|---|
| js-yaml | 3.13.1 → **3.15.0** | direct dep | CVE-2026-59869 (YAML-parse DoS) |
| fast-uri | 3.1.2 → **3.1.4** | override (via ajv) | CVE-2026-13676, CVE-2026-16221 (host-canonicalization bypass) |
| linkify-it | 5.0.1 → **5.0.2** | override (via markdown-it) | CVE-2026-59887 (`mailto:` DoS) |

These are patch/minor bumps within the same major - no library API changes, no source changes. Impact is client-side (browser assets); fast-uri is reached only via ajv `format: uri` validation, so its bump is defense-in-depth.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
