### PR TITLE
fix(zebra): compare DateTimes with DateTime.compare in model tests

### DIFF
--- a/zebra/test/zebra/models/job_stop_request_test.exs
+++ b/zebra/test/zebra/models/job_stop_request_test.exs
@@ -84,7 +84,7 @@ defmodule Zebra.Models.JobStopRequestTest do
 
       new_updated_at = req.updated_at
 
-      assert old_updated_at < new_updated_at
+      assert DateTime.compare(old_updated_at, new_updated_at) == :lt
     end
 
     test "it updates the fields" do

--- a/zebra/test/zebra/models/job_test.exs
+++ b/zebra/test/zebra/models/job_test.exs
@@ -160,7 +160,7 @@ defmodule Zebra.Models.JobTest do
 
       new_updated_at = job.updated_at
 
-      assert old_updated_at < new_updated_at
+      assert DateTime.compare(old_updated_at, new_updated_at) == :lt
     end
 
     test "it updates the fields" do

--- a/zebra/test/zebra/models/task_test.exs
+++ b/zebra/test/zebra/models/task_test.exs
@@ -26,7 +26,7 @@ defmodule Zebra.Models.TaskTest do
 
       new_updated_at = task.updated_at
 
-      assert old_updated_at < new_updated_at
+      assert DateTime.compare(old_updated_at, new_updated_at) == :lt
     end
 
     test "it updates the fields" do


### PR DESCRIPTION
`Zebra: QA` fails deterministically on main since August 1: `Zebra.Models.JobTest "it updates updated_at"` asserts `old_updated_at < new_updated_at` on DateTime **structs**, which uses Erlang term ordering — it compares the `day` field before month and year. The test factory pins timestamps at compile time (`@timestamp`), so a cached build from late July yields day 29 vs day 7 after the month rollover and the assertion inverts.

Replaces the raw `<` with `DateTime.compare(...) == :lt` at all three sites of the pattern (`job_test`, `job_stop_request_test`, `task_test`). All three fields are `:utc_datetime`, so `DateTime.compare/2` is the correct comparison.

This unblocks every PR touching `zebra/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)