### PR TITLE
feat(plumber): implement safe_name function to handle long queue names and ensure uniqueness

### DIFF
--- a/plumber/ppl/lib/ppl/ppls_reviser.ex
+++ b/plumber/ppl/lib/ppl/ppls_reviser.ex
@@ -53,7 +53,7 @@ defmodule Ppl.PplsReviser do
     end
   end
   defp set_queue(ppl, _definition, ppl_args) do
-    with name               <- "#{ppl.label}-#{ppl.yml_file_path}",
+    with name               <- default_queue_name(ppl),
          {:ok, params}      <- form_queue_params(ppl_args, name, "project"),
          {:ok, queue}       <- QueuesQueries.get_or_insert_queue(params),
     do: {:ok, %{queue_id: queue.queue_id, in_parallel?: false}}
@@ -62,7 +62,7 @@ defmodule Ppl.PplsReviser do
   defp get_queue_details(queue_map, ppl, _ppl_args) when is_map(queue_map) do
     with name            <- Map.get(queue_map, "name", false),
          user_generated? <- name != false,
-         name            <- name || "#{ppl.label}-#{ppl.yml_file_path}",
+         name            <- name || default_queue_name(ppl),
          scope           <- Map.get(queue_map, "scope", "project"),
          processing      <- Map.get(queue_map, "processing", "serialized"),
          in_parallel?    <- processing == "parallel",
@@ -70,8 +70,8 @@ defmodule Ppl.PplsReviser do
   end
 
   defp get_queue_details(queue_list, ppl, ppl_args) when is_list(queue_list) do
-    default_queue_name = "#{ppl.label}-#{ppl.yml_file_path}"
-    default = {:ok, default_queue_name, "project", false, false}
+    default_name = default_queue_name(ppl)
+    default = {:ok, default_name, "project", false, false}
 
     ref_type = Map.get(ppl_args, "git_ref_type", "")
     {:ok, w_params} = when_params(ppl_args, ppl.label, ref_type)
@@ -87,6 +87,8 @@ defmodule Ppl.PplsReviser do
       end
     end)
   end
+
+  defp default_queue_name(ppl), do: "#{ppl.label}-#{ppl.yml_file_path}"
 
   defp form_queue_params(request_args, name, scope, user_generated \\ false) do
     %{

--- a/plumber/ppl/lib/ppl/queues/model/queues.ex
+++ b/plumber/ppl/lib/ppl/queues/model/queues.ex
@@ -27,6 +27,12 @@ defmodule Ppl.Queues.Model.Queues do
   @optional_fields ~w(user_generated)a
   @valid_scopes ~w(project organization)
 
+  # `queues.name` is a Postgres `varchar(255)`, whose limit is counted in
+  # Unicode codepoints (not bytes or graphemes).
+  @max_name_length 255
+  # Number of hex chars of the sha256 suffix appended when a name is shortened.
+  @name_hash_length 16
+
 
   @doc ~S"""
   ## Examples:
@@ -46,6 +52,7 @@ defmodule Ppl.Queues.Model.Queues do
     |> cast(params, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> validate_inclusion(:scope, @valid_scopes)
+    |> validate_name_length()
     # this unique_constraint references unique_index in migration
     |> unique_constraint(:unique_queue_name_for_project,
                           name: :unique_queue_name_for_project)
@@ -53,4 +60,67 @@ defmodule Ppl.Queues.Model.Queues do
     |> unique_constraint(:unique_queue_name_for_org,
                           name: :unique_queue_name_for_org)
   end
+
+  @doc """
+  Largest queue name the `name` column can store, counted in Unicode codepoints.
+  """
+  def max_name_length, do: @max_name_length
+
+  @doc ~S"""
+  Returns a queue name guaranteed to fit the `varchar(255)` `name` column.
+
+  Names within the limit are returned unchanged. Longer names - e.g. an implicit
+  queue named after a very long branch or tag (`"<label>-<yml_file_path>"`) - are
+  deterministically shortened to a readable prefix plus a hash of the full name.
+  Hashing keeps distinct long names in distinct queues; plain truncation would
+  collide names that share a prefix and wrongly serialize unrelated pipelines.
+
+  ## Examples:
+
+      iex> Ppl.Queues.Model.Queues.safe_name("master-.semaphore/semaphore.yml")
+      "master-.semaphore/semaphore.yml"
+
+      iex> name = String.duplicate("a", 300)
+      iex> safe = Ppl.Queues.Model.Queues.safe_name(name)
+      iex> String.length(safe)
+      255
+      iex> safe == Ppl.Queues.Model.Queues.safe_name(name)
+      true
+  """
+  def safe_name(name) when is_binary(name) do
+    cond do
+      # Fast path: a codepoint is >= 1 byte, so byte_size <= limit => within limit.
+      byte_size(name) <= @max_name_length -> name
+      codepoint_count(name) <= @max_name_length -> name
+      true -> shorten_name(name)
+    end
+  end
+
+  defp shorten_name(name) do
+    hash =
+      :crypto.hash(:sha256, name)
+      |> Base.encode16(case: :lower)
+      |> binary_part(0, @name_hash_length)
+
+    prefix =
+      name
+      |> String.codepoints()
+      |> Enum.take(@max_name_length - @name_hash_length - 1)
+      |> Enum.join()
+
+    "#{prefix}-#{hash}"
+  end
+
+  defp validate_name_length(changeset) do
+    validate_change(changeset, :name, fn :name, name ->
+      if codepoint_count(name) <= @max_name_length do
+        []
+      else
+        [name: {"should be at most %{count} character(s)",
+                count: @max_name_length, validation: :length, kind: :max, type: :string}]
+      end
+    end)
+  end
+
+  defp codepoint_count(name), do: name |> String.codepoints() |> length()
 end

--- a/plumber/ppl/lib/ppl/queues/model/queues_queries.ex
+++ b/plumber/ppl/lib/ppl/queues/model/queues_queries.ex
@@ -26,8 +26,10 @@ defmodule Ppl.Queues.Model.QueuesQueries do
   Creates new DB record for queue with given params
   """
   def insert_queue(params) do
-    queue_id = UUID.uuid4()
-    params = Map.put(params, :queue_id, queue_id)
+    params =
+      params
+      |> normalize_name()
+      |> Map.put(:queue_id, UUID.uuid4())
 
     %Queues{} |> Queues.changeset(params) |> Repo.insert()
     |> process_response(params)
@@ -46,6 +48,10 @@ defmodule Ppl.Queues.Model.QueuesQueries do
      LT.info("", "QueuesQueries.insert() - There is already queue caled '#{params.name}'"
                 <> "for organization with id '#{params.organization_id}'")
     {:error, {:queue_exists, {params.name, params.organization_id, "organization"}}}
+  end
+  defp process_response({:error, %Ecto.Changeset{valid?: false} = changeset}, params) do
+    LT.error(changeset, "QueuesQueries.insert() - invalid queue with name '#{Map.get(params, :name)}'")
+    {:error, {:invalid_queue, changeset}}
   end
   defp process_response(queue, _params) do
     LT.info(queue, "Queue persisted")
@@ -119,7 +125,9 @@ defmodule Ppl.Queues.Model.QueuesQueries do
   @doc """
   Finds queue with given name for given project or organization
   """
-  def get_by_name_and_id(%{name: name, project_id: pr_id, scope: "project"}) do
+  def get_by_name_and_id(params), do: params |> normalize_name() |> do_get_by_name_and_id()
+
+  defp do_get_by_name_and_id(%{name: name, project_id: pr_id, scope: "project"}) do
     Queues
     |> where([q], q.name == ^name)
     |> where([q], q.scope == "project")
@@ -127,7 +135,7 @@ defmodule Ppl.Queues.Model.QueuesQueries do
     |> Repo.one()
     |> return_tuple("Queue #{name} for project #{pr_id} not found.")
   end
-  def get_by_name_and_id(%{name: name, organization_id: org_id, scope: "organization"}) do
+  defp do_get_by_name_and_id(%{name: name, organization_id: org_id, scope: "organization"}) do
     Queues
     |> where([q], q.name == ^name)
     |> where([q], q.scope == "organization")
@@ -135,7 +143,7 @@ defmodule Ppl.Queues.Model.QueuesQueries do
     |> Repo.one()
     |> return_tuple("Queue #{name} for organization #{org_id} not found.")
   end
-  def get_by_name_and_id(_), do: {:error, "Invalid parameters for getting a queue."}
+  defp do_get_by_name_and_id(_), do: {:error, "Invalid parameters for getting a queue."}
 
   @doc """
   Finds queue by its id
@@ -148,6 +156,14 @@ defmodule Ppl.Queues.Model.QueuesQueries do
   end
 
   # Utility
+
+  # Keep the queue name within the `varchar(255)` column so a long branch/tag
+  # (implicit queue "<label>-<yml_file_path>") does not blow up the insert. Both
+  # the writer (get_or_insert_queue) and the limit-check reader (ScheduleLimits
+  # via get_by_name_and_id) go through here, so they agree on the stored name.
+  defp normalize_name(%{name: name} = params) when is_binary(name),
+    do: %{params | name: Queues.safe_name(name)}
+  defp normalize_name(params), do: params
 
   defp return_tuple(nil, nil_msg), do: ToTuple.error(nil_msg)
   defp return_tuple(value, _),     do: ToTuple.ok(value)

--- a/plumber/ppl/test/queues/model/queues_queries_test.exs
+++ b/plumber/ppl/test/queues/model/queues_queries_test.exs
@@ -2,6 +2,7 @@ defmodule Ppl.Queues.Model.QueuesQueries.Test do
   use ExUnit.Case
 
   alias Ppl.Queues.Model.QueuesQueries
+  alias Ppl.Queues.Model.Queues
 
   setup do
     Test.Helpers.truncate_db()
@@ -254,5 +255,28 @@ defmodule Ppl.Queues.Model.QueuesQueries.Test do
     assert {:ok, queue_1} = QueuesQueries.insert_queue(params)
 
     assert {:ok, queue_1} == QueuesQueries.get_or_insert_queue(params)
+  end
+
+  # Long / implicit queue names (issue #10098)
+
+  test "get_or_insert_queue() shortens an over-long implicit name so the insert succeeds" do
+    long_label = String.duplicate("x", 300)
+    params = %{name: "#{long_label}-.semaphore/semaphore.yml", scope: "project",
+               project_id: UUID.uuid4, organization_id: UUID.uuid4, user_generated: false}
+
+    assert {:ok, queue} = QueuesQueries.get_or_insert_queue(params)
+    assert String.length(queue.name) <= Queues.max_name_length()
+  end
+
+  test "get_or_insert_queue() reuses the same queue for a repeated over-long name" do
+    long_label = String.duplicate("x", 300)
+    params = %{name: "#{long_label}-.semaphore/semaphore.yml", scope: "project",
+               project_id: UUID.uuid4, organization_id: UUID.uuid4, user_generated: false}
+
+    assert {:ok, %{queue_id: queue_id}} = QueuesQueries.get_or_insert_queue(params)
+    # a second identical request must map to the same queue, not create a duplicate
+    assert {:ok, %{queue_id: ^queue_id}} = QueuesQueries.get_or_insert_queue(params)
+    # and it is findable via the raw (un-normalized) params too
+    assert {:ok, %{queue_id: ^queue_id}} = QueuesQueries.get_by_name_and_id(params)
   end
 end

--- a/plumber/ppl/test/queues/model/queues_test.exs
+++ b/plumber/ppl/test/queues/model/queues_test.exs
@@ -2,9 +2,49 @@ defmodule Ppl.Queues.Model.Queues.Test do
   use ExUnit.Case
   doctest Ppl.Queues.Model.Queues
 
+  alias Ppl.Queues.Model.Queues
+
   setup do
     Test.Helpers.truncate_db()
     :ok
   end
 
+  describe "safe_name/1" do
+    test "returns names within the limit unchanged" do
+      assert Queues.safe_name("master-.semaphore/semaphore.yml") ==
+               "master-.semaphore/semaphore.yml"
+
+      at_limit = String.duplicate("a", Queues.max_name_length())
+      assert Queues.safe_name(at_limit) == at_limit
+    end
+
+    test "shortens an over-long name to fit the column and is deterministic" do
+      name = String.duplicate("a", 300)
+      safe = Queues.safe_name(name)
+
+      assert codepoints(safe) == Queues.max_name_length()
+      assert safe == Queues.safe_name(name)
+      assert String.starts_with?(safe, String.duplicate("a", 100))
+    end
+
+    test "keeps distinct long names in distinct queues even when they share a prefix" do
+      prefix = String.duplicate("feature/very-long-branch-", 12)
+      name_a = prefix <> "a"
+      name_b = prefix <> "b"
+
+      assert codepoints(name_a) > Queues.max_name_length()
+      refute Queues.safe_name(name_a) == Queues.safe_name(name_b)
+    end
+
+    test "counts multibyte names by codepoints, not bytes" do
+      # 200 codepoints (600 bytes) fits varchar(255); 300 codepoints does not.
+      kept = String.duplicate("中", 200)
+      shortened = String.duplicate("中", 300)
+
+      assert Queues.safe_name(kept) == kept
+      assert codepoints(Queues.safe_name(shortened)) <= Queues.max_name_length()
+    end
+  end
+
+  defp codepoints(str), do: str |> String.codepoints() |> length()
 end


### PR DESCRIPTION
## 📝 Description

Branch/tag names longer than ~230 chars overflowed the implicit pipeline queue name (`"<label>-<yml_file_path>"` stored in `queues.name`, a `varchar(255)`), so the insert failed and the pipeline got stuck in `regular_init` and was failed as "stuck" - the workflow never started.

This adds `Queues.safe_name/1`, which passes names ≤255 through unchanged and deterministically shortens longer ones to a readable prefix + a hash of the full name (so distinct branches keep distinct queues), normalized at a single `QueuesQueries` chokepoint so the writer (`PplsReviser`) and the queuing-limit reader (`ScheduleLimits`) agree on the stored name. It also adds a length validation to the `Queues` changeset and stops mislogging invalid inserts as "persisted". 

The change is backward compatible (all existing queue names are ≤255, so it's a no-op for them) and leaves scope keys untouched.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
