### PR TITLE
docs: update xcode16 mentions

### DIFF
--- a/docs/docs/reference/machine-types.md
+++ b/docs/docs/reference/machine-types.md
@@ -134,11 +134,10 @@ Semaphore Cloud provides the following Apple machine types:
 
 | Type | Virtual CPUs | Architecture | OS Supported | Memory | Disk |
 |--|--|--|--|--|--|
-| `a2-standard-4` | 4 | Apple Silicon | [macOS Xcode16](./os-apple#mac-16)<br/>[macOS Xcode26](./os-apple#mac-26) | 8 | 150 |
+| `a2-standard-4` | 4 | Apple Silicon | [macOS Xcode26](./os-apple#mac-26) | 8 | 150 |
 
 A2 machines can be paired with:
 
-- [macOS Xcode16](./os-apple#mac-16)
 - [macOS Xcode26](./os-apple#mac-26)
 
 ## See also

--- a/docs/docs/reference/os-apple.md
+++ b/docs/docs/reference/os-apple.md
@@ -185,7 +185,7 @@ Following gems are pre-installed:
 </details>
 
 
-## macOS Xcode 16 {#mac-16}
+## (DEPRECATED) macOS Xcode 16 {#mac-16}
 
 <Tabs groupId="editor-yaml">
 <TabItem value="editor" label="Editor">

--- a/docs/docs/reference/pipeline-yaml.md
+++ b/docs/docs/reference/pipeline-yaml.md
@@ -95,7 +95,7 @@ Part of the [`agent`](#agent) definition. This is an optional property to specif
 If a value is not provided, the default for the machine type is used:
 
 - `e1-standard-*` machine types: `ubuntu2404`
-- `a2-standard-*` machine types: `macos-xcode16`
+- `a2-standard-*` machine types: `macos-xcode26`
 
 The list of valid values for Semaphore Cloud is available on the [machine types reference](./machine-types) page.
 
@@ -804,7 +804,7 @@ blocks:
       agent:
           machine:
             type: a2-standard-4
-            os_image: macos-xcode16
+            os_image: macos-xcode26
    # highlight-end
       jobs:
         - name: Using agent job

--- a/docs/docs/using-semaphore/jobs.md
+++ b/docs/docs/using-semaphore/jobs.md
@@ -1033,7 +1033,7 @@ blocks:
       agent:
         machine:
           type: a2-standard-4
-          os_image: macos-xcode16
+          os_image: macos-xcode26
     # highlight-end
       jobs:
         - name: Build


### PR DESCRIPTION
## 📝 Description
Updated mentions of the `macos-xcode16` image in preparation for deprecation.

## ✅ Checklist
- [x] I have tested this change
- [x] This change requires documentation update
