### PR TITLE
feat(zebra): add macOS Xcode 16 brownout schedule

### DIFF
--- a/zebra/lib/zebra/machines/brownout.ex
+++ b/zebra/lib/zebra/machines/brownout.ex
@@ -18,7 +18,7 @@ defmodule Zebra.Machines.Brownout do
   """
   @spec schedules() :: brownout_schedules()
   def schedules do
-    BrownoutSchedule.macosxcode15()
+    BrownoutSchedule.macosxcode16()
   end
 
   @doc """

--- a/zebra/lib/zebra/machines/brownout_schedule.ex
+++ b/zebra/lib/zebra/machines/brownout_schedule.ex
@@ -149,6 +149,63 @@ defmodule Zebra.Machines.BrownoutSchedule do
     first_phase ++ second_phase ++ third_phase
   end
 
+  @spec macosxcode16 :: Brownout.brownout_schedules()
+  def macosxcode16 do
+    first_phase =
+      phase(
+        Date.range(~D[2026-09-07], ~D[2026-09-13]),
+        [
+          {~T[10:00:00], ~T[10:15:00]},
+          {~T[13:00:00], ~T[13:15:00]},
+          {~T[16:00:00], ~T[16:15:00]},
+          {~T[19:00:00], ~T[19:15:00]},
+          {~T[22:00:00], ~T[22:15:00]}
+        ],
+        ["macos-xcode16"]
+      )
+
+    second_phase =
+      phase(
+        Date.range(~D[2026-09-14], ~D[2026-09-20]),
+        [
+          {~T[10:00:00], ~T[10:30:00]},
+          {~T[13:00:00], ~T[13:30:00]},
+          {~T[16:00:00], ~T[16:30:00]},
+          {~T[19:00:00], ~T[19:30:00]},
+          {~T[22:00:00], ~T[22:30:00]}
+        ],
+        ["macos-xcode16"]
+      )
+
+    third_phase =
+      phase(
+        Date.range(~D[2026-09-21], ~D[2026-09-27]),
+        [
+          {~T[10:00:00], ~T[11:00:00]},
+          {~T[13:00:00], ~T[14:00:00]},
+          {~T[16:00:00], ~T[17:00:00]},
+          {~T[19:00:00], ~T[20:00:00]},
+          {~T[22:00:00], ~T[23:00:00]}
+        ],
+        ["macos-xcode16"]
+      )
+
+    fourth_phase =
+      phase(
+        Date.range(~D[2026-09-28], ~D[2026-10-04]),
+        [
+          {~T[10:00:00], ~T[12:00:00]},
+          {~T[13:00:00], ~T[15:00:00]},
+          {~T[16:00:00], ~T[18:00:00]},
+          {~T[19:00:00], ~T[21:00:00]},
+          {~T[22:00:00], ~T[00:00:00]}
+        ],
+        ["macos-xcode16"]
+      )
+
+    first_phase ++ second_phase ++ third_phase ++ fourth_phase
+  end
+
   @doc """
   Creates a brownout schedule for a given date and time range.
   """

--- a/zebra/test/zebra/machines/brownout_schedule_test.exs
+++ b/zebra/test/zebra/machines/brownout_schedule_test.exs
@@ -69,6 +69,28 @@ defmodule Zebra.Machines.BrownoutScheduleTest do
            }
   end
 
+  test "creates macos-xcode16 brownout schedule" do
+    schedule = BrownoutSchedule.macosxcode16()
+
+    assert length(schedule) == 140
+
+    [first_event | _] = schedule
+
+    assert first_event == %{
+             from: ~U[2026-09-07 10:00:00Z],
+             os_images: ["macos-xcode16"],
+             to: ~U[2026-09-07 10:15:00Z]
+           }
+
+    [last_event | _] = schedule |> Enum.reverse()
+
+    assert last_event == %{
+             from: ~U[2026-10-04 22:00:00Z],
+             os_images: ["macos-xcode16"],
+             to: ~U[2026-10-05 00:00:00Z]
+           }
+  end
+
   describe "creating phases" do
     test "work as expected" do
       phase =

--- a/zebra/test/zebra/machines/brownout_test.exs
+++ b/zebra/test/zebra/machines/brownout_test.exs
@@ -90,15 +90,27 @@ defmodule Zebra.Machines.BrownoutTest do
   end
 
   describe "applying brownout on default schedules" do
-    test "works for macos-xcode15" do
+    test "works for macos-xcode16" do
       assert Brownout.os_image_in_brownout?(
-               ~U[2026-06-15 10:10:00Z],
+               ~U[2026-09-07 10:10:00Z],
                "regular-org",
-               "macos-xcode15"
+               "macos-xcode16"
              ) == true
 
       assert Brownout.os_image_in_brownout?(
-               ~U[2026-06-15 10:15:01Z],
+               ~U[2026-09-07 10:15:01Z],
+               "regular-org",
+               "macos-xcode16"
+             ) == false
+
+      assert Brownout.os_image_in_brownout?(
+               ~U[2026-10-04 23:30:00Z],
+               "regular-org",
+               "macos-xcode16"
+             ) == true
+
+      assert Brownout.os_image_in_brownout?(
+               ~U[2026-09-07 10:10:00Z],
                "regular-org",
                "macos-xcode15"
              ) == false


### PR DESCRIPTION
## 📝 Description

Adds the macOS Xcode 16 brownout schedule, as agreed in the deprecation kick-off.

Four weekly phases, Sep 7 – Oct 4 2026, five slots per day at 10:00 / 13:00 / 16:00 / 19:00 / 22:00 UTC with escalating duration:

| Week | Jobs using `macos-xcode16` will not start for |
| --- | --- |
| Sep 7–13 | 15 minutes |
| Sep 14–20 | 30 minutes |
| Sep 21–27 | 1 hour |
| Sep 28 – Oct 4 | 2 hours |

140 events in total. The final slot of the last phase runs 22:00–00:00, which `phase/3` rolls over to the following day, so the schedule ends at `2026-10-05 00:00Z`.

`Brownout.schedules/0` now returns the `macos-xcode16` schedule. The `macos-xcode15` window closed on 2026-07-05, so nothing active is dropped; `macosxcode15/0` is retained alongside the earlier `ubuntu2004` and `macos-xcode14` schedules.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
