### PR TITLE
fix(front): patch js-yaml and fast-uri CVEs tripping the JS dependency gate

### DIFF
--- a/front/assets/package-lock.json
+++ b/front/assets/package-lock.json
@@ -7668,9 +7668,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/front/assets/package-lock.json
+++ b/front/assets/package-lock.json
@@ -31,7 +31,7 @@
         "domurl": "2.3.0",
         "highlight.js": "^9.16.2",
         "jquery": ">= 3.1",
-        "js-yaml": "^3.15.0",
+        "js-yaml": "^3.15.1",
         "lodash": "4.18.1",
         "markdown-it": "^14.1.0",
         "markdown-it-textual-uml": "^0.17.1",
@@ -3101,10 +3101,21 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -7383,10 +7394,21 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -8964,9 +8986,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -10522,10 +10544,21 @@
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/front/assets/package.json
+++ b/front/assets/package.json
@@ -116,7 +116,7 @@
     "uglify-js-brunch": "2.10.0"
   },
   "overrides": {
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.5",
     "linkify-it": "^5.0.2",
     "lodash-es": "4.18.1",
     "dagre-d3": {

--- a/front/assets/package.json
+++ b/front/assets/package.json
@@ -39,7 +39,7 @@
     "domurl": "2.3.0",
     "highlight.js": "^9.16.2",
     "jquery": ">= 3.1",
-    "js-yaml": "^3.15.0",
+    "js-yaml": "^3.15.1",
     "lodash": "4.18.1",
     "markdown-it": "^14.1.0",
     "markdown-it-textual-uml": "^0.17.1",
@@ -121,6 +121,15 @@
     "lodash-es": "4.18.1",
     "dagre-d3": {
       "d3-color": "3.1.0"
+    },
+    "eslint": {
+      "js-yaml": "^4.3.1"
+    },
+    "@eslint/eslintrc": {
+      "js-yaml": "^4.3.1"
+    },
+    "mocha": {
+      "js-yaml": "^4.3.1"
     }
   }
 }


### PR DESCRIPTION
The JS dependency scan in `Front: Security checks` fails on every run touching `front/` since two advisories landed this week, blocking any front-touching PR:

- **CVE-2026-59870 / GHSA-5p4m-2wfm-xmqj (HIGH)** — js-yaml quadratic CPU consumption in `!!omap` resolution, affecting both the 3.x and 4.x lines. Fixed by bumping the direct dependency 3.15.0 → 3.15.1 and forcing the nested eslint/mocha copies to 4.3.1 via `overrides` (mocha pins js-yaml exactly, so `npm update` cannot move it).
- **CVE-2026-18446 (HIGH)** — fast-uri host confusion via backslash in URI authority. Override bumped to 3.1.5 (cherry-picked from the closed semaphoreio/semaphore#1143).

Lockfile regenerated with `npm install --package-lock-only`; the only version changes are the four js-yaml copies and fast-uri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)