### PR TITLE
fix(guard): don't let the revoked flag gate OAuth token fetches

### DIFF
--- a/guard/lib/guard/front_repo/repo_host_account.ex
+++ b/guard/lib/guard/front_repo/repo_host_account.ex
@@ -146,29 +146,11 @@ defmodule Guard.FrontRepo.RepoHostAccount do
     end
   end
 
-  # Already revoked: don't hammer the shared OAuth consumer credential with a
-  # refresh that's known to fail. A successful fetch elsewhere self-heals
-  # this (see RepoHostAccount.update_token/4), so this short-circuit can't
-  # get permanently stuck.
-  #
-  # NOTE (tracked follow-up, not fixed here): this DOES mean an
-  # already-revoked row can no longer self-heal itself purely by being
-  # looked up - the refresh call that would flip revoked:false on success
-  # never fires once revoked:true is latched. `handle_update_repo_status`
-  # also calls `get_token` (this path) *before* `handle_validate_token`
-  # (the live-validate path that can flip revoked both ways), so live
-  # validate never runs for a short-circuited row either. Recovery for an
-  # already-revoked row is via reconnect (clears :revoked, see
-  # `id/api.ex`) or an admin `revoked=false` flip. Acceptable: post-fix, a
-  # row only reaches revoked:true on a genuine invalid_grant/401, so this
-  # is correct behavior, not a stuck state - it's still worth eventually
-  # reordering handle_update_repo_status to try live-validate first.
-  def get_github_token(%__MODULE__{revoked: true} = rha) do
-    Logger.debug("Skipping GitHub token refresh for #{rha.user_id}: account already revoked")
-
-    {:error, :revoked}
-  end
-
+  # `revoked` must never gate the fetch. The column carries a backlog of
+  # false positives from an older write path that latched it on any 4xx
+  # (transient WAF/edge 403s included); those rows still hold working
+  # credentials, so gating here turns them into hard failures. Always ask
+  # the provider and let the live response decide.
   def get_github_token(%__MODULE__{} = rha) do
     with_negative_cache(rha, fn ->
       case Guard.Api.Github.user_token(rha) do
@@ -185,12 +167,6 @@ defmodule Guard.FrontRepo.RepoHostAccount do
     end)
   end
 
-  def get_bitbucket_token(%__MODULE__{revoked: true} = rha) do
-    Logger.debug("Skipping Bitbucket token refresh for #{rha.user_id}: account already revoked")
-
-    {:error, :revoked}
-  end
-
   def get_bitbucket_token(rha) do
     with_negative_cache(rha, fn ->
       case Guard.Api.Bitbucket.user_token(rha) do
@@ -205,12 +181,6 @@ defmodule Guard.FrontRepo.RepoHostAccount do
           {:error, reason}
       end
     end)
-  end
-
-  def get_gitlab_token(%__MODULE__{revoked: true} = rha) do
-    Logger.debug("Skipping GitLab token refresh for #{rha.user_id}: account already revoked")
-
-    {:error, :revoked}
   end
 
   def get_gitlab_token(rha) do

--- a/guard/test/guard/front_repo/repo_host_account_test.exs
+++ b/guard/test/guard/front_repo/repo_host_account_test.exs
@@ -200,15 +200,31 @@ defmodule Guard.FrontRepo.RepoHostAccountTest do
       refute reloaded.revoked
     end
 
-    test "already-revoked row short-circuits: no refresh call is made", %{rha: rha} do
+    test "already-revoked row is not gated: the refresh is attempted and the token returned",
+         %{rha: rha} do
       {:ok, rha} = RepoHostAccount.update_revoke_status(rha, true)
 
       Tesla.Mock.mock_global(fn
         %{method: :post, url: "https://bitbucket.org/site/oauth2/access_token"} ->
-          flunk("refresh endpoint must not be called for an already-revoked account")
+          {:ok,
+           %Tesla.Env{status: 200, body: %{"access_token" => "fresh_token", "expires_in" => 3600}}}
+      end)
+
+      assert {:ok, {"fresh_token", _}} = RepoHostAccount.get_bitbucket_token(rha)
+    end
+
+    test "already-revoked row with a genuinely dead grant stays revoked", %{rha: rha} do
+      {:ok, rha} = RepoHostAccount.update_revoke_status(rha, true)
+
+      Tesla.Mock.mock_global(fn
+        %{method: :post, url: "https://bitbucket.org/site/oauth2/access_token"} ->
+          {:ok, %Tesla.Env{status: 400, body: %{"error" => "invalid_grant"}}}
       end)
 
       assert {:error, :revoked} = RepoHostAccount.get_bitbucket_token(rha)
+
+      reloaded = FrontRepo.get!(RepoHostAccount, rha.id)
+      assert reloaded.revoked == true
     end
 
     test "negative cache: a second call within the TTL does not hit the provider",
@@ -345,6 +361,45 @@ defmodule Guard.FrontRepo.RepoHostAccountTest do
     end
   end
 
+  describe "get_github_token/1 (revoked flag must not gate the fetch)" do
+    test "revoked:true row whose stored token still validates returns that token" do
+      {_user, rha} =
+        Support.Members.insert_user_with_github_account(revoked: true, token: "stored_token")
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 200, body: %{}}}
+
+        %{method: :post, url: "https://github.com/login/oauth/access_token"} ->
+          flunk("must not attempt a refresh while the stored token still validates")
+      end)
+
+      assert {:ok, {"stored_token", nil}} = RepoHostAccount.get_github_token(rha)
+    end
+
+    test "revoked:true row with a genuinely dead grant still returns :revoked and stays revoked" do
+      {_user, rha} =
+        Support.Members.insert_user_with_github_account(
+          revoked: true,
+          token: "dead_token",
+          refresh_token: "dead_refresh_token"
+        )
+
+      Tesla.Mock.mock_global(fn
+        %{method: :get, url: "https://api.github.com"} ->
+          {:ok, %Tesla.Env{status: 401, body: %{}}}
+
+        %{method: :post, url: "https://github.com/login/oauth/access_token"} ->
+          {:ok, %Tesla.Env{status: 400, body: %{"error" => "invalid_grant"}}}
+      end)
+
+      assert {:error, :revoked} = RepoHostAccount.get_github_token(rha)
+
+      reloaded = FrontRepo.get!(RepoHostAccount, rha.id)
+      assert reloaded.revoked == true
+    end
+  end
+
   describe "get_gitlab_token/1 (GitLab refresh - transient vs revoked)" do
     setup do
       {:ok, user} = Support.Factories.RbacUser.insert()
@@ -379,6 +434,33 @@ defmodule Guard.FrontRepo.RepoHostAccountTest do
     end
 
     test "genuine 400 invalid_grant IS a real revocation: row gets revoked", %{rha: rha} do
+      Tesla.Mock.mock_global(fn
+        %{method: :post, url: "https://gitlab.com/oauth/token"} ->
+          {:ok, %Tesla.Env{status: 400, body: %{"error" => "invalid_grant"}}}
+      end)
+
+      assert {:error, :revoked} = RepoHostAccount.get_gitlab_token(rha)
+
+      reloaded = FrontRepo.get!(RepoHostAccount, rha.id)
+      assert reloaded.revoked == true
+    end
+
+    test "already-revoked row is not gated: the refresh is attempted and the token returned",
+         %{rha: rha} do
+      {:ok, rha} = RepoHostAccount.update_revoke_status(rha, true)
+
+      Tesla.Mock.mock_global(fn
+        %{method: :post, url: "https://gitlab.com/oauth/token"} ->
+          {:ok,
+           %Tesla.Env{status: 200, body: %{"access_token" => "fresh_token", "expires_in" => 3600}}}
+      end)
+
+      assert {:ok, {"fresh_token", _}} = RepoHostAccount.get_gitlab_token(rha)
+    end
+
+    test "already-revoked row with a genuinely dead grant stays revoked", %{rha: rha} do
+      {:ok, rha} = RepoHostAccount.update_revoke_status(rha, true)
+
       Tesla.Mock.mock_global(fn
         %{method: :post, url: "https://gitlab.com/oauth/token"} ->
           {:ok, %Tesla.Env{status: 400, body: %{"error" => "invalid_grant"}}}


### PR DESCRIPTION
## What's wrong

`semaphoreio/semaphore#1193` did two separable things. The first was right and should stay: it narrowed the OAuth refresh write path so only a genuine `error=invalid_grant` latches `revoked = true`, instead of any 4xx. The second is this regression — it also started *reading* that column as a hard gate ahead of every token fetch:

```elixir
def get_github_token(%__MODULE__{revoked: true} = rha) do
  Logger.debug("Skipping GitHub token refresh for #{rha.user_id}: account already revoked")

  {:error, :revoked}   # ← returns here; no HTTP call, stored token never looked at
end
```

Before that gate existed, nothing consulted `revoked` on this path. `Guard.Api.Github.user_token/1` asks the provider whether the stored token still works and uses it when the answer is yes:

```elixir
case validate_token(repo_host_account.token) do
  {:ok, true}          -> {:ok, {repo_host_account.token, nil}}
  {:error, :transient} -> {:ok, {repo_host_account.token, nil}}
  _                    -> handle_fetch_token(repo_host_account)
end
```

GitHub OAuth-app tokens don't expire, so a falsely-flagged account answered "still valid" indefinitely and worked fine. The column was effectively write-only data.

The problem is that the pre-#1193 write path had been filling that column with false positives — it latched `revoked` on any 4xx, which includes transient edge/WAF 403s, rate limits, and our own client credentials being momentarily rejected. Those rows hold perfectly good credentials. Adding a gate that trusts the column, with no migration for the rows written before the write path was corrected, turned every one of them from *working* into a hard failure.

## Impact

A large population of accounts across all three providers began failing the moment this deployed, and is still failing. `guard` returns `NOT_FOUND` for the token, `repository_hub` fails `create_build_status`, and the user-visible symptom is commit statuses never arriving on pull requests.

The diagnostic signature is that `guard` logs the revocation error while making **no outbound provider request at all** — no refresh attempt, no validate attempt. Nothing has actually asked the provider whether these tokens are good; only our own column claims they aren't.

The inline NOTE on the removed clause reasoned that "post-fix, a row only reaches `revoked:true` on a genuine invalid_grant/401, so this is correct behavior, not a stuck state". That holds for rows written after the fix. It does not hold for the backlog written before it, and that backlog is the whole regression.

## What this changes

Removes the three `%__MODULE__{revoked: true}` clauses from `get_github_token/1`, `get_bitbucket_token/1` and `get_gitlab_token/1`. All rows go back through `with_negative_cache/2`, and the live provider response decides. Nothing else.

Removing the gate also restores a code path that can correct the column on its own: `handle_update_repo_status/2` calls `get_token/2` *before* `handle_validate_token/3`, so the gate made `get_token` fail before the live-validate that does `update_revoke_status(repo_account, not is_valid)` could ever run. With the gate gone, `RefreshRepositoryProvider` clears false-positive flags again.

## What it deliberately keeps

Every other part of #1193 is untouched and should stay — `classify_refresh_response/2` and its `:revoked` vs `:transient` split, the `refresh_token ||` fallback in `handle_ok_token_response/2`, `revoked: false` in `update_token/4`, the `:oauth_refresh_failure_cache` with its 60s TTL and `maybe_invalidate_negative_cache/2`, and `handle_token_error/3` including the exact `"Token for not found."` string that `RepositoryHub.GithubAdapter.SyncRepositoryAction` string-matches.

## Load

The gate was motivated by not hammering the shared OAuth consumer credential with refreshes known to fail. That concern is answered by the negative cache rather than the gate — the removed clauses sat *before* `with_negative_cache/2`, so revoked rows now flow through it and a failure is cached for 60s keyed on `rha.id`.

Worst case per account, per replica: 2 HTTP calls / 60s for GitHub (it always live-validates, then attempts a refresh), 1 / 60s for Bitbucket and GitLab (their expiry check is local). Cachex here is node-local, so cluster-wide is `N_replicas ×` that. Strictly better bounded than the pre-#1193 state, which had neither a gate nor a cache. A row with a nil or empty `refresh_token` returns `{:error, :revoked}` with zero outbound HTTP, and that result is cached too.

## Tests

```
mix test test/guard/front_repo/repo_host_account_test.exs --warnings-as-errors
27 tests, 0 failures

adjacent: api/{github,bitbucket,gitlab}, invitees, grpc_servers/user_server
118 tests, 0 failures

mix format --check-formatted → clean      mix credo → clean
```

New coverage, per provider: a `revoked: true` row whose stored token still validates returns that token, and a `revoked: true` row with a genuinely dead grant still returns `{:error, :revoked}` and stays flagged.

One existing test from #1193 had to be rewritten. `"already-revoked row short-circuits: no refresh call is made"` asserted the gate itself via `flunk()` on the refresh endpoint, so it cannot survive this change; it's replaced by the two behaviours above.

## Follow-ups, not in this PR

- **Pre-existing crash in `Guard.Utils.OAuth.handle_ok_token_response/2`.** For GitHub, `nil_valid` is `true`, so a 2xx refresh that omits `expires_in` passes the guard and reaches `{:ok, parsed} = DateTime.from_unix(nil, :second)` → `FunctionClauseError`. Traced to `179f067a`, not #1193, and equally reachable before the gate existed — so this PR restores rather than introduces the exposure. The same `if` also means a refreshed token expiring within 5 minutes silently persists nothing.
- **Ordering of `handle_update_repo_status/2`.** The #1193 NOTE flagged it: `get_token/2` runs before `handle_validate_token/3`, so the path that can correct the flag sits behind the path that fails on it. Worth inverting.
- **Whether `revoked` should gate anything at all.** Three call sites write this column and only one validates before writing. It's worth deciding whether it's an unreliable cache that must be live-validated before use, or a value with a single owner responsible for its accuracy.
- **The stale comment above `@oauth_refresh_failure_cache`**, which still opens "for a row that is NOT yet revoked". Left alone here to keep the diff to the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
