### PR TITLE
chore(github_hooks): bump mail to 2.9.1

### DIFF
--- a/github_hooks/Gemfile.lock
+++ b/github_hooks/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap


### PR DESCRIPTION
## 📝 Description

Bumps the transitive `mail` gem to clear GHSA-mvxr-6m87-mv2q, an email address spoofing issue via malformed RFC 2047 encoded-words, flagged by bundler-audit.

| Gem | From | To | Fixes |
|---|---|---|---|
| `mail` (transitive, via actionmailer) | 2.9.0 | 2.9.1 | GHSA-mvxr-6m87-mv2q |

`mail` is loaded by the Rails actionmailer railtie, but github_hooks defines no mailers and neither sends nor parses email, so the vulnerable RFC 2047 address parser is not reachable; bumped to keep the transitive dependency patched.

Conservative `bundle lock --update mail --conservative`, so the diff is a single line (`mail 2.9.0` to `2.9.1`) and every other gem stays pinned. No Gemfile change (mail is transitive). 

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
