### PR TITLE
fix(github_notifier): report stopped/canceled pipelines as error, not failure

### DIFF
--- a/github_notifier/lib/github_notifier/status.ex
+++ b/github_notifier/lib/github_notifier/status.ex
@@ -79,4 +79,5 @@ defmodule GithubNotifier.Status do
   defp map_status("success"), do: :SUCCESS
   defp map_status("pending"), do: :PENDING
   defp map_status("failure"), do: :FAILURE
+  defp map_status("stopped"), do: :STOPPED
 end

--- a/github_notifier/lib/github_notifier/utils/state.ex
+++ b/github_notifier/lib/github_notifier/utils/state.ex
@@ -11,68 +11,45 @@ defmodule GithubNotifier.Utils.State do
   @message_build_canceled "The build was canceled on Semaphore 2.0."
   @message_build_pending "The build is pending on Semaphore 2.0."
 
-  def extract(pipeline) do
-    case pipeline.result do
-      :PASSED ->
-        case pipeline.state do
-          :DONE -> {@success, @message_build_passed}
-          _ -> {@pending, @message_build_pending}
-        end
+  def extract(%{state: :DONE} = pipeline), do: verdict(pipeline.result)
+  def extract(_pipeline), do: {@pending, @message_build_pending}
 
-      # A stopped/canceled pipeline never reached a verdict, so it reports as
-      # :STOPPED rather than a failure — an interrupted build is not a failed one.
-      result when result in [:STOPPED, :CANCELED] ->
-        case pipeline.state do
-          :DONE -> {@stopped, @message_build_canceled}
-          _ -> {@pending, @message_build_pending}
-        end
+  def extract_with_summary(%{state: :DONE} = pipeline, pipeline_summary),
+    do: verdict(pipeline.result, pipeline_summary)
 
-      _ ->
-        case pipeline.state do
-          :DONE -> {@failure, @message_build_failed}
-          _ -> {@pending, @message_build_pending}
-        end
-    end
+  def extract_with_summary(_pipeline, _pipeline_summary),
+    do: {@pending, @message_build_pending}
+
+  defp verdict(:PASSED), do: {@success, @message_build_passed}
+
+  # A stopped/canceled pipeline never reached a verdict, so it reports as
+  # :STOPPED rather than a failure — an interrupted build is not a failed one.
+  defp verdict(result) when result in [:STOPPED, :CANCELED],
+    do: {@stopped, @message_build_canceled}
+
+  defp verdict(_), do: {@failure, @message_build_failed}
+
+  defp verdict(:PASSED, summary) do
+    message =
+      if summary.passed > 0,
+        do: "#{pluralize(summary.passed, "test")} passed.",
+        else: @message_build_passed
+
+    {@success, message}
   end
 
-  def extract_with_summary(pipeline, pipeline_summary) do
-    case pipeline.result do
-      :PASSED ->
-        case pipeline.state do
-          :DONE ->
-            message =
-              if pipeline_summary.passed > 0,
-                do: "#{pluralize(pipeline_summary.passed, "test")} passed.",
-                else: @message_build_passed
+  defp verdict(result, _summary) when result in [:STOPPED, :CANCELED],
+    do: {@stopped, @message_build_canceled}
 
-            {@success, message}
+  defp verdict(_, summary) do
+    failures = summary.failed + summary.error
 
-          _ ->
-            {@pending, @message_build_pending}
-        end
+    message =
+      if failures > 0,
+        do: "#{pluralize(failures, "test")} failed.",
+        else: @message_build_failed
 
-      result when result in [:STOPPED, :CANCELED] ->
-        case pipeline.state do
-          :DONE -> {@stopped, @message_build_canceled}
-          _ -> {@pending, @message_build_pending}
-        end
-
-      _ ->
-        case pipeline.state do
-          :DONE ->
-            failures = pipeline_summary.failed + pipeline_summary.error
-
-            message =
-              if failures > 0,
-                do: "#{pluralize(failures, "test")} failed.",
-                else: @message_build_failed
-
-            {@failure, message}
-
-          _ ->
-            {@pending, @message_build_pending}
-        end
-    end
+    {@failure, message}
   end
 
   defp pluralize(count, fragment) do

--- a/github_notifier/lib/github_notifier/utils/state.ex
+++ b/github_notifier/lib/github_notifier/utils/state.ex
@@ -3,10 +3,12 @@ defmodule GithubNotifier.Utils.State do
 
   @success "success"
   @failure "failure"
+  @stopped "stopped"
   @pending "pending"
 
   @message_build_passed "The build passed on Semaphore 2.0."
   @message_build_failed "The build failed on Semaphore 2.0."
+  @message_build_canceled "The build was canceled on Semaphore 2.0."
   @message_build_pending "The build is pending on Semaphore 2.0."
 
   def extract(pipeline) do
@@ -14,6 +16,14 @@ defmodule GithubNotifier.Utils.State do
       :PASSED ->
         case pipeline.state do
           :DONE -> {@success, @message_build_passed}
+          _ -> {@pending, @message_build_pending}
+        end
+
+      # A stopped/canceled pipeline never reached a verdict, so it reports as
+      # :STOPPED rather than a failure — an interrupted build is not a failed one.
+      result when result in [:STOPPED, :CANCELED] ->
+        case pipeline.state do
+          :DONE -> {@stopped, @message_build_canceled}
           _ -> {@pending, @message_build_pending}
         end
 
@@ -39,6 +49,12 @@ defmodule GithubNotifier.Utils.State do
 
           _ ->
             {@pending, @message_build_pending}
+        end
+
+      result when result in [:STOPPED, :CANCELED] ->
+        case pipeline.state do
+          :DONE -> {@stopped, @message_build_canceled}
+          _ -> {@pending, @message_build_pending}
         end
 
       _ ->

--- a/github_notifier/test/github_notifier/utils/state_test.exs
+++ b/github_notifier/test/github_notifier/utils/state_test.exs
@@ -152,6 +152,23 @@ defmodule GithubNotifier.Utils.State.Test do
     assert State.extract(pipeline) == {"pending", "The build is pending on Semaphore 2.0."}
   end
 
+  test "when pipeline is running => return pending regardless of test summary" do
+    pipeline =
+      struct(Pipeline,
+        state: :RUNNING,
+        result: :PASSED
+      )
+
+    pipeline_summary =
+      struct(Summary,
+        total: 100,
+        passed: 100
+      )
+
+    assert State.extract_with_summary(pipeline, pipeline_summary) ==
+             {"pending", "The build is pending on Semaphore 2.0."}
+  end
+
   test "when pipeline canceled => return stopped regardless of test summary" do
     pipeline =
       struct(Pipeline,

--- a/github_notifier/test/github_notifier/utils/state_test.exs
+++ b/github_notifier/test/github_notifier/utils/state_test.exs
@@ -111,4 +111,63 @@ defmodule GithubNotifier.Utils.State.Test do
     assert State.extract_with_summary(pipeline, pipeline_summary) ==
              {"failure", "The build failed on Semaphore 2.0."}
   end
+
+  test "when block stopped => return stopped, not failure" do
+    block =
+      struct(Block,
+        state: :DONE,
+        result: :STOPPED
+      )
+
+    assert State.extract(block) == {"stopped", "The build was canceled on Semaphore 2.0."}
+  end
+
+  test "when pipeline canceled => return stopped, not failure" do
+    pipeline =
+      struct(Pipeline,
+        state: :DONE,
+        result: :CANCELED
+      )
+
+    assert State.extract(pipeline) == {"stopped", "The build was canceled on Semaphore 2.0."}
+  end
+
+  test "when pipeline stopped => return stopped, not failure" do
+    pipeline =
+      struct(Pipeline,
+        state: :DONE,
+        result: :STOPPED
+      )
+
+    assert State.extract(pipeline) == {"stopped", "The build was canceled on Semaphore 2.0."}
+  end
+
+  test "when pipeline canceled but not yet done => return pending" do
+    pipeline =
+      struct(Pipeline,
+        state: :STOPPING,
+        result: :CANCELED
+      )
+
+    assert State.extract(pipeline) == {"pending", "The build is pending on Semaphore 2.0."}
+  end
+
+  test "when pipeline canceled => return stopped regardless of test summary" do
+    pipeline =
+      struct(Pipeline,
+        state: :DONE,
+        result: :CANCELED
+      )
+
+    pipeline_summary =
+      struct(Summary,
+        total: 100,
+        passed: 50,
+        failed: 30,
+        error: 20
+      )
+
+    assert State.extract_with_summary(pipeline, pipeline_summary) ==
+             {"stopped", "The build was canceled on Semaphore 2.0."}
+  end
 end


### PR DESCRIPTION
## What

`GithubNotifier.Utils.State` maps every non-`PASSED`, `DONE` pipeline/block to
the GitHub `failure` commit-status state ("The build failed on Semaphore 2.0."),
including ones whose result is `STOPPED` or `CANCELED`.

This routes `STOPPED`/`CANCELED` (state `DONE`) results to the existing
`:STOPPED` build status instead: `State.extract` / `extract_with_summary` emit a
`"stopped"` token, `Status.map_status/1` translates it to
`InternalApi.Repository.CreateBuildStatusRequest.Status` `:STOPPED`, and
`repository_hub` already surfaces `:STOPPED` to GitHub as the `error`
commit-status state (with the "The build was canceled on Semaphore 2.0."
description). `PASSED`/`FAILED` are unchanged.

## Why

A canceled or stopped pipeline never reached a verdict, so reporting it as a
build `failure` is inaccurate — it wasn't a failed build, it was interrupted.
GitHub's `error` commit-status state (which `:STOPPED` already maps to) reflects
that far better, and — unlike simply skipping the notification — it avoids
leaving a stale `pending` status behind.

The delivery path for `:STOPPED` already exists end-to-end: the
`CreateBuildStatusRequest.Status` proto has a `STOPPED` value, and the GitHub,
GitLab, and Bitbucket adapters in `repository_hub` all already accept `:STOPPED`
and translate it for their provider. The notifier was the one layer that never
emitted it, so this is a small, self-contained change on the producing side.

## Scope

Single change in `github_notifier` (`state.ex` + `status.ex`); no proto or
`repository_hub` changes — those already support `:STOPPED`.

The diff is larger than the behavioral change itself: adding the
`STOPPED`/`CANCELED` branch pushed `extract/1` and `extract_with_summary/2` past
Credo's cyclomatic-complexity limit (9). A separate, behavior-preserving commit
therefore flattens the nested `result`/`state` cases into a `%{state: :DONE}`
function-head guard plus small `verdict/1` and `verdict/2` clauses, bringing the
complexity back under the limit. That commit changes structure only — the
`{state, message}` outputs are identical for every input.

## Testing

Added `state_test.exs` cases covering `STOPPED`/`CANCELED` for both `extract/1`
and `extract_with_summary/2` (including the `extract_with_summary` short-circuit
that ignores the test summary for a canceled build), plus a not-yet-`DONE`
(`STOPPING`) case that must stay `pending`. Verified the module compiles and
exercised `extract` / `extract_with_summary` against these cases. (Full
`mix test` relies on CI — deps are not fetched in the local offline
environment.)
