### PR TITLE
chore(front): ignore server-only grpc advisories in mix_audit

### DIFF
--- a/front/.mix-audit.txt
+++ b/front/.mix-audit.txt
@@ -38,3 +38,23 @@ GHSA-j9wq-vxxc-94wf
 GHSA-pj7v-xfvx-wmjq
 # CRLF / header injection via unvalidated `domain` and `path` options (domain/path not user-controlled)
 GHSA-mp55-p8c9-rfw2
+
+# --- grpc 0.5.0-beta.1 advisories, all first patched in grpc 1.0.0 ---
+# All three are server-side only, and front never starts a gRPC server: there is no `use
+# GRPC.Server` and no GRPC.Server.Supervisor anywhere in lib/. grpc is used purely as a client
+# (GRPC.Stub) against internal backend services; cowboy and grpc_gun come in transitively through
+# the grpc dep. The bump to 1.0.0 is a breaking major shared with nine other apps in the monorepo
+# (branch_hub, guard, notifications, projecthub-rest-api, secrethub, zebra, ee/audit,
+# ee/pre_flight_checks, public-api/v1alpha), so it belongs on a coordinated dep-bump branch.
+#
+# RCE / atom-table exhaustion via :erlang.binary_to_term in GRPC.Codec.Erlpack.decode/2. Needs a
+# server that explicitly registers the Erlpack codec and accepts application/grpc+erlpack; front
+# registers no codec and serves no gRPC endpoint.
+GHSA-grp7-v8xh-rj7h
+# Decompression bomb in GRPC.Compressor.Gzip.decompress/1, fired by frames arriving at a server
+# carrying grpc-encoding: gzip. front only decodes responses from internal services, which are not
+# attacker-controlled.
+GHSA-6ccx-9c9f-327w
+# Unbounded request-body accumulation in read_full_body/3
+# (lib/grpc/server/adapters/cowboy/handler.ex) — the server request read loop only.
+GHSA-q8gf-9rvj-gmgj


### PR DESCRIPTION
`mix_audit` began failing `Front: Security checks` on three `grpc` 0.5.0-beta.1 advisories published after the last green run. All three are server-side only, and `front` runs no gRPC server, so this excludes them from the scan rather than patching.

## Reachability

`front` has no `use GRPC.Server` and no `GRPC.Server.Supervisor` anywhere in `lib/` — `grpc` is used purely as a client through `GRPC.Stub` against internal backend services. `cowboy` and `grpc_gun` are pulled in transitively by the `grpc` dependency, not because anything here listens.

| Advisory | Severity | Vulnerable path | Why `front` is not exposed |
|---|---|---|---|
| GHSA-grp7-v8xh-rj7h | critical | `:erlang.binary_to_term` in `GRPC.Codec.Erlpack.decode/2` | Requires a server that explicitly registers the Erlpack codec and accepts `application/grpc+erlpack`. `front` registers no codec and serves no gRPC endpoint. |
| GHSA-6ccx-9c9f-327w | high | `GRPC.Compressor.Gzip.decompress/1` | Fires on frames arriving at a server with `grpc-encoding: gzip`. `front` only decodes responses from internal services, which are not attacker-controlled. |
| GHSA-q8gf-9rvj-gmgj | high | `read_full_body/3` in `lib/grpc/server/adapters/cowboy/handler.ex` | The server request read loop only. |

## Why not upgrade

All three are first patched in `grpc` 1.0.0. `front` pins `{:grpc, "0.5.0-beta.1", override: true}`, and nine other apps in this repo sit on the same version — `branch_hub`, `guard`, `notifications`, `projecthub-rest-api`, `secrethub`, `zebra`, `ee/audit`, `ee/pre_flight_checks` and `public-api/v1alpha`. Moving to 1.0.0 is a breaking major across all of them, so it belongs on a coordinated dependency-bump branch rather than riding along with a scanner unblock.

Each entry carries its rationale inline in `front/.mix-audit.txt`, matching the existing entries in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
