### PR TITLE
Name the rerun controls after what they rerun

### DIFF
--- a/docs/docs/using-semaphore/pipelines.md
+++ b/docs/docs/using-semaphore/pipelines.md
@@ -148,14 +148,14 @@ Here you can see the how spc evaluated the pipeline and all the actions taken du
 
 When a job in the pipeline fails, the default behavior is to stop the pipeline. You can attempt to re-run the pipeline in two ways:
 
-- Pressing **Rerun** restarts the whole pipeline from the beginning
-- Pressing **Rebuild Pipeline** only re-runs the blocks with failed jobs
+- Pressing **Rerun Workflow** starts a fresh run of the whole workflow from the same commit
+- Pressing **Rerun Failed Jobs** re-runs only what did not pass in that pipeline, keeping the jobs that did — the granularity (failed jobs or their whole blocks) follows the pipeline's rerun settings
 
 ![Location of rerun and rebuild buttons](./img/rerun-pipeline.jpg)
 
 ### Job-level partial rerun {#job-level-rerun}
 
-When the job-level partial rerun feature is enabled for your organization, **Rebuild Pipeline** goes one step further inside each re-run block: jobs that already passed are *reused* instead of being executed again, and only the failed jobs actually re-run.
+When the job-level partial rerun feature is enabled for your organization, **Rerun Failed Jobs** goes one step further inside each re-run block: jobs that already passed are *reused* instead of being executed again, and only the failed jobs actually re-run.
 
 Enabling the feature changes the default rebuild behavior. To keep re-running whole blocks — for the entire pipeline or for individual blocks — set the [`partial_rerun: block`](../reference/pipeline-yaml#partial-rerun) property in the pipeline YAML. Any other value is rejected when the pipeline YAML is validated.
 

--- a/front/assets/js/workflow_editor/templates/configurator/block.js
+++ b/front/assets/js/workflow_editor/templates/configurator/block.js
@@ -239,13 +239,13 @@ export class BlockConfigTemplate {
     if(unknown) status = "Unrecognized"
 
     let options = {
-      title: "Rebuild granularity",
+      title: "Rerun granularity",
       status: status,
       collapsable: true
     }
 
     return Section.section(options, `
-      <p class="f5 gray mb2">What <b>Rebuild Pipeline</b> re-runs in this block</p>
+      <p class="f5 gray mb2">What <b>Rerun Failed Jobs</b> re-runs in this block</p>
 
       <select data-action=selectBlockPartialRerun class="form-control form-control-small w-100">
         ${unknown ? `<option value="${escapeHtml(selected)}" selected>${escapeHtml(selected)} — not a valid value</option>` : ""}

--- a/front/assets/js/workflow_editor/templates/configurator/pipeline.js
+++ b/front/assets/js/workflow_editor/templates/configurator/pipeline.js
@@ -110,7 +110,7 @@ export class PipelineConfigTempate {
     if(unknown) status = "Unrecognized"
 
     let options = {
-      title: "Rebuild granularity",
+      title: "Rerun granularity",
       status: status,
       collapsable: true
     }
@@ -119,7 +119,7 @@ export class PipelineConfigTempate {
       `<option value="${escapeHtml(value)}" selected>${escapeHtml(value)} — not a valid value</option>` : ""
 
     return Section.section(options, `
-      <p class="f5 gray mb2">What <b>Rebuild Pipeline</b> re-runs after a failure</p>
+      <p class="f5 gray mb2">What <b>Rerun Failed Jobs</b> re-runs after a failure</p>
 
       <select data-action=selectPipelinePartialRerun class="form-control form-control-small w-100">
         ${unknownOption}

--- a/front/assets/js/workflow_view/interactive_pipeline_tree.js
+++ b/front/assets/js/workflow_view/interactive_pipeline_tree.js
@@ -47,7 +47,7 @@ export var InteractivePipelineTree = {
       event.preventDefault();
       let button = $(event.currentTarget);
       let href = button.attr("href");
-      button.text("Rebuilding...")
+      button.text("Rerunning...")
       button.attr("disabled", true);
 
       let req = $.ajax({
@@ -61,7 +61,7 @@ export var InteractivePipelineTree = {
       req.done(function(data) {
         if(data.error != undefined) {
           Notice.error(data.error)
-          button.text("Rebuild Pipeline")
+          button.text("Rerun Failed Jobs")
           button.attr("disabled", false);
         } else {
           Notice.notice(data.message)

--- a/front/lib/front_web/templates/layout/job.html.eex
+++ b/front/lib/front_web/templates/layout/job.html.eex
@@ -58,9 +58,9 @@
     </div>
     <div class="flex">
       <%= if !assigns[:permissions] or @permissions["project.job.rerun"] do %>
-        <%= link "Rerun", to: workflow_path(@conn, :rebuild, @workflow.id), method: :post, class: "btn btn-secondary ml1", "data-tippy-content": "Rerun the parent workflow, including this job" %>
+        <%= link "Rerun Workflow", to: workflow_path(@conn, :rebuild, @workflow.id), method: :post, class: "btn btn-secondary ml1", "data-tippy-content": "Starts a fresh run of the whole workflow, including this job" %>
       <% else %>
-        <button class="btn btn-secondary" disabled>Rerun</button>
+        <button class="btn btn-secondary" disabled>Rerun Workflow</button>
       <% end %>
       <div class="ml2 pl2 bl b--lighter-gray">
       <%= link to: "/workflows/#{@workflow.id}/edit" do %>

--- a/front/lib/front_web/templates/layout/workflow.html.eex
+++ b/front/lib/front_web/templates/layout/workflow.html.eex
@@ -62,9 +62,9 @@
       </h1>
       <div class="flex-shrink-0 pt1 pt0-m">
       <%= if !assigns[:permissions] or @permissions["project.job.rerun"] do %>
-          <%= link "Rerun", to: workflow_path(@conn, :rebuild, @workflow.id), method: :post, class: "btn btn-secondary" %>
+          <%= link "Rerun Workflow", to: workflow_path(@conn, :rebuild, @workflow.id), method: :post, class: "btn btn-secondary", "data-tippy-content": "Starts a fresh run of the whole workflow from this commit" %>
         <% else %>
-          <button class="btn btn-secondary" disabled>Rerun</button>
+          <button class="btn btn-secondary" disabled>Rerun Workflow</button>
         <% end %>
       </div>
     </div>

--- a/front/lib/front_web/templates/workflow/status/_interactive_pipeline.html.eex
+++ b/front/lib/front_web/templates/workflow/status/_interactive_pipeline.html.eex
@@ -23,7 +23,7 @@
     <% end %>
     <%= if FeatureProvider.feature_enabled?(:ui_partial_ppl_rebuild, param: @conn.assigns[:organization_id]) && @conn.assigns.permissions["project.job.rerun"] && FrontWeb.PipelineView.pipeline_rebuildable?(@pipeline) && !FrontWeb.PipelineView.anonymous?(@conn) do %>
       <span class="gray mh2">&middot;</span>
-      <%= link "Rebuild Pipeline", to: pipeline_rebuild_path(@conn, :rebuild, @workflow.id, @pipeline.id), class: "btn btn-secondary btn-tiny", pipeline_rebuild_button: "true", title: "Rerun only failed jobs in this pipeline" %>
+      <%= link "Rerun Failed Jobs", to: pipeline_rebuild_path(@conn, :rebuild, @workflow.id, @pipeline.id), class: "btn btn-secondary btn-small", pipeline_rebuild_button: "true", title: "Reruns only the jobs in this pipeline that did not pass, keeping the ones that did. Use Rerun Workflow above for a fresh run of everything." %>
     <% end %>
     <span class="child ml2">←</span>
   </div>

--- a/front/lib/front_web/templates/workflow/status/_interactive_pipeline.html.eex
+++ b/front/lib/front_web/templates/workflow/status/_interactive_pipeline.html.eex
@@ -23,7 +23,7 @@
     <% end %>
     <%= if FeatureProvider.feature_enabled?(:ui_partial_ppl_rebuild, param: @conn.assigns[:organization_id]) && @conn.assigns.permissions["project.job.rerun"] && FrontWeb.PipelineView.pipeline_rebuildable?(@pipeline) && !FrontWeb.PipelineView.anonymous?(@conn) do %>
       <span class="gray mh2">&middot;</span>
-      <%= link "Rerun Failed Jobs", to: pipeline_rebuild_path(@conn, :rebuild, @workflow.id, @pipeline.id), class: "btn btn-secondary btn-small", pipeline_rebuild_button: "true", title: "Reruns only the jobs in this pipeline that did not pass, keeping the ones that did. Use Rerun Workflow above for a fresh run of everything." %>
+      <%= link "Rerun Failed Jobs", to: pipeline_rebuild_path(@conn, :rebuild, @workflow.id, @pipeline.id), class: "btn btn-secondary btn-tiny", pipeline_rebuild_button: "true", "data-tippy-content": "Reruns only the jobs in this pipeline that did not pass, keeping the ones that did. Use Rerun Workflow above for a fresh run of everything." %>
     <% end %>
     <span class="child ml2">←</span>
   </div>


### PR DESCRIPTION
## What

The two rerun controls on the workflow page describe themselves in ways that invert their actual scope. The header button reads **Rerun** but starts a completely new workflow from the same commit. The button on a failed pipeline row reads **Rebuild Pipeline** but is the narrow one — it re-runs only what did not pass inside that single pipeline. Reading the labels, "Rebuild Pipeline" is the one that sounds like a full restart, so people reach for whichever button is nearest and get the scope they did not want. That is the confusion reported in semaphoreio/semaphore#686.

This renames both controls after what they rerun and makes the difference legible without a click:

- Header: `Rerun` → **Rerun Workflow**, tooltip "Starts a fresh run of the whole workflow from this commit". Same on the job page header, where the tooltip also keeps the "including this job" note.
- Pipeline row: `Rebuild Pipeline` → **Rerun Failed Jobs**, tooltip "Reruns only the jobs in this pipeline that did not pass, keeping the ones that did. Use Rerun Workflow above for a fresh run of everything."

That row tooltip previously existed as a plain `title` attribute and did not surface in the tree. It now uses `data-tippy-content`, the mechanism the rest of the app uses: `app.js` binds those on page load, and Pollman already destroys and rebinds tooltips around each partial refresh, so the tooltip survives the tree's polling. Button sizes are unchanged — the row keeps `btn-tiny`, matching `Stop Pipeline` next to it.

Follow-through so the rename does not leave stale copy behind: the tree JS in-flight label (`Rebuilding...` → `Rerunning...`) and its error-restore label, the workflow editor's rerun-granularity section (which named the button in its explanatory line), and the docs passage describing both buttons — that passage additionally claimed the header button "restarts the whole pipeline from the beginning", which is wrong; it restarts the workflow.

Routes, permissions, feature gating and behaviour are untouched. The row button still renders only behind `ui_partial_ppl_rebuild`, so organizations without that feature see a single unambiguous **Rerun Workflow**.

## Scope

This is a deliberate low-effort interim step: it fixes the vocabulary, not the layout. The larger piece of work — collapsing both controls into one pipeline-scoped `Rerun` menu that enumerates the pipelines with failures — is being explored separately (semaphoreio/semaphore#1178 carries the playground it is designed in). The vocabulary picked here is the vocabulary that design lands on, so this rename is not thrown away when the menu ships.

## Verification

Copy-only change; no spec asserts any of the renamed strings. The guest-path assertion in `workflow_controller_test.exs` that refutes the presence of a rerun button is unaffected — anonymous and guest viewers render `workflow/_workflow.html.eex`, which has no rerun control at all. Relying on CI for compile, format, lint and the front suites.

## Left for a follow-up

`docs/docs/using-semaphore/pipelines.md` embeds `img/rerun-pipeline.jpg`, a screenshot showing the old labels. It needs to be retaken once this is deployed. The versioned CE/EE docs are intentionally not touched — released versions still ship the old labels.

`Stop Pipeline`, in the same row, still has no tooltip at all.
