### PR TITLE
feat(public-api/v1alpha): implement single-tenant organization creation restriction

### DIFF
--- a/public-api/v1alpha/config/config.exs
+++ b/public-api/v1alpha/config/config.exs
@@ -28,6 +28,10 @@ config :pipelines_api,
 on_prem? = if(System.get_env("ON_PREM") == "true", do: true, else: false)
 config :pipelines_api, on_prem?: on_prem?
 
+# Single-tenant installs disable user-initiated org creation, mirroring the
+# front app's SINGLE_TENANT flag. Read by PipelinesAPI.Organizations.Onboarding.
+config :pipelines_api, single_tenant: System.get_env("SINGLE_TENANT") == "true"
+
 feature_provider =
   if on_prem? do
     {FeatureProvider.YamlProvider,

--- a/public-api/v1alpha/config/runtime.exs
+++ b/public-api/v1alpha/config/runtime.exs
@@ -29,6 +29,10 @@ end
 on_prem? = if(System.get_env("ON_PREM") == "true", do: true, else: false)
 config :pipelines_api, on_prem?: on_prem?
 
+# Single-tenant installs disable user-initiated org creation, mirroring the
+# front app's SINGLE_TENANT flag. Read by PipelinesAPI.Organizations.Onboarding.
+config :pipelines_api, single_tenant: System.get_env("SINGLE_TENANT") == "true"
+
 feature_provider =
   if on_prem? do
     {FeatureProvider.YamlProvider,

--- a/public-api/v1alpha/helm/templates/deployment.yaml
+++ b/public-api/v1alpha/helm/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: {{ .Values.logging }}
             - name: API_VERSION
               value: "v1alpha"
+            - name: SINGLE_TENANT
+              value: "true"
             - name: PPL_GRPC_URL
               valueFrom:
                 configMapKeyRef:

--- a/public-api/v1alpha/lib/pipelines_api/organizations/onboarding.ex
+++ b/public-api/v1alpha/lib/pipelines_api/organizations/onboarding.ex
@@ -16,12 +16,13 @@ defmodule PipelinesAPI.Organizations.Onboarding do
     end
   end
 
-  # Single-tenant installs disable user-initiated org creation, mirroring
-  # FrontWeb.OrganizationOnboardingController.single_tenant_check on the UI path.
+  # Single-tenant installs disable user-initiated org creation, same intent as
+  # FrontWeb.OrganizationOnboardingController.single_tenant_check. Front renders 404 to hide the
+  # onboarding page from the browser flow; this documented API returns 403 (forbidden).
   # Controlled by the SINGLE_TENANT env var (see config/config.exs + config/runtime.exs).
   defp validate_single_tenant do
     if Application.fetch_env!(:pipelines_api, :single_tenant),
-      do: {:error, {:user, "Organization creation is disabled on this instance."}},
+      do: {:error, {:forbidden, "Organization creation is disabled on this instance."}},
       else: :ok
   end
 

--- a/public-api/v1alpha/lib/pipelines_api/organizations/onboarding.ex
+++ b/public-api/v1alpha/lib/pipelines_api/organizations/onboarding.ex
@@ -9,10 +9,20 @@ defmodule PipelinesAPI.Organizations.Onboarding do
   @spec create_organization(String.t(), String.t(), String.t()) ::
           {:ok, map()} | {:error, tuple()}
   def create_organization(name, username, user_id) do
-    with :ok <- OrganizationsClient.is_valid(name, username, user_id),
+    with :ok <- validate_single_tenant(),
+         :ok <- OrganizationsClient.is_valid(name, username, user_id),
          :ok <- validate_billing(user_id) do
       OrganizationsClient.create(user_id, name, username)
     end
+  end
+
+  # Single-tenant installs disable user-initiated org creation, mirroring
+  # FrontWeb.OrganizationOnboardingController.single_tenant_check on the UI path.
+  # Controlled by the SINGLE_TENANT env var (see config/config.exs + config/runtime.exs).
+  defp validate_single_tenant do
+    if Application.fetch_env!(:pipelines_api, :single_tenant),
+      do: {:error, {:user, "Organization creation is disabled on this instance."}},
+      else: :ok
   end
 
   defp validate_billing(user_id) do

--- a/public-api/v1alpha/test/organizations/create_test.exs
+++ b/public-api/v1alpha/test/organizations/create_test.exs
@@ -148,4 +148,49 @@ defmodule PipelinesAPI.Organizations.Create.Test do
       assert Poison.decode!(conn.resp_body) == "Organization name is already taken"
     end
   end
+
+  describe "POST /organizations — single-tenant install (org creation disabled)" do
+    setup do
+      single_tenant = Application.fetch_env!(:pipelines_api, :single_tenant)
+      Application.put_env(:pipelines_api, :single_tenant, true)
+      on_exit(fn -> Application.put_env(:pipelines_api, :single_tenant, single_tenant) end)
+      :ok
+    end
+
+    test "-> 403 forbidden, and nothing downstream is called" do
+      test_pid = self()
+
+      GrpcMock.stub(OrganizationMock, :is_valid, fn _, _ ->
+        send(test_pid, :is_valid_called)
+        IsValidResponse.new(is_valid: true)
+      end)
+
+      GrpcMock.stub(BillingMock, :can_setup_organization, fn _, _ ->
+        send(test_pid, :billing_called)
+        CanSetupOrganizationResponse.new(allowed: true)
+      end)
+
+      GrpcMock.stub(OrganizationMock, :create, fn _, _ ->
+        send(test_pid, :create_called)
+
+        CreateResponse.new(
+          status:
+            InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+          organization: Organization.new(org_id: @org_id, name: "acme")
+        )
+      end)
+
+      conn = call_create(%{"username" => "acme"})
+
+      assert conn.status == 403
+
+      assert Poison.decode!(conn.resp_body) ==
+               "Organization creation is disabled on this instance."
+
+      # the single-tenant guard runs first, so nothing downstream fires
+      refute_receive :is_valid_called, 200
+      refute_receive :billing_called, 200
+      refute_receive :create_called, 200
+    end
+  end
 end

--- a/public-api/v1alpha/test/organizations/onboarding_test.exs
+++ b/public-api/v1alpha/test/organizations/onboarding_test.exs
@@ -18,6 +18,9 @@ defmodule PipelinesAPI.Organizations.Onboarding.Test do
     on_prem? = Application.fetch_env!(:pipelines_api, :on_prem?)
     on_exit(fn -> Application.put_env(:pipelines_api, :on_prem?, on_prem?) end)
 
+    single_tenant = Application.fetch_env!(:pipelines_api, :single_tenant)
+    on_exit(fn -> Application.put_env(:pipelines_api, :single_tenant, single_tenant) end)
+
     test_pid = self()
 
     # Innocuous defaults; individual tests re-stub what they exercise. Billing
@@ -114,6 +117,31 @@ defmodule PipelinesAPI.Organizations.Onboarding.Test do
       end)
 
       assert {:error, {:user, "Organization name is already taken"}} =
+               Onboarding.create_organization("Acme Org", "acme", @owner_id)
+
+      refute_receive :create_called, 200
+    end
+  end
+
+  describe "create_organization/3 on a single-tenant install (org creation disabled)" do
+    setup do
+      Application.put_env(:pipelines_api, :single_tenant, true)
+      :ok
+    end
+
+    test "returns a user error and never validates, bills, or creates" do
+      assert {:error, {:user, "Organization creation is disabled on this instance."}} =
+               Onboarding.create_organization("Acme Org", "acme", @owner_id)
+
+      # the single-tenant guard runs before is_valid/billing/create, so nothing downstream fires
+      refute_receive :billing_called, 200
+      refute_receive :create_called, 200
+    end
+
+    test "blocks regardless of on_prem? (single_tenant is the sole gate)" do
+      Application.put_env(:pipelines_api, :on_prem?, false)
+
+      assert {:error, {:user, "Organization creation is disabled on this instance."}} =
                Onboarding.create_organization("Acme Org", "acme", @owner_id)
 
       refute_receive :create_called, 200

--- a/public-api/v1alpha/test/organizations/onboarding_test.exs
+++ b/public-api/v1alpha/test/organizations/onboarding_test.exs
@@ -129,8 +129,8 @@ defmodule PipelinesAPI.Organizations.Onboarding.Test do
       :ok
     end
 
-    test "returns a user error and never validates, bills, or creates" do
-      assert {:error, {:user, "Organization creation is disabled on this instance."}} =
+    test "returns a forbidden (403) error and never validates, bills, or creates" do
+      assert {:error, {:forbidden, "Organization creation is disabled on this instance."}} =
                Onboarding.create_organization("Acme Org", "acme", @owner_id)
 
       # the single-tenant guard runs before is_valid/billing/create, so nothing downstream fires
@@ -141,7 +141,7 @@ defmodule PipelinesAPI.Organizations.Onboarding.Test do
     test "blocks regardless of on_prem? (single_tenant is the sole gate)" do
       Application.put_env(:pipelines_api, :on_prem?, false)
 
-      assert {:error, {:user, "Organization creation is disabled on this instance."}} =
+      assert {:error, {:forbidden, "Organization creation is disabled on this instance."}} =
                Onboarding.create_organization("Acme Org", "acme", @owner_id)
 
       refute_receive :create_called, 200


### PR DESCRIPTION
## 📝 Description

Disables user-initiated org creation on single-tenant installs for the v1alpha public API's `POST /api/v1alpha/organizations`, matching the intent of the front UI's `single_tenant_check` (front renders 404 to hide the page in the browser flow; this documented API returns **403 Forbidden** rather than pretend the route is gone). These installs run one org per install, but this path had no equivalent guard, so a caller could still create extra orgs, and blocking it up front also keeps the SaaS-only billing gRPC (`can_setup_organization`) from being reached where no billing service exists.

New `SINGLE_TENANT` env var → `config :pipelines_api, single_tenant` (`config/config.exs`, `config/runtime.exs`).

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
