### PR TITLE
fix(velocity): propagate read errors in LimitedGzipReader

### DIFF
--- a/ee/velocity/pkg/collector/superjerry.go
+++ b/ee/velocity/pkg/collector/superjerry.go
@@ -27,6 +27,8 @@ import (
 
 var ErrNotFound = errors.New("not found")
 
+var reportHTTPClient = &http.Client{Timeout: 5 * time.Minute}
+
 type Superjerry struct {
 	reportFetcherClient service.ReportFetcherClient
 	projectHubClient    service.ProjectHubClient
@@ -174,7 +176,7 @@ func (c *Superjerry) prepareReport(projectID string, jobID string) ([]parser.Tes
 	}
 
 	log.Printf("Fetching report for job: %s\n", jobID)
-	response, err := http.Get(url) // #nosec
+	response, err := reportHTTPClient.Get(url) // #nosec
 	if err != nil {
 		return nil, err
 	}

--- a/ee/velocity/pkg/compression/gzip.go
+++ b/ee/velocity/pkg/compression/gzip.go
@@ -82,7 +82,7 @@ func (lgr *LimitedGzipReader) Read(p []byte) (int, error) {
 		// Size limit reached, return custom error
 		return n, ErrSizeLimitReached
 	}
-	return n, nil
+	return n, err
 }
 
 func (lgr *LimitedGzipReader) Close() error {

--- a/ee/velocity/pkg/compression/gzip_test.go
+++ b/ee/velocity/pkg/compression/gzip_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -29,4 +32,54 @@ func Test_GzipDecompressBigFile(t *testing.T) {
 	decoder := json.NewDecoder(decompressedReader)
 	err = decoder.Decode(&struct{}{})
 	assert.Error(t, err, "should not be nil")
+}
+
+type erroringReader struct {
+	err error
+}
+
+func (r *erroringReader) Read(p []byte) (int, error) {
+	return 0, r.err
+}
+
+func Test_LimitedGzipReaderPropagatesReaderErrors(t *testing.T) {
+	readErr := errors.New("connection reset by peer")
+	lgr := NewLimitedGzipReader(&erroringReader{err: readErr}, 100, nil)
+
+	n, err := lgr.Read(make([]byte, 10))
+
+	assert.Equal(t, 0, n)
+	assert.ErrorIs(t, err, readErr)
+}
+
+func Test_GzipDecompressTruncatedStreamReturnsError(t *testing.T) {
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+	_, err := gz.Write(bytes.Repeat([]byte(`{"key": "value"}`), 1000))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = gz.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	truncated := b.Bytes()[:b.Len()/2]
+	reader, err := GzipDecompress(bytes.NewReader(truncated), 1024*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, readErr := io.ReadAll(reader)
+		done <- readErr
+	}()
+
+	select {
+	case readErr := <-done:
+		assert.Error(t, readErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("read of truncated gzip stream did not terminate")
+	}
 }


### PR DESCRIPTION
## Problem

`velocity-hub-superjerry-worker` pods intermittently freeze at their CPU limit and stop consuming from the queue. The last log line is always `Decoding report from job: ...`, then silence, while the container burns CPU indefinitely. The gRPC liveness probe only covers the internal API goroutine, so the pod is never restarted and stays out of rotation.

## Root cause

`LimitedGzipReader.Read` swallows any non-`io.EOF` error from the underlying reader and returns `(0, nil)`. The superjerry collector streams the report download through this wrapper into the JSON decoder; when the HTTP body fails mid-stream (connection reset, truncated gzip), the underlying reader returns a persistent error, the wrapper masks it as `(0, nil)`, and the decoder retries `Read` in a tight busy loop forever. The delivery is never acked, so with prefetch 1 the consumer receives nothing more.

## Fix

Propagate the underlying read error in `LimitedGzipReader.Read`, and give the report download an `http.Client` with a 5 minute timeout so a stalled connection cannot block the consumer either.

## Tests

`Test_LimitedGzipReaderPropagatesReaderErrors` — a non-EOF reader error must surface. `Test_GzipDecompressTruncatedStreamReturnsError` — reading a truncated gzip stream must terminate with an error; before the fix this hangs, reproducing the production busy-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)