### PR TITLE
feat(front): add Turbo Drive SPA navigation

### DIFF
--- a/front/assets/js/app.js
+++ b/front/assets/js/app.js
@@ -559,6 +559,7 @@ export var App = {
   teardownPage: function () {
     Pollman.stop();
     Timer.stop();
+    DiagramDrag.stop();
 
     if (window.FaviconUpdater) {
       window.FaviconUpdater.stop();

--- a/front/assets/js/app.js
+++ b/front/assets/js/app.js
@@ -80,6 +80,7 @@ import { DeploymentTargets } from "./deployments";
 
 import { Features } from "./features";
 import { Overlay } from "./overlay";
+import { TurboNavigation } from "./turbo_navigation";
 import { RoleForm } from "./roles/role_form.js";
 
 var ace = require('brace');
@@ -492,11 +493,40 @@ export var App = {
       config: InjectedDataByBackend.ReportConfig,
     })
   },
-  // App.run() is invoked at the bottom of the body element
-  run: function () {
+  //
+  // Bootstrap that must happen exactly once per document.
+  //
+  // Everything here binds to window, document or the custom element registry.
+  // Turbo keeps all three alive across visits, so re-running this would stack
+  // a duplicate scroll handler, click handler or posthog client per navigation.
+  //
+  runOnce: function () {
+    Overlay.init();
+
+    defineTimeAgoElement()
+    managePageHeaderShaddows()
+    enableMagicBreadcrumbs()
+    maybeEnablePosthog()
+
+    window.Tippy = Tippy;
+
+    $(document).on("click", ".x-select-on-click", function (event) {
+      event.currentTarget.setSelectionRange(0, event.currentTarget.value.length);
+    });
+
+    window.addEventListener("load", initPylonChatDraggable, { once: true });
+  },
+
+  //
+  // Bootstrap that has to happen for every page, including each Turbo visit.
+  //
+  // These either read page specific data out of InjectedDataByBackend, bind to
+  // elements in the current body, or - like Notice - delegate off document.body,
+  // which Turbo replaces wholesale on every render.
+  //
+  runPage: function () {
     Features.init(InjectedDataByBackend.Features || {});
 
-    Overlay.init();
     if (InjectedDataByBackend.InitialPlan) {
       TrialOverlay({
         dom: document.getElementById("trial-overlay"),
@@ -504,17 +534,10 @@ export var App = {
       })
     }
 
-    defineTimeAgoElement()
-    managePageHeaderShaddows()
-    enableMagicBreadcrumbs()
-    maybeEnablePosthog()
-
-
     if (InjectedDataByBackend.JumpTo !== undefined) {
       window.jumpTo = JumpTo.init();
     }
 
-    window.Tippy = Tippy;
     Tippy.defaultTip('[data-tippy-content]');
     Tippy.otherDefaultTip('.default-tip');
     Tippy.defaultDropdown('.js-dropdown-menu-trigger');
@@ -523,16 +546,24 @@ export var App = {
 
     window.Notice.init();
 
-
-    $(document).on("click", ".x-select-on-click", function (event) {
-      event.currentTarget.setSelectionRange(0, event.currentTarget.value.length);
-    });
-
     for (const el of document.querySelectorAll('[data-hotkey]')) {
       install(el);
     }
+  },
 
-    window.addEventListener("load", initPylonChatDraggable, { once: true });
+  //
+  // Releases the page that is about to be swapped out by Turbo. Modules that
+  // own timers, polling loops or editor instances have to be stopped here or
+  // they keep running against a body that no longer exists.
+  //
+  teardownPage: function () {
+    Pollman.stop();
+    Timer.stop();
+
+    if (window.FaviconUpdater) {
+      window.FaviconUpdater.stop();
+      window.FaviconUpdater = null;
+    }
   }
 };
 
@@ -622,7 +653,29 @@ function maybeEnablePosthog() {
   }
 }
 
-App.run()
-if (InjectedDataByBackend.JS != "" && InjectedDataByBackend.JS !== undefined) {
-  App[InjectedDataByBackend.JS]();
+//
+// Runs the per-page init function named by the backend, if there is one.
+// InjectedDataByBackend.JS is repopulated by _scripts.html.eex on every render,
+// so this picks up the new page's entry point after each Turbo visit.
+//
+function dispatchPageInit() {
+  const name = InjectedDataByBackend.JS;
+
+  if (name === undefined || name === "" || typeof App[name] !== "function") {
+    return;
+  }
+
+  App[name]();
 }
+
+App.runOnce()
+
+TurboNavigation.start({
+  onPageLoad: function () {
+    App.runPage();
+    dispatchPageInit();
+  },
+  onPageTeardown: function () {
+    App.teardownPage();
+  },
+})

--- a/front/assets/js/app.js
+++ b/front/assets/js/app.js
@@ -81,6 +81,7 @@ import { DeploymentTargets } from "./deployments";
 import { Features } from "./features";
 import { Overlay } from "./overlay";
 import { TurboNavigation } from "./turbo_navigation";
+import { islandRoot, unmountIslands } from "./preact_islands";
 import { RoleForm } from "./roles/role_form.js";
 
 var ace = require('brace');
@@ -96,7 +97,7 @@ window.SelfHostedAgents = SelfHostedAgents
 export var App = {
   agents: function () {
     Agents({
-      dom: document.getElementById("agents-app"),
+      dom: islandRoot(document.getElementById("agents-app")),
       config: InjectedDataByBackend.AgentsConfig,
     })
   },
@@ -204,13 +205,13 @@ export var App = {
   },
   index_new_project: function () {
     ProjectOnboardingCreate({
-      dom: document.getElementById("new-project-app"),
+      dom: islandRoot(document.getElementById("new-project-app")),
       config: window.InjectedDataByBackend.NewProjectConfig,
     });
   },
   index_project_bootstrap: function () {
     ProjectOnboardingWorkflowSetup({
-      dom: document.getElementById("new-project-app"),
+      dom: islandRoot(document.getElementById("new-project-app")),
       config: window.InjectedDataByBackend.NewProjectBootstrapConfig,
     });
   },
@@ -278,14 +279,14 @@ export var App = {
 
     document.querySelectorAll("#deploy-key-config-app").forEach((dom) => {
       DeployKeyConfig({
-        dom: dom,
+        dom: islandRoot(dom),
         config: dom.dataset
       })
     });
 
     document.querySelectorAll("#webhook-config-app").forEach((dom) => {
       WebhookConfig({
-        dom: dom,
+        dom: islandRoot(dom),
         config: dom.dataset
       })
     });
@@ -304,29 +305,29 @@ export var App = {
     const serviceAccountsEl = document.getElementById("service-accounts");
     if (serviceAccountsEl) {
       const config = JSON.parse(serviceAccountsEl.dataset.config);
-      ServiceAccounts({ dom: serviceAccountsEl, config });
+      ServiceAccounts({ dom: islandRoot(serviceAccountsEl), config });
     }
 
     const addPeopleEl = document.getElementById("add-people");
     if (addPeopleEl) {
-      AddPeople({ dom: addPeopleEl, config: addPeopleEl.dataset });
+      AddPeople({ dom: islandRoot(addPeopleEl), config: addPeopleEl.dataset });
     }
 
     const syncPeopleEl = document.querySelector(".app-sync-people");
     if (syncPeopleEl) {
-      SyncPeople({ dom: syncPeopleEl, config: syncPeopleEl.dataset });
+      SyncPeople({ dom: islandRoot(syncPeopleEl), config: syncPeopleEl.dataset });
     }
 
     document.querySelectorAll(".app-edit-person").forEach((editPersonAppRoot) => {
       EditPerson({
-        dom: editPersonAppRoot,
+        dom: islandRoot(editPersonAppRoot),
         config: editPersonAppRoot.dataset
       })
     });
   },
   organization_okta: function () {
     OrganizationOktaGroupMappingApp({
-      dom: document.getElementById("group-mapping-container"),
+      dom: islandRoot(document.getElementById("group-mapping-container")),
       config: window.InjectedDataByBackend.OrganizationOktaConfig
     });
   },
@@ -362,7 +363,7 @@ export var App = {
   testResults: function () {
     Pollman.init({ interval: 4000 })
     TestResults({
-      dom: document.getElementById("test-results"),
+      dom: islandRoot(document.getElementById("test-results")),
       jsonURL: InjectedDataByBackend.jsonArtifactsURL,
       scope: InjectedDataByBackend.scope,
       encodedEmail: InjectedDataByBackend.encodedEmail,
@@ -426,19 +427,19 @@ export var App = {
   },
   organization_health_tab: function () {
     OrganizationHealth({
-      dom: document.getElementById("organization-health-app"),
+      dom: islandRoot(document.getElementById("organization-health-app")),
       config: InjectedDataByBackend.OrganizationHealthConfig,
     });
   },
   flaky_tests_tab: function () {
     FlakyTests({
-      dom: document.getElementById("flaky-tests-app"),
+      dom: islandRoot(document.getElementById("flaky-tests-app")),
       config: InjectedDataByBackend.FlakyTestsConfig,
     });
   },
   insights: function () {
     Insights({
-      dom: document.getElementById("insights-app"),
+      dom: islandRoot(document.getElementById("insights-app")),
       config: InjectedDataByBackend.InsightsConfig,
     })
     new Star();
@@ -465,31 +466,31 @@ export var App = {
   },
   billingDashboard: function () {
     Billing({
-      dom: document.getElementById("billing-app"),
+      dom: islandRoot(document.getElementById("billing-app")),
       config: InjectedDataByBackend.BillingConfig,
     })
   },
   gitIntegration: function () {
     GitIntegration({
-      dom: document.getElementById("git-integration-app"),
+      dom: islandRoot(document.getElementById("git-integration-app")),
       config: InjectedDataByBackend.GitIntegrationConfig,
     })
   },
   organizationOnboarding: function () {
     OrganizationOnboarding({
-      dom: document.getElementById("organization-onboarding-app"),
+      dom: islandRoot(document.getElementById("organization-onboarding-app")),
       config: InjectedDataByBackend.OrganizationOnboardingConfig,
     })
   },
   getStarted: function () {
     GetStarted({
-      dom: document.getElementById("get-started-app"),
+      dom: islandRoot(document.getElementById("get-started-app")),
       config: InjectedDataByBackend.GetStartedConfig,
     })
   },
   report: function() {
     Report({
-      dom: document.getElementById("report-app"),
+      dom: islandRoot(document.getElementById("report-app")),
       config: InjectedDataByBackend.ReportConfig,
     })
   },
@@ -529,7 +530,7 @@ export var App = {
 
     if (InjectedDataByBackend.InitialPlan) {
       TrialOverlay({
-        dom: document.getElementById("trial-overlay"),
+        dom: islandRoot(document.getElementById("trial-overlay")),
         config: InjectedDataByBackend.InitialPlan,
       })
     }
@@ -560,6 +561,7 @@ export var App = {
     Pollman.stop();
     Timer.stop();
     DiagramDrag.stop();
+    unmountIslands();
 
     if (window.FaviconUpdater) {
       window.FaviconUpdater.stop();

--- a/front/assets/js/groups/group_management.js
+++ b/front/assets/js/groups/group_management.js
@@ -130,7 +130,7 @@ export var GroupManagement = {
     .then((response) => response.text())
     .then((html) => {
       reRenderPage(html)
-      App.run()
+      App.runPage()
       App["people_page"]()
     })
     .catch(e =>{
@@ -164,7 +164,7 @@ export var GroupManagement = {
     })
     .then((html) => {
       reRenderPage(html)
-      App.run()
+      App.runPage()
       App["people_page"]()
     })
     .catch(e =>{

--- a/front/assets/js/people/add_to_project.js
+++ b/front/assets/js/people/add_to_project.js
@@ -154,7 +154,7 @@ export var AddToProject = {
     .then((response) => response.text())
     .then((html) => {
       reRenderPage(html)
-      App.run()
+      App.runPage()
       App["people_page"]()
     })
     .catch(e =>{

--- a/front/assets/js/people/change_role_dropdown.js
+++ b/front/assets/js/people/change_role_dropdown.js
@@ -85,7 +85,7 @@ export var ChangeRoleDropdown = {
     })
     .then((html) => {
       reRenderPage(html)
-      App.run()
+      App.runPage()
       App["people_page"]()
     })
     .catch((error) => {

--- a/front/assets/js/people/retract_role.js
+++ b/front/assets/js/people/retract_role.js
@@ -41,7 +41,7 @@ export var RetractRole = {
     .then((response)=>response.text())
     .then((html) => {
       reRenderPage(html)
-      App.run()
+      App.runPage()
       App["people_page"]()
     })
     .catch((error) => {

--- a/front/assets/js/pollman.js
+++ b/front/assets/js/pollman.js
@@ -57,6 +57,13 @@ import $ from "jquery";
 
 export var Pollman = {
   init: function (options) {
+    //
+    // Cancel a looper left over from a previous page. Under Turbo Drive init()
+    // runs again on every visit, and the looper reschedules itself, so without
+    // this each visit would leave another polling chain running forever.
+    //
+    this.cancelLooper();
+
     this.options = _.defaults(options || {}, {
       interval: 2000,
       saveScrollElements: [],
@@ -70,6 +77,10 @@ export var Pollman = {
 
     this.noRefreshCycle = 0;
 
+    // Turbo teardown calls stop() on every visit, so clear the flag here or
+    // the looper started below would never actually poll.
+    this.stopped = false;
+
     if(this.options.startLooper) {
       this.looper();
     }
@@ -81,7 +92,19 @@ export var Pollman = {
 
   stop: function () {
     this.stopped = true;
+    this.cancelLooper();
     this.forgetFetchInProgress();
+  },
+
+  //
+  // Clears the pending looper timeout, if any. stop() on its own only stops
+  // polling; the timeout chain keeps rescheduling itself until it is cleared.
+  //
+  cancelLooper: function () {
+    if (this.looperTimeout) {
+      clearTimeout(this.looperTimeout);
+      this.looperTimeout = null;
+    }
   },
 
   forgetFetchInProgress: function () {
@@ -90,6 +113,13 @@ export var Pollman = {
 
   start: function () {
     this.stopped = false;
+
+    // stop() clears the timeout chain, so resume it here. Scheduling rather
+    // than calling looper() directly keeps the original behaviour of waiting
+    // one interval before the next poll.
+    if (!this.looperTimeout && this.options) {
+      this.looperTimeout = setTimeout(this.looper.bind(this), this.options.interval);
+    }
   },
 
   poll: function (options, callback) {
@@ -149,7 +179,7 @@ export var Pollman = {
       this.poll(this.options);
     }
 
-    setTimeout(this.looper.bind(this), this.options.interval);
+    this.looperTimeout = setTimeout(this.looper.bind(this), this.options.interval);
   },
 
   startForUrl: function (url) {

--- a/front/assets/js/preact_islands.js
+++ b/front/assets/js/preact_islands.js
@@ -1,0 +1,50 @@
+/**
+ * @prettier
+ */
+
+//
+// Preact islands mount into elements inside the body, and Turbo Drive discards
+// the body without telling Preact about it.
+//
+// The components release their window and document listeners from useEffect
+// cleanups, and those only run on unmount. Left alone, every visit to a page
+// with an island leaves another live listener behind, pointing at DOM that is
+// no longer in the document. So the roots have to be unmounted explicitly,
+// while the old body is still in place.
+//
+// Islands defined as custom elements (preactement) look after themselves -
+// removing them from the document fires disconnectedCallback.
+//
+import { render } from "preact";
+
+const mounted = new Set();
+
+//
+// Records a container as holding a Preact root and returns it unchanged, so it
+// can wrap an existing lookup at the point of mounting:
+//
+//   Agents({ dom: islandRoot(document.getElementById("agents-app")), config })
+//
+export function islandRoot(element) {
+  if (element) {
+    mounted.add(element);
+  }
+
+  return element;
+}
+
+//
+// Unmounts every tracked root. render(null, container) is Preact's unmount:
+// it diffs the tree away and runs the effect cleanups on the way out.
+//
+export function unmountIslands() {
+  mounted.forEach((element) => render(null, element));
+  mounted.clear();
+}
+
+//
+// Exposed for tests.
+//
+export function trackedIslandCount() {
+  return mounted.size;
+}

--- a/front/assets/js/preact_islands.spec.js
+++ b/front/assets/js/preact_islands.spec.js
@@ -1,0 +1,89 @@
+import { expect } from "chai"
+import { h, render } from "preact"
+import { useEffect } from "preact/hooks"
+import { act } from "preact/test-utils"
+import { islandRoot, unmountIslands, trackedIslandCount } from "./preact_islands"
+
+describe("PreactIslands", () => {
+  beforeEach(() => {
+    unmountIslands()
+    document.body.innerHTML = ""
+  })
+
+  const container = () => {
+    const element = document.createElement("div")
+    document.body.appendChild(element)
+    return element
+  }
+
+  describe("islandRoot", () => {
+    it("returns the element it was given", () => {
+      const element = container()
+
+      expect(islandRoot(element)).to.equal(element)
+    })
+
+    it("ignores a container that is not on the page", () => {
+      expect(islandRoot(null)).to.equal(null)
+      expect(trackedIslandCount()).to.equal(0)
+    })
+
+    it("tracks a container only once", () => {
+      const element = container()
+
+      islandRoot(element)
+      islandRoot(element)
+
+      expect(trackedIslandCount()).to.equal(1)
+    })
+  })
+
+  describe("unmountIslands", () => {
+    //
+    // The behaviour the Turbo teardown depends on: the listeners these islands
+    // register live on window, so only an unmount releases them.
+    //
+    it("runs the effect cleanups of a mounted island", () => {
+      let released = false
+
+      const Island = () => {
+        useEffect(() => () => { released = true }, [])
+        return null
+      }
+
+      // act() flushes the effect, which is what registers the cleanup. In a
+      // browser it has run long before anyone navigates away.
+      act(() => {
+        render(h(Island, null), islandRoot(container()))
+      })
+      expect(released).to.equal(false)
+
+      unmountIslands()
+
+      expect(released).to.equal(true)
+    })
+
+    it("clears the island out of the container", () => {
+      const element = islandRoot(container())
+      render(h("p", null, "mounted"), element)
+      expect(element.textContent).to.equal("mounted")
+
+      unmountIslands()
+
+      expect(element.textContent).to.equal("")
+    })
+
+    it("forgets the containers so a later page starts clean", () => {
+      islandRoot(container())
+      islandRoot(container())
+
+      unmountIslands()
+
+      expect(trackedIslandCount()).to.equal(0)
+    })
+
+    it("does nothing when no island was mounted", () => {
+      expect(() => unmountIslands()).to.not.throw()
+    })
+  })
+})

--- a/front/assets/js/turbo_navigation.js
+++ b/front/assets/js/turbo_navigation.js
@@ -1,0 +1,119 @@
+/**
+ * @prettier
+ */
+
+//
+// Turbo Drive integration.
+//
+// Semaphore is a server rendered app: every page ships its own inline
+// <script> blocks that populate window.InjectedDataByBackend, and app.js
+// dispatches to a per-page init function based on InjectedDataByBackend.JS.
+//
+// Turbo swaps the <body> without reloading the document, which breaks three
+// assumptions that hold on a full page load:
+//
+//   1. app.js runs once per page. Under Turbo the bundle lives in <head> and
+//      is never re-executed, so the per-page dispatch has to be driven by
+//      turbo:load instead of by module top-level code.
+//
+//   2. InjectedDataByBackend starts empty. The <head> block that initializes
+//      it is not re-run, so keys set by the previous page would leak into the
+//      next one. We reset it before each render.
+//
+//   3. Handlers bound in init() live as long as the page. They don't: Turbo
+//      replaces the <body> element, so anything bound to document.body dies
+//      with it, while anything bound to window or document survives and would
+//      stack up one copy per visit. See runOnce/runPage in app.js.
+//
+export const TurboNavigation = {
+  //
+  // Starts Turbo Drive, unless the backend disabled it for this organization.
+  //
+  // onPageLoad     - runs after every render, including the first one.
+  // onPageTeardown - runs before every render, to release the previous page.
+  //
+  // Returns true when Turbo took over navigation. When it did not, onPageLoad
+  // is invoked synchronously, so a page with the flag off boots exactly the way
+  // it did before Turbo existed.
+  //
+  start: function ({ onPageLoad, onPageTeardown }) {
+    if (!this.isEnabled()) {
+      onPageLoad();
+      return false;
+    }
+
+    this.loadTurbo({ onPageLoad, onPageTeardown });
+
+    return true;
+  },
+
+  //
+  // Turbo is imported lazily because merely importing it builds a Session, a
+  // ProgressBar and the turbo-frame/turbo-stream custom elements. Deferring
+  // that keeps the import free of side effects for the majority of orgs that
+  // have the flag off, and keeps this module loadable outside a browser.
+  //
+  loadTurbo: function ({ onPageLoad, onPageTeardown }) {
+    return import("@hotwired/turbo").then((Turbo) => {
+      document.addEventListener("turbo:before-render", () => {
+        onPageTeardown();
+        this.resetInjectedData();
+      });
+
+      document.addEventListener("turbo:load", () => {
+        this.pruneDuplicateNonceTags();
+        onPageLoad();
+      });
+
+      //
+      // Link navigation only, for now.
+      //
+      // Turbo also intercepts form submissions, but it requires the response to
+      // be a redirect and treats a rendered 200 as an error. Plenty of our
+      // controllers re-render the form with a 200 when validation fails, so
+      // enabling this would need every form flow audited first.
+      //
+      Turbo.setFormMode("off");
+
+      Turbo.start();
+    });
+  },
+
+  isEnabled: function () {
+    return window.InjectedDataByBackend.TurboNavigation === true;
+  },
+
+  //
+  // Mirrors the initialization in the <head> of _head.html.eex. That block is
+  // not re-executed by Turbo, so without this every page would inherit the
+  // previous page's keys (a stale pipelineStatusUrl, FilterOptions, etc.).
+  //
+  resetInjectedData: function () {
+    const preserved = {
+      Environment: window.InjectedDataByBackend.Environment,
+      Posthog: window.InjectedDataByBackend.Posthog,
+      TurboNavigation: window.InjectedDataByBackend.TurboNavigation,
+    };
+
+    window.InjectedDataByBackend = { Watchman: {} };
+    Object.assign(window.InjectedDataByBackend, preserved);
+  },
+
+  //
+  // Turbo reads the first meta[name="csp-nonce"] in the document and stamps it
+  // onto the scripts it injects. That first tag has to stay the one from the
+  // originally loaded page, because the CSP header being enforced is still that
+  // page's header - the document was never reloaded.
+  //
+  // Turbo's head merge appends the incoming page's nonce tag rather than
+  // replacing it, so the original stays first and keeps winning. The appended
+  // copies are dead weight that would otherwise grow by one per visit.
+  //
+  pruneDuplicateNonceTags: function () {
+    const tags = document.querySelectorAll('meta[name="csp-nonce"]');
+
+    for (let i = 1; i < tags.length; i++) {
+      tags[i].remove();
+    }
+  },
+};

--- a/front/assets/js/turbo_navigation.js
+++ b/front/assets/js/turbo_navigation.js
@@ -53,6 +53,9 @@ export const TurboNavigation = {
   // that keeps the import free of side effects for the majority of orgs that
   // have the flag off, and keeps this module loadable outside a browser.
   //
+  // Note this defers evaluation, not download: build.js bundles without
+  // splitting, so Turbo ships inside app.js for every organization either way.
+  //
   loadTurbo: function ({ onPageLoad, onPageTeardown }) {
     return import("@hotwired/turbo").then((Turbo) => {
       document.addEventListener("turbo:before-render", () => {

--- a/front/assets/js/turbo_navigation.js
+++ b/front/assets/js/turbo_navigation.js
@@ -76,7 +76,7 @@ export const TurboNavigation = {
       // controllers re-render the form with a 200 when validation fails, so
       // enabling this would need every form flow audited first.
       //
-      Turbo.setFormMode("off");
+      Turbo.config.forms.mode = "off";
 
       Turbo.start();
     });

--- a/front/assets/js/turbo_navigation.spec.js
+++ b/front/assets/js/turbo_navigation.spec.js
@@ -1,0 +1,86 @@
+import { expect } from "chai"
+import { TurboNavigation } from "./turbo_navigation"
+
+describe("TurboNavigation", () => {
+  beforeEach(() => {
+    window.InjectedDataByBackend = { Watchman: {} }
+    document.head.innerHTML = ""
+  })
+
+  describe("isEnabled", () => {
+    it("is disabled when the backend did not set the flag", () => {
+      expect(TurboNavigation.isEnabled()).to.equal(false)
+    })
+
+    it("is enabled only for a literal true", () => {
+      window.InjectedDataByBackend.TurboNavigation = "true"
+      expect(TurboNavigation.isEnabled()).to.equal(false)
+
+      window.InjectedDataByBackend.TurboNavigation = true
+      expect(TurboNavigation.isEnabled()).to.equal(true)
+    })
+  })
+
+  describe("resetInjectedData", () => {
+    it("drops keys belonging to the page being navigated away from", () => {
+      window.InjectedDataByBackend.pipelineStatusUrl = "/workflows/1/status"
+      window.InjectedDataByBackend.FilterOptions = ["master"]
+
+      TurboNavigation.resetInjectedData()
+
+      expect(window.InjectedDataByBackend.pipelineStatusUrl).to.equal(undefined)
+      expect(window.InjectedDataByBackend.FilterOptions).to.equal(undefined)
+    })
+
+    it("keeps the document wide configuration", () => {
+      window.InjectedDataByBackend.Environment = { Env: "prod" }
+      window.InjectedDataByBackend.Posthog = { apiKey: "key" }
+      window.InjectedDataByBackend.TurboNavigation = true
+
+      TurboNavigation.resetInjectedData()
+
+      expect(window.InjectedDataByBackend.Environment).to.deep.equal({ Env: "prod" })
+      expect(window.InjectedDataByBackend.Posthog).to.deep.equal({ apiKey: "key" })
+      expect(window.InjectedDataByBackend.TurboNavigation).to.equal(true)
+    })
+
+    it("restores the empty Watchman namespace set up in the head", () => {
+      window.InjectedDataByBackend.Watchman = { metric: 1 }
+
+      TurboNavigation.resetInjectedData()
+
+      expect(window.InjectedDataByBackend.Watchman).to.deep.equal({})
+    })
+  })
+
+  describe("pruneDuplicateNonceTags", () => {
+    const nonceTags = () =>
+      Array.from(document.querySelectorAll('meta[name="csp-nonce"]')).map((tag) => tag.content)
+
+    it("keeps the nonce from the originally loaded page", () => {
+      document.head.innerHTML = `
+        <meta name="csp-nonce" content="original">
+        <meta name="csp-nonce" content="second-visit">
+        <meta name="csp-nonce" content="third-visit">
+      `
+
+      TurboNavigation.pruneDuplicateNonceTags()
+
+      expect(nonceTags()).to.deep.equal(["original"])
+    })
+
+    it("leaves a single tag alone", () => {
+      document.head.innerHTML = `<meta name="csp-nonce" content="original">`
+
+      TurboNavigation.pruneDuplicateNonceTags()
+
+      expect(nonceTags()).to.deep.equal(["original"])
+    })
+
+    it("does nothing when there is no nonce tag", () => {
+      TurboNavigation.pruneDuplicateNonceTags()
+
+      expect(nonceTags()).to.deep.equal([])
+    })
+  })
+})

--- a/front/assets/js/workflow_view/diagram_drag.js
+++ b/front/assets/js/workflow_view/diagram_drag.js
@@ -3,6 +3,14 @@ export var DiagramDrag = {
     var container = document.getElementById("diagram");
     if (!container) return;
 
+    //
+    // Under Turbo Drive init() runs again on every visit to the workflow view.
+    // The mousemove/mouseup listeners live on window and the cursor style tag
+    // on document.head, neither of which is replaced by the body swap, so drop
+    // the previous page's set before installing this one.
+    //
+    this.stop();
+
     var state = { active: false, startX: 0, startY: 0, scrollLeft: 0, pageScrollTop: 0 };
 
     function isPipelineContent(e) {
@@ -26,7 +34,7 @@ export var DiagramDrag = {
       container.style.userSelect = "none"; // njsscan-ignore: node_username
     });
 
-    window.addEventListener("mousemove", function (e) {
+    this.onMouseMove = function (e) {
       if (!state.active) return;
 
       if (e.buttons === 0) {
@@ -41,19 +49,44 @@ export var DiagramDrag = {
       var scrollDelta = window.scrollY - state.pageScrollTop;
       var dy = e.pageY - state.startY - scrollDelta;
       window.scrollTo(0, state.pageScrollTop - dy);
-    });
+    };
 
-    window.addEventListener("mouseup", function () {
+    this.onMouseUp = function () {
       if (!state.active) return;
       state.active = false;
       container.style.cursor = "grab";
       container.style.userSelect = "";
-    });
+    };
+
+    window.addEventListener("mousemove", this.onMouseMove);
+    window.addEventListener("mouseup", this.onMouseUp);
 
     container.style.cursor = "grab";
 
-    var style = document.createElement("style");
-    style.textContent = "#diagram .drag-ignore, #diagram .drag-ignore * { cursor: default; }";
-    document.head.appendChild(style);
+    this.style = document.createElement("style");
+    this.style.textContent = "#diagram .drag-ignore, #diagram .drag-ignore * { cursor: default; }";
+    document.head.appendChild(this.style);
+  },
+
+  //
+  // The mousedown listener is bound to #diagram, which Turbo discards along
+  // with the rest of the body, so only the window listeners and the style tag
+  // have to be released here.
+  //
+  stop: function () {
+    if (this.onMouseMove) {
+      window.removeEventListener("mousemove", this.onMouseMove);
+      this.onMouseMove = null;
+    }
+
+    if (this.onMouseUp) {
+      window.removeEventListener("mouseup", this.onMouseUp);
+      this.onMouseUp = null;
+    }
+
+    if (this.style) {
+      this.style.remove();
+      this.style = null;
+    }
   }
 };

--- a/front/assets/js/workflow_view/timer.js
+++ b/front/assets/js/workflow_view/timer.js
@@ -4,7 +4,18 @@ import "moment-duration-format"
 
 export var Timer = {
   init: function() {
-    setInterval(this.tick, 1000);
+    // Under Turbo Drive init() runs again on each visit to the workflow view,
+    // so drop any previous interval instead of stacking a second ticker.
+    this.stop();
+
+    this.ticker = setInterval(this.tick, 1000);
+  },
+
+  stop: function() {
+    if (this.ticker) {
+      clearInterval(this.ticker);
+      this.ticker = null;
+    }
   },
 
   tick: function() {

--- a/front/assets/package-lock.json
+++ b/front/assets/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@algolia/autocomplete-core": "^1.12.1",
         "@github/hotkey": "^1.3.0",
+        "@hotwired/turbo": "^8.0.23",
         "@monaco-editor/react": "^4.6.0",
         "@popperjs/core": "^2.11.5",
         "@preact/signals": "^1.3.0",
@@ -3159,6 +3160,15 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@github/hotkey/-/hotkey-1.3.0.tgz",
       "integrity": "sha512-8bszqQdjX7nnE7GyKUIuoIywDAnehxG9uGCxSNI3ZruWKVqT7+J7CxTsTH3n2AiIt+IiwglnBaa9OIwz1Q5PtA=="
+    },
+    "node_modules/@hotwired/turbo": {
+      "version": "8.0.23",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-8.0.23.tgz",
+      "integrity": "sha512-GZ7cijxEZ6Ig71u7rD6LHaRv/wcE/hNsc+nEfiWOkLNqUgLOwo5MNGWOy5ZV9ZUDSiQx1no7YxjTNnT4O6//cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",

--- a/front/assets/package.json
+++ b/front/assets/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@algolia/autocomplete-core": "^1.12.1",
     "@github/hotkey": "^1.3.0",
+    "@hotwired/turbo": "^8.0.23",
     "@monaco-editor/react": "^4.6.0",
     "@popperjs/core": "^2.11.5",
     "@preact/signals": "^1.3.0",

--- a/front/lib/front_web/templates/layout/_head.html.eex
+++ b/front/lib/front_web/templates/layout/_head.html.eex
@@ -29,6 +29,14 @@
       are still cached and reused for back/forward, which do fire turbo:load.
     -->
     <meta name="turbo-cache-control" content="no-preview">
+
+    <!--
+      Turbo 8 prefetches a link's target on hover unless told otherwise, which
+      would fire a speculative GET for every link a cursor crosses. Link
+      navigation is all we are adopting here; prefetching is a separate change
+      to make deliberately, with the extra request load measured first.
+    -->
+    <meta name="turbo-prefetch" content="false">
   <% end %>
 
   <%= social_metatags(@conn) %>

--- a/front/lib/front_web/templates/layout/_head.html.eex
+++ b/front/lib/front_web/templates/layout/_head.html.eex
@@ -10,24 +10,26 @@
   <meta name="description" content="<%= description(@conn) %>">
   <meta name="author" content="">
 
-  <!--
-    Turbo stamps this nonce onto every script it injects. It reads the first
-    meta[name="csp-nonce"] in the document, which stays the one from the
-    originally loaded page - the same nonce that page's CSP header whitelists.
-  -->
-  <meta name="csp-nonce" content="<%= @conn.assigns[:script_src_nonce] %>">
+  <%= if turbo_enabled?(@conn) do %>
+    <!--
+      Turbo stamps this nonce onto every script it injects. It reads the first
+      meta[name="csp-nonce"] in the document, which stays the one from the
+      originally loaded page - the same nonce that page's CSP header whitelists.
+    -->
+    <meta name="csp-nonce" content="<%= @conn.assigns[:script_src_nonce] %>">
 
-  <%= if turbo_full_reload_page?(@conn) do %>
-    <meta name="turbo-visit-control" content="reload">
+    <%= if turbo_full_reload_page?(@conn) do %>
+      <meta name="turbo-visit-control" content="reload">
+    <% end %>
+
+    <!--
+      Turbo paints a cached snapshot before the fresh response arrives, but it
+      only fires turbo:load for the real render. The preview would therefore show
+      a page whose tooltips, hotkeys and per-page init have not run yet. Snapshots
+      are still cached and reused for back/forward, which do fire turbo:load.
+    -->
+    <meta name="turbo-cache-control" content="no-preview">
   <% end %>
-
-  <!--
-    Turbo paints a cached snapshot before the fresh response arrives, but it
-    only fires turbo:load for the real render. The preview would therefore show
-    a page whose tooltips, hotkeys and per-page init have not run yet. Snapshots
-    are still cached and reused for back/forward, which do fire turbo:load.
-  -->
-  <meta name="turbo-cache-control" content="no-preview">
 
   <%= social_metatags(@conn) %>
 

--- a/front/lib/front_web/templates/layout/_head.html.eex
+++ b/front/lib/front_web/templates/layout/_head.html.eex
@@ -10,10 +10,29 @@
   <meta name="description" content="<%= description(@conn) %>">
   <meta name="author" content="">
 
+  <!--
+    Turbo stamps this nonce onto every script it injects. It reads the first
+    meta[name="csp-nonce"] in the document, which stays the one from the
+    originally loaded page - the same nonce that page's CSP header whitelists.
+  -->
+  <meta name="csp-nonce" content="<%= @conn.assigns[:script_src_nonce] %>">
+
+  <%= if turbo_full_reload_page?(@conn) do %>
+    <meta name="turbo-visit-control" content="reload">
+  <% end %>
+
+  <!--
+    Turbo paints a cached snapshot before the fresh response arrives, but it
+    only fires turbo:load for the real render. The preview would therefore show
+    a page whose tooltips, hotkeys and per-page init have not run yet. Snapshots
+    are still cached and reused for back/forward, which do fire turbo:load.
+  -->
+  <meta name="turbo-cache-control" content="no-preview">
+
   <%= social_metatags(@conn) %>
 
   <!-- Semaphore CSS -->
-  <link rel="stylesheet" media="screen" href="<%= assets_path() %>/css/app.css" />
+  <link rel="stylesheet" media="screen" data-turbo-track="reload" href="<%= assets_path() %>/css/app.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
 
   <!-- Favicon -->
@@ -26,4 +45,16 @@
     window.InjectedDataByBackend = {};
     window.InjectedDataByBackend.Watchman = {};
   </script>
+
+  <!--
+    The bundle lives in <head> on purpose: Turbo re-executes every <script> in
+    <body> on each visit, which would re-download and re-run the whole bundle.
+    Head scripts are only added when not already present, so this runs once.
+    "defer" keeps it executing after the body parses, so the per-page
+    InjectedDataByBackend blocks are populated before App boots.
+  -->
+  <script defer
+          nonce="<%= @conn.assigns[:script_src_nonce] %>"
+          data-turbo-track="reload"
+          src="<%= static_path(@conn, "/projects/assets/app.js") %>"></script>
 </head>

--- a/front/lib/front_web/templates/layout/_scripts.html.eex
+++ b/front/lib/front_web/templates/layout/_scripts.html.eex
@@ -3,9 +3,8 @@
   window.InjectedDataByBackend.Environment.Env = "<%= Application.get_env(:front, :environment) %>"
   window.InjectedDataByBackend.Integrations = {}
   window.InjectedDataByBackend.Posthog = <%= raw posthog_config_json(@conn) %>
+  window.InjectedDataByBackend.TurboNavigation = <%= FeatureProvider.feature_enabled?(:turbo_navigation, param: @conn.assigns[:organization_id]) %>
 <%= if @conn.assigns[:js] do %>
   window.InjectedDataByBackend.JS = "<%= @conn.assigns[:js] %>"
 <% end %>
 </script>
-
-<script nonce="<%= @conn.assigns[:script_src_nonce] %>" src="<%= static_path(@conn, "/projects/assets/app.js") %>"></script>

--- a/front/lib/front_web/templates/layout/_scripts.html.eex
+++ b/front/lib/front_web/templates/layout/_scripts.html.eex
@@ -3,7 +3,7 @@
   window.InjectedDataByBackend.Environment.Env = "<%= Application.get_env(:front, :environment) %>"
   window.InjectedDataByBackend.Integrations = {}
   window.InjectedDataByBackend.Posthog = <%= raw posthog_config_json(@conn) %>
-  window.InjectedDataByBackend.TurboNavigation = <%= FeatureProvider.feature_enabled?(:turbo_navigation, param: @conn.assigns[:organization_id]) %>
+  window.InjectedDataByBackend.TurboNavigation = <%= turbo_enabled?(@conn) %>
 <%= if @conn.assigns[:js] do %>
   window.InjectedDataByBackend.JS = "<%= @conn.assigns[:js] %>"
 <% end %>

--- a/front/lib/front_web/views/layout_view.ex
+++ b/front/lib/front_web/views/layout_view.ex
@@ -20,7 +20,7 @@ defmodule FrontWeb.LayoutView do
   # without the flag has to receive the page exactly as it was before Turbo.
   #
   def turbo_enabled?(conn) do
-    FeatureProvider.feature_enabled?(:turbo_navigation, param: conn.assigns[:organization_id])
+    FeatureProvider.feature_enabled?(:ui_turbo_navigation, param: conn.assigns[:organization_id])
   end
 
   def login_url(conn) do

--- a/front/lib/front_web/views/layout_view.ex
+++ b/front/lib/front_web/views/layout_view.ex
@@ -2,6 +2,18 @@ defmodule FrontWeb.LayoutView do
   use FrontWeb, :view
   alias Front.Async
 
+  #
+  # Pages that own long lived client state - Monaco and ace in the workflow
+  # editor, the streaming log viewer on a job - and would have to tear it all
+  # down to survive a Turbo render. They are cheap to opt out of, so navigating
+  # to one performs a normal full page load instead.
+  #
+  @turbo_full_reload_pages ~w(workflow_editor logs)
+
+  def turbo_full_reload_page?(conn) do
+    to_string(conn.assigns[:js]) in @turbo_full_reload_pages
+  end
+
   def login_url(conn) do
     org_id = conn.assigns.organization_id
     origin_url = Plug.Conn.request_url(conn)

--- a/front/lib/front_web/views/layout_view.ex
+++ b/front/lib/front_web/views/layout_view.ex
@@ -14,6 +14,15 @@ defmodule FrontWeb.LayoutView do
     to_string(conn.assigns[:js]) in @turbo_full_reload_pages
   end
 
+  #
+  # Single source of truth for the flag. The head renders before the scripts
+  # partial, so both need to ask the same question, and an organization
+  # without the flag has to receive the page exactly as it was before Turbo.
+  #
+  def turbo_enabled?(conn) do
+    FeatureProvider.feature_enabled?(:turbo_navigation, param: conn.assigns[:organization_id])
+  end
+
   def login_url(conn) do
     org_id = conn.assigns.organization_id
     origin_url = Plug.Conn.request_url(conn)

--- a/front/test/front_web/views/layout_view_test.exs
+++ b/front/test/front_web/views/layout_view_test.exs
@@ -82,27 +82,27 @@ defmodule FrontWeb.LayoutViewTest do
 
     setup do
       # The org level override can only be set for a feature that exists, and
-      # turbo_navigation is not part of the default seed.
-      Support.Stubs.Feature.setup_feature("turbo_navigation", state: :HIDDEN, quantity: 0)
+      # ui_turbo_navigation is not part of the default seed.
+      Support.Stubs.Feature.setup_feature("ui_turbo_navigation", state: :HIDDEN, quantity: 0)
 
       :ok
     end
 
     test "is true for an organization the feature is enabled for" do
-      Support.Stubs.Feature.enable_feature(@org_id, :turbo_navigation)
+      Support.Stubs.Feature.enable_feature(@org_id, :ui_turbo_navigation)
 
       assert FrontWeb.LayoutView.turbo_enabled?(conn_with_org(@org_id))
     end
 
     test "is false for an organization the feature is hidden for" do
-      Support.Stubs.Feature.disable_feature(@org_id, :turbo_navigation)
+      Support.Stubs.Feature.disable_feature(@org_id, :ui_turbo_navigation)
 
       refute FrontWeb.LayoutView.turbo_enabled?(conn_with_org(@org_id))
     end
   end
 
   #
-  # No setup here on purpose. turbo_navigation has no feature record yet, so
+  # No setup here on purpose. ui_turbo_navigation has no feature record yet, so
   # this is what every organization gets today, and it is the case that keeps
   # the flag off until someone provisions it.
   #

--- a/front/test/front_web/views/layout_view_test.exs
+++ b/front/test/front_web/views/layout_view_test.exs
@@ -75,7 +75,7 @@ defmodule FrontWeb.LayoutViewTest do
     end
   end
 
-  describe "turbo_enabled?/1" do
+  describe "turbo_enabled?/1 with the feature provisioned" do
     @org_id "78114608-be8a-465a-b9cd-81970fb802c6"
 
     defp conn_with_org(org_id), do: %Plug.Conn{assigns: %{organization_id: org_id}}
@@ -99,8 +99,15 @@ defmodule FrontWeb.LayoutViewTest do
 
       refute FrontWeb.LayoutView.turbo_enabled?(conn_with_org(@org_id))
     end
+  end
 
-    test "is false for an organization the feature was never provisioned for" do
+  #
+  # No setup here on purpose. turbo_navigation has no feature record yet, so
+  # this is what every organization gets today, and it is the case that keeps
+  # the flag off until someone provisions it.
+  #
+  describe "turbo_enabled?/1 without the feature provisioned" do
+    test "is false for an organization" do
       refute FrontWeb.LayoutView.turbo_enabled?(conn_with_org(@org_id))
     end
 

--- a/front/test/front_web/views/layout_view_test.exs
+++ b/front/test/front_web/views/layout_view_test.exs
@@ -80,6 +80,14 @@ defmodule FrontWeb.LayoutViewTest do
 
     defp conn_with_org(org_id), do: %Plug.Conn{assigns: %{organization_id: org_id}}
 
+    setup do
+      # The org level override can only be set for a feature that exists, and
+      # turbo_navigation is not part of the default seed.
+      Support.Stubs.Feature.setup_feature("turbo_navigation", state: :HIDDEN, quantity: 0)
+
+      :ok
+    end
+
     test "is true for an organization the feature is enabled for" do
       Support.Stubs.Feature.enable_feature(@org_id, :turbo_navigation)
 

--- a/front/test/front_web/views/layout_view_test.exs
+++ b/front/test/front_web/views/layout_view_test.exs
@@ -52,4 +52,26 @@ defmodule FrontWeb.LayoutViewTest do
       assert html =~ "Your Semaphore Enterprise Edition license will expire on"
     end
   end
+
+  describe "turbo_full_reload_page?/1" do
+    defp conn_with_js(js), do: %Plug.Conn{assigns: %{js: js}}
+
+    test "opts pages owning long lived client state out of Turbo rendering" do
+      assert FrontWeb.LayoutView.turbo_full_reload_page?(conn_with_js(:workflow_editor))
+      assert FrontWeb.LayoutView.turbo_full_reload_page?(conn_with_js(:logs))
+    end
+
+    test "matches the assign whether it is an atom or a string" do
+      assert FrontWeb.LayoutView.turbo_full_reload_page?(conn_with_js("workflow_editor"))
+    end
+
+    test "lets every other page render through Turbo" do
+      refute FrontWeb.LayoutView.turbo_full_reload_page?(conn_with_js(:workflow_view))
+      refute FrontWeb.LayoutView.turbo_full_reload_page?(conn_with_js(:people_page))
+    end
+
+    test "is false when the page sets no js assign" do
+      refute FrontWeb.LayoutView.turbo_full_reload_page?(%Plug.Conn{assigns: %{}})
+    end
+  end
 end

--- a/front/test/front_web/views/layout_view_test.exs
+++ b/front/test/front_web/views/layout_view_test.exs
@@ -74,4 +74,30 @@ defmodule FrontWeb.LayoutViewTest do
       refute FrontWeb.LayoutView.turbo_full_reload_page?(%Plug.Conn{assigns: %{}})
     end
   end
+
+  describe "turbo_enabled?/1" do
+    @org_id "78114608-be8a-465a-b9cd-81970fb802c6"
+
+    defp conn_with_org(org_id), do: %Plug.Conn{assigns: %{organization_id: org_id}}
+
+    test "is true for an organization the feature is enabled for" do
+      Support.Stubs.Feature.enable_feature(@org_id, :turbo_navigation)
+
+      assert FrontWeb.LayoutView.turbo_enabled?(conn_with_org(@org_id))
+    end
+
+    test "is false for an organization the feature is hidden for" do
+      Support.Stubs.Feature.disable_feature(@org_id, :turbo_navigation)
+
+      refute FrontWeb.LayoutView.turbo_enabled?(conn_with_org(@org_id))
+    end
+
+    test "is false for an organization the feature was never provisioned for" do
+      refute FrontWeb.LayoutView.turbo_enabled?(conn_with_org(@org_id))
+    end
+
+    test "is false when there is no organization on the conn" do
+      refute FrontWeb.LayoutView.turbo_enabled?(%Plug.Conn{assigns: %{}})
+    end
+  end
 end


### PR DESCRIPTION
Replaces full-page MPA navigation with Turbo Drive, behind the `:turbo_navigation` feature flag (off by default). Our organization **kvist** would love to be a tester for this functionality!

## Changes

- **CSP** — adds `<meta name="csp-nonce">`. Turbo reads the *first* such tag, which stays the originally loaded page's, so the per-request nonce keeps matching the enforced CSP header. No CSP weakening needed.
- **Bundle** — `app.js` moves from `<body>` to `<head defer>`. Turbo re-executes every body script per visit, which would re-download the 10.9 MB bundle each navigation.
- **Init lifecycle** — `App.run()` splits into `runOnce` / `runPage` / `teardownPage`. Turbo replaces the `<body>` element, so `body`-delegated handlers must re-bind while `window`/`document` ones would otherwise stack.
- **Leak fixes** — `Pollman.stop()` only set a flag while its recursive `setTimeout` kept rescheduling, and `Timer` stored no interval handle. Both leaked per visit and already affected the existing `App.run()` callers.
- **Opt-outs** — workflow editor and job logs use `turbo-visit-control: reload`; they own Monaco/ace and log-streaming state.

## Scope limits

- `Turbo.setFormMode("off")` — link navigation only. Turbo requires form responses to redirect, and many controllers re-render a 200 on validation failure.
- `turbo-cache-control: no-preview` — previews don't fire `turbo:load`, so they'd paint a page whose per-page init hadn't run. Back/forward still uses the cache.

## Testing

`lint.js`, `compile.ts`, `test.js` (468 passing) and the non-browser Elixir suite (1813 tests, 0 failures) are green. The Wallaby browser suite has not been run yet.