### PR TITLE
Store role ids in deployment target ROLE subject rules

### DIFF
--- a/ee/gofer/lib/gofer/deployment/model/deployment/subject_rule.ex
+++ b/ee/gofer/lib/gofer/deployment/model/deployment/subject_rule.ex
@@ -32,8 +32,16 @@ defmodule Gofer.Deployment.Model.Deployment.SubjectRule do
   defp validate_subject_id(:USER, changeset = %Ecto.Changeset{}),
     do: Ecto.Changeset.validate_required(changeset, [:subject_id])
 
-  defp validate_subject_id(:ROLE, changeset = %Ecto.Changeset{}),
-    do: Ecto.Changeset.validate_required(changeset, [:subject_id])
+  defp validate_subject_id(:ROLE, changeset = %Ecto.Changeset{}) do
+    changeset
+    |> Ecto.Changeset.validate_required([:subject_id])
+    |> Ecto.Changeset.validate_change(:subject_id, fn :subject_id, value ->
+      case Ecto.UUID.cast(value) do
+        {:ok, _} -> []
+        :error -> [subject_id: "must be a role id"]
+      end
+    end)
+  end
 
   defp validate_subject_id(:GROUP, changeset = %Ecto.Changeset{}),
     do: Ecto.Changeset.validate_required(changeset, [:subject_id])

--- a/ee/gofer/test/deployment/model/deployment_test.exs
+++ b/ee/gofer/test/deployment/model/deployment_test.exs
@@ -43,7 +43,7 @@ defmodule Gofer.Deployment.Model.DeploymentTest do
     end
 
     test "when name is longer than 255 characters then invalid", %{bare_params: params} do
-      name = for _ <- 1..300, into: "", do: <<Enum.random('0123456789abcdef')>>
+      name = for _ <- 1..300, into: "", do: <<Enum.random(~c"0123456789abcdef")>>
       changeset = assert_invalid?(&Deployment.changeset/2, %{params | name: name})
 
       assert [
@@ -107,6 +107,12 @@ defmodule Gofer.Deployment.Model.DeploymentTest do
 
     test "casts subject rules", %{bare_params: params, subject_rules: rules} do
       assert_valid?(&Deployment.changeset/2, %{params | subject_rules: rules})
+    end
+
+    test "when ROLE subject rule carries a role name instead of an id then invalid",
+         %{bare_params: params} do
+      rules = [%{type: :ROLE, subject_id: "Admin"}]
+      assert_invalid?(&Deployment.changeset/2, %{params | subject_rules: rules})
     end
 
     test "casts object rules", %{bare_params: params, object_rules: rules} do

--- a/public-api/v1alpha/lib/pipelines_api/deployments_client/request_formatter.ex
+++ b/public-api/v1alpha/lib/pipelines_api/deployments_client/request_formatter.ex
@@ -639,8 +639,10 @@ defmodule PipelinesAPI.DeploymentTargetsClient.RequestFormatter do
   defp check_role_subject_ids(error, _org_id, _subject_rules), do: error
 
   defp role_name_to_role_map(project_scope_roles) do
-    Enum.into(project_scope_roles, %{}, fn role ->
-      {String.downcase(role.name), role.name}
+    Enum.reduce(project_scope_roles, %{}, fn role, acc ->
+      acc
+      |> Map.put(String.downcase(role.name), role.id)
+      |> Map.put(String.downcase(role.id), role.id)
     end)
   end
 

--- a/public-api/v1alpha/test/deployments_client_test.exs
+++ b/public-api/v1alpha/test/deployments_client_test.exs
@@ -8,6 +8,8 @@ defmodule PipelinesAPI.DeploymentsClient.Test do
   @default_org_id "92be62c2-9cf4-4dad-b168-d6efa6aa5e21"
   @default_project_id "92be1234-1234-4234-8234-123456789012"
 
+  defp admin_role_id, do: Support.Stubs.DB.find_by(:rbac_roles, :name, "Admin").id
+
   setup do
     Support.Stubs.DB.reset()
 
@@ -113,6 +115,8 @@ defmodule PipelinesAPI.DeploymentsClient.Test do
       assert %{subject_id: subject_id} =
                Support.Stubs.DB.find_by(:subject_role_bindings, :project_id, @default_project_id)
 
+      admin_role_id = admin_role_id()
+
       target_params =
         Map.merge(ctx.target_params, ctx.extra_args)
         |> Map.put("subject_rules", [
@@ -132,7 +136,7 @@ defmodule PipelinesAPI.DeploymentsClient.Test do
                 project_id: "92be1234-1234-4234-8234-123456789012",
                 subject_rules: [
                   %{git_login: "milica-nerlovic", subject_id: ^subject_id, type: :USER},
-                  %{subject_id: "Admin", type: :ROLE}
+                  %{subject_id: ^admin_role_id, type: :ROLE}
                 ],
                 url: "https://staging.rtx.com"
               }} = DeploymentsClient.create(params, conn)
@@ -298,6 +302,8 @@ defmodule PipelinesAPI.DeploymentsClient.Test do
       assert %{subject_id: subject_id} =
                Support.Stubs.DB.find_by(:subject_role_bindings, :project_id, @default_project_id)
 
+      admin_role_id = admin_role_id()
+
       params =
         params
         |> Map.merge(target_params)
@@ -316,9 +322,34 @@ defmodule PipelinesAPI.DeploymentsClient.Test do
               %{
                 subject_rules: [
                   %{git_login: "milica-nerlovic", subject_id: ^subject_id, type: :USER},
-                  %{subject_id: "Admin", type: :ROLE}
+                  %{subject_id: ^admin_role_id, type: :ROLE}
                 ]
               }} = DeploymentsClient.update(params, conn)
+    end
+
+    test "when a ROLE rule is given as a role id then it round-trips unchanged", ctx do
+      conn = create_conn(ctx)
+      admin_role_id = admin_role_id()
+      target_params = Map.merge(ctx.target_params, ctx.extra_args)
+      {:ok, key} = SecretClient.key()
+      params = create_params(target_params, UUID.uuid4(), [], [], key)
+      {:ok, target} = DeploymentsClient.create(params, conn)
+
+      target_params = Map.put(target_params, "id", target.id)
+
+      params =
+        params
+        |> Map.merge(target_params)
+        |> Map.put("subject_rules", [%{"type" => "ROLE", "subject_id" => admin_role_id}])
+        |> Map.put("unique_token", UUID.uuid4())
+        |> Map.put("old_target", target)
+        |> Map.put("old_env_vars", [])
+        |> Map.put("old_files", [])
+
+      conn = update_conn(ctx) |> Map.put(:params, params)
+
+      assert {:ok, %{subject_rules: [%{subject_id: ^admin_role_id, type: :ROLE}]}} =
+               DeploymentsClient.update(params, conn)
     end
   end
 

--- a/public-api/v1alpha/test/router/deployments/create_test.exs
+++ b/public-api/v1alpha/test/router/deployments/create_test.exs
@@ -239,13 +239,15 @@ defmodule Router.Deployments.CreateTest do
       {status_code, _, created_target} = create_deployment(ctx, params)
       assert status_code == 200
 
+      admin_role_id = Support.Stubs.DB.find_by(:rbac_roles, :name, "Admin").id
+
       assert [
                %{
                  "git_login" => "milica-nerlovic",
                  "subject_id" => ^subject_id,
                  "type" => "USER"
                },
-               %{"subject_id" => "Admin", "type" => "ROLE"}
+               %{"subject_id" => ^admin_role_id, "type" => "ROLE"}
              ] = created_target["subject_rules"]
 
       target = Support.Stubs.DB.find(:deployment_targets, created_target["id"])
@@ -257,7 +259,10 @@ defmodule Router.Deployments.CreateTest do
                  subject_id: subject_id,
                  type: 0
                },
-               %InternalApi.Gofer.DeploymentTargets.SubjectRule{subject_id: "Admin", type: 1}
+               %InternalApi.Gofer.DeploymentTargets.SubjectRule{
+                 subject_id: admin_role_id,
+                 type: 1
+               }
              ] == target.api_model.subject_rules
 
       assert length(target.api_model.object_rules) == 2

--- a/public-api/v1alpha/test/router/deployments/update_test.exs
+++ b/public-api/v1alpha/test/router/deployments/update_test.exs
@@ -466,9 +466,11 @@ defmodule Router.Deployments.UpdateTest do
 
       assert status_code == 200
 
+      admin_role_id = Support.Stubs.DB.find_by(:rbac_roles, :name, "Admin").id
+
       assert [
                %{"git_login" => "milica-nerlovic", "subject_id" => subject_id, "type" => "USER"},
-               %{"subject_id" => "Admin", "type" => "ROLE"}
+               %{"subject_id" => admin_role_id, "type" => "ROLE"}
              ] == updated_target["subject_rules"]
     end
 

--- a/public-api/v2/lib/internal_clients/deployment_targets_client/request_formatter.ex
+++ b/public-api/v2/lib/internal_clients/deployment_targets_client/request_formatter.ex
@@ -298,8 +298,10 @@ defmodule InternalClients.DeploymentTargetsClient.RequestFormatter do
   end
 
   defp role_name_to_role_map(project_scope_roles) do
-    Enum.into(project_scope_roles, %{}, fn role ->
-      {String.downcase(role.name), role.name}
+    Enum.reduce(project_scope_roles, %{}, fn role, acc ->
+      acc
+      |> Map.put(String.downcase(role.name), role.id)
+      |> Map.put(String.downcase(role.id), role.id)
     end)
   end
 

--- a/public-api/v2/lib/public_api/schemas/deployment_targets/deployment_target.ex
+++ b/public-api/v2/lib/public_api/schemas/deployment_targets/deployment_target.ex
@@ -101,11 +101,12 @@ defmodule PublicAPI.Schemas.DeploymentTargets.DeploymentTarget do
                 type: :array,
                 description: "The list of roles of users that are allowed to trigger a deployment,
                  by default project roles are `Reader`, `Contributor` and `Admin`, read more [here](https://docs.semaphoreci.com/security/default-roles/#project-roles).
-                 Role names are case insensitive.",
+                 On input, a role name (case insensitive) or a role id is accepted;
+                 responses contain role ids.",
                 items: %Schema{
-                  example: "Contributor",
+                  example: "b64d2b39-0a2b-4c1e-b190-b7d4a656e30b",
                   type: :string,
-                  description: "The name of the role."
+                  description: "The id of the role. Role names are accepted on input."
                 }
               },
               users: %Schema{

--- a/public-api/v2/test/router/deployment_targets/create_test.exs
+++ b/public-api/v2/test/router/deployment_targets/create_test.exs
@@ -193,7 +193,9 @@ defmodule Router.Deployments.CreateTest do
       {status_code, _, created_target} = create_deployment(ctx, params)
       assert status_code == 200
 
-      assert %{"users" => ["milica-nerlovic"], "roles" => ["Admin"]} =
+      admin_role_id = Support.Stubs.DB.find_by(:rbac_roles, :name, "Admin").id
+
+      assert %{"users" => ["milica-nerlovic"], "roles" => [^admin_role_id]} =
                created_target["spec"]["subject_rules"]
 
       target = Support.Stubs.DB.find(:deployment_targets, created_target["metadata"]["id"])
@@ -205,7 +207,10 @@ defmodule Router.Deployments.CreateTest do
                  subject_id: subject_id,
                  type: :USER
                },
-               %InternalApi.Gofer.DeploymentTargets.SubjectRule{subject_id: "Admin", type: :ROLE}
+               %InternalApi.Gofer.DeploymentTargets.SubjectRule{
+                 subject_id: admin_role_id,
+                 type: :ROLE
+               }
              ] == target.api_model.subject_rules
 
       assert length(target.api_model.object_rules) == 2


### PR DESCRIPTION
Fixes #1140.

## The bug

A `ROLE` subject rule written through the public API stored the role's **name** in `subject_id`:

```elixir
defp role_name_to_role_map(project_scope_roles) do
  Enum.into(project_scope_roles, %{}, fn role ->
    {String.downcase(role.name), role.name}   # value should be role.id
  end)
end
```

Gofer authorizes by comparing `subject_id` against role **ids**:

```elixir
# ee/gofer/lib/gofer/deployment/guardian.ex
defp role_rules_apply?(rules, subject, opts) do
  role_ids = Enum.map(rules, & &1.subject_id)
  case RBAC.check_roles(subject, role_ids, opts) do
```

So the rule matched nobody. The write returned 200, `GET` reported the rule, and every promotion was denied — with no error and nothing on the target to show it was inert.

Present in both v1alpha and v2. The v2 call site already expected an id — it names the map `role_name_to_uuid` and binds `role_id` before building `%API.SubjectRule{type: :ROLE, subject_id: role_id}` — it was simply handed `role.name`.

## The change

`role_name_to_role_map/1` now maps to `role.id`, and since the same map validates the incoming `subject_id`, it also accepts a role id:

```elixir
defp role_name_to_role_map(project_scope_roles) do
  Enum.reduce(project_scope_roles, %{}, fn role, acc ->
    acc
    |> Map.put(String.downcase(role.name), role.id)
    |> Map.put(String.downcase(role.id), role.id)
  end)
end
```

Accepting the id matters for more than symmetry. Rules created in the web UI store a real role uuid; sending one back was rejected as `role "<uuid>" is not valid`. Because `subject_rules` is replaced wholesale on update, a client could not do read-modify-write on such a target at all — the only way to make the request succeed was to downgrade the role rule to a name, which silently destroyed the access it granted. That is how we found this: adding a bookmark parameter to 29 production targets removed Admin deploy access from every one of them, and no response indicated anything had changed.

Role names continue to work exactly as before.

## Tests

Updated the assertions that encoded the old behaviour — they expected `subject_id: "Admin"` — to expect the Admin project role's id, looked up from the stub DB. Added a case asserting a role rule given as an id round-trips unchanged.

- `public-api/v1alpha/test/deployments_client_test.exs`
- `public-api/v1alpha/test/router/deployments/create_test.exs`
- `public-api/v1alpha/test/router/deployments/update_test.exs`
- `public-api/v2/test/router/deployment_targets/create_test.exs`

I don't have an Elixir toolchain set up, so **I have not run the suite locally** — I'd appreciate CI confirming it, and I'm happy to iterate on anything it flags.

## Notes for reviewers

- **No data migration.** Rules already stored as names stay inert until rewritten. A migration in Gofer that resolves stored role names to ids would fix existing installations; I left it out as it seemed a separate call. Happy to add it.
- **v2 response shape.** v2 exposes `spec.subject_rules.roles` as the raw `subject_id` list, so those now read as ids rather than names — the same thing v1alpha already returns for UI-created rules. If you would rather v2 kept presenting names, the tidier variant is to resolve id → name on read and I can do that instead.
- Validation resolves against project-scope roles only. That is unchanged here, and worth knowing: `Contributor` and `Participant` are accepted while `Owner` and `Member` are rejected, which is what confirmed the lookup was real but discarding the id.
