### PR TITLE
fix(zebra): use repository default branch instead of hardcoded master

### DIFF
--- a/zebra/lib/zebra/workers/job_request_factory/repository.ex
+++ b/zebra/lib/zebra/workers/job_request_factory/repository.ex
@@ -31,9 +31,12 @@ defmodule Zebra.Workers.JobRequestFactory.Repository do
       name: repository.name,
       url: repository.url,
       provider: repository.provider,
-      default_branch: "master"
+      default_branch: default_branch(repository.default_branch)
     }
   end
+
+  defp default_branch(branch) when branch in [nil, ""], do: "master"
+  defp default_branch(branch), do: branch
 
   def files(nil), do: {:ok, []}
 

--- a/zebra/test/zebra/apis/public_job_api_test.exs
+++ b/zebra/test/zebra/apis/public_job_api_test.exs
@@ -67,18 +67,7 @@ defmodule Zebra.Api.PublicJobApiTest do
       )
     end)
 
-    GrpcMock.stub(Support.FakeServers.RepositoryApi, :describe, fn _, _ ->
-      key = "--BEGIN....lalalala..private_key...END---"
-
-      repository =
-        InternalApi.Repository.Repository.new(
-          name: "test-repo",
-          url: "git@github.com:/test-org/test-repo.git",
-          provider: "github"
-        )
-
-      InternalApi.Repository.DescribeResponse.new(repository: repository, private_ssh_key: key)
-    end)
+    mock_repository("master")
 
     stub(Support.MockedProvider, :provide_features, fn org_id, opts ->
       {:ok, features} = Support.StubbedProvider.provide_features(org_id, opts)
@@ -521,6 +510,32 @@ defmodule Zebra.Api.PublicJobApiTest do
       get_job_debug_ssh_key_passes_permission_check(task.id)
     end
 
+    test "when the repository default branch is main and attach on default branch is allowed => gets the key" do
+      alias InternalApi.Projecthub.Project.Spec.PermissionType
+
+      mock_repository("main")
+      mock_repo_proxy(:BRANCH, "main", "test-org/test-repo", "")
+      mock_project([], [PermissionType.value(:DEFAULT_BRANCH)])
+
+      {:ok, task} = Support.Factories.Task.create()
+      get_job_debug_ssh_key_passes_permission_check(task.id)
+    end
+
+    test "when the repository default branch is main and attach on default branch is blocked => raise error" do
+      alias InternalApi.Projecthub.Project.Spec.PermissionType
+
+      mock_repository("main")
+      mock_repo_proxy(:BRANCH, "main", "test-org/test-repo", "")
+      mock_project([], [PermissionType.value(:NON_DEFAULT_BRANCH)])
+
+      {:ok, task} = Support.Factories.Task.create()
+
+      get_job_debug_ssh_key_fails_permission_check(
+        "You are not allowed to attach jobs on the default branch of this project",
+        task.id
+      )
+    end
+
     test "when the project belongs to restricted org and blocks attach on non default branch => raise error" do
       mock_repo_proxy(:BRANCH, "some-non-default-branch", "test-org/test-repo", "")
       mock_project([], [])
@@ -939,6 +954,27 @@ defmodule Zebra.Api.PublicJobApiTest do
       mock_repo_proxy(:BRANCH, "master", "test-org/test-repo", "")
       mock_project([PermissionType.value(:DEFAULT_BRANCH)], [])
       create_debug_job_passes_permission_check()
+    end
+
+    test "when the repository default branch is main and debug on default branch is allowed => creates job" do
+      alias InternalApi.Projecthub.Project.Spec.PermissionType
+
+      mock_repository("main")
+      mock_repo_proxy(:BRANCH, "main", "test-org/test-repo", "")
+      mock_project([PermissionType.value(:DEFAULT_BRANCH)], [])
+      create_debug_job_passes_permission_check()
+    end
+
+    test "when the repository default branch is main and debug on default branch is blocked => raise error" do
+      alias InternalApi.Projecthub.Project.Spec.PermissionType
+
+      mock_repository("main")
+      mock_repo_proxy(:BRANCH, "main", "test-org/test-repo", "")
+      mock_project([PermissionType.value(:NON_DEFAULT_BRANCH)], [])
+
+      create_debug_job_fails_permission_check(
+        "You are not allowed to debug jobs on the default branch of this project"
+      )
     end
 
     test "when the project belongs to restricted org and blocks debug on non default branch => raise error" do
@@ -1444,6 +1480,22 @@ defmodule Zebra.Api.PublicJobApiTest do
   end
 
   # Utility functions
+  def mock_repository(default_branch) do
+    GrpcMock.stub(Support.FakeServers.RepositoryApi, :describe, fn _, _ ->
+      key = "--BEGIN....lalalala..private_key...END---"
+
+      repository =
+        InternalApi.Repository.Repository.new(
+          name: "test-repo",
+          url: "git@github.com:/test-org/test-repo.git",
+          provider: "github",
+          default_branch: default_branch
+        )
+
+      InternalApi.Repository.DescribeResponse.new(repository: repository, private_ssh_key: key)
+    end)
+  end
+
   def mock_repo_proxy(hook_type, branch_name, repo_slug, pr_slug) do
     GrpcMock.stub(Support.FakeServers.RepoProxyApi, :describe, fn _, _ ->
       status = InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK))

--- a/zebra/test/zebra/workers/job_request_factory/repository_test.exs
+++ b/zebra/test/zebra/workers/job_request_factory/repository_test.exs
@@ -26,17 +26,7 @@ defmodule Zebra.Workers.JobRequestFactory.RepositoryTest do
 
   describe ".find" do
     test "uses repository api" do
-      GrpcMock.stub(Support.FakeServers.RepositoryApi, :describe, fn _, _ ->
-        InternalApi.Repository.DescribeResponse.new(
-          repository:
-            InternalApi.Repository.Repository.new(
-              name: "zebra2",
-              url: "git@bitbucket.org:test-org/test-repo.git",
-              provider: "github"
-            ),
-          private_ssh_key: @private_ssh_key
-        )
-      end)
+      stub_describe(default_branch: "main")
 
       repository =
         {:ok,
@@ -44,10 +34,16 @@ defmodule Zebra.Workers.JobRequestFactory.RepositoryTest do
            name: "zebra2",
            url: "git@bitbucket.org:test-org/test-repo.git",
            provider: "github",
-           default_branch: "master"
+           default_branch: "main"
          }, "--BEGIN....lalalala..private_key...END---"}
 
       assert repository == Repository.find(@project.spec.repository.id)
+    end
+
+    test "falls back to master when the default branch is empty" do
+      stub_describe(default_branch: "")
+
+      assert {:ok, %{default_branch: "master"}, _} = Repository.find(@project.spec.repository.id)
     end
   end
 
@@ -85,6 +81,16 @@ defmodule Zebra.Workers.JobRequestFactory.RepositoryTest do
                  "value" => Base.encode64("HEAD")
                }
              ]
+    end
+
+    test "when there is no repo_proxy for project debug job on a repository defaulting to main" do
+      repository = %{@repository | default_branch: "main"}
+
+      {:ok, envs} = Repository.env_vars(repository, nil, :project_debug_job)
+
+      assert %{"name" => "SEMAPHORE_GIT_BRANCH", "value" => Base.encode64("main")} in envs
+
+      assert %{"name" => "SEMAPHORE_GIT_WORKING_BRANCH", "value" => Base.encode64("main")} in envs
     end
 
     test "when build this is a branch build" do
@@ -329,5 +335,20 @@ defmodule Zebra.Workers.JobRequestFactory.RepositoryTest do
                }
              ]
     end
+  end
+
+  defp stub_describe(default_branch: default_branch) do
+    GrpcMock.stub(Support.FakeServers.RepositoryApi, :describe, fn _, _ ->
+      InternalApi.Repository.DescribeResponse.new(
+        repository:
+          InternalApi.Repository.Repository.new(
+            name: "zebra2",
+            url: "git@bitbucket.org:test-org/test-repo.git",
+            provider: "github",
+            default_branch: default_branch
+          ),
+        private_ssh_key: @private_ssh_key
+      )
+    end)
   end
 end


### PR DESCRIPTION
## 📝 Description

The job request factory discarded the default_branch returned by repository-hub's Describe and hardcoded "master". Repos whose default branch is "main" therefore never matched the DEFAULT_BRANCH toggle in the debug/attach permission check, and project debug jobs got SEMAPHORE_GIT_BRANCH / SEMAPHORE_GIT_WORKING_BRANCH pointing at a branch that may not exist.

Serialize the value we already receive, falling back to "master" when it is empty - rows predating the default_branch column carry no value.

Behavior change: debug/attach DEFAULT_BRANCH and NON_DEFAULT_BRANCH permissions now resolve against the real default branch, and project debug jobs check out that branch instead of master.

## ✅ Checklist
- [x] I have tested this change
- [ ] This change requires documentation update
