### PR TITLE
test(front): fix timing races in the browser suite

### DIFF
--- a/front/test/browser/people_test.exs
+++ b/front/test/browser/people_test.exs
@@ -226,9 +226,14 @@ defmodule Front.Browser.PeopleTest do
 
   defp assert_number_of_role_labels(page, expected_no) do
     role_label_css_selector = "span.f6.normal.ml1.ph1.br2"
-    role_label_elems = all(page, Query.css(role_label_css_selector))
 
-    assert length(role_label_elems) == expected_no
+    #
+    # Counting a non-blocking all/2 asserts against whatever happens to be
+    # rendered at that instant. A count query retries until the labels settle,
+    # and reports the number it did find when they never do.
+    #
+    page |> Support.Browser.assert_stable(Query.css(role_label_css_selector, count: expected_no))
+
     true
   end
 

--- a/front/test/browser/projects_settings/artifacts_test.exs
+++ b/front/test/browser/projects_settings/artifacts_test.exs
@@ -175,9 +175,46 @@ defmodule Front.Browser.ProjectSettings.ArtifactsTest do
   end
 
   defp save(page) do
+    previous = saved_policy_or_nil()
+
+    page =
+      page
+      |> execute_script("window.confirm = function(){return true;}")
+      |> click(Query.css("button", text: "Save changes"))
+
+    #
+    # click/2 returns as soon as the form is submitted, without waiting for the
+    # response. update_artifact_settings/2 re-renders rather than redirecting,
+    # so there is no flash to wait on, and the tests re-open the page straight
+    # after saving - that navigation can preempt the in-flight POST and leave
+    # the reloaded page with no policies at all. Wait for the write to land.
+    #
+    # Bounded and non-fatal on purpose: a save that legitimately writes an
+    # identical policy should not turn into a timeout here, and the real
+    # assertions still run afterwards.
+    #
+    await(fn -> saved_policy_or_nil() != previous end)
+
     page
-    |> execute_script("window.confirm = function(){return true;}")
-    |> click(Query.css("button", text: "Save changes"))
+  end
+
+  defp saved_policy_or_nil do
+    case Support.Stubs.DB.last(:artifacts_retention_policies) do
+      nil -> nil
+      row -> row.api_model
+    end
+  end
+
+  defp await(fun, attempts \\ 50)
+  defp await(_fun, 0), do: :ok
+
+  defp await(fun, attempts) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(100)
+      await(fun, attempts - 1)
+    end
   end
 
   defp add_policy(page, section_selector, pattern, age) do
@@ -193,10 +230,16 @@ defmodule Front.Browser.ProjectSettings.ArtifactsTest do
 
   defp remove_policy(page, section_selector, index: index) do
     find(page, section_selector, fn section ->
-      input_forms = all(section, Query.data("name", "input-form"))
-      input_form = Enum.at(input_forms, index)
-
-      input_form |> click(Query.data("action", "remove-retention-policy"))
+      #
+      # all/2 does not block, unlike find/3. When the policy saved just before
+      # this has not rendered yet the list comes back short, Enum.at/2 returns
+      # nil, and the nil ends up as the first argument to click/2 - which
+      # surfaces as a FunctionClauseError on execute_query/2 rather than as a
+      # missing element. Let find/3 wait for the form instead.
+      #
+      section
+      |> find(Query.data("name", "input-form", at: index, count: :any))
+      |> click(Query.data("action", "remove-retention-policy"))
     end)
   end
 

--- a/front/test/support/browser/workflow_editor.ex
+++ b/front/test/support/browser/workflow_editor.ex
@@ -56,7 +56,15 @@ defmodule Support.Browser.WorkflowEditor do
   def select_block(session, block_name) do
     query = Query.css("#workflow-editor-diagram [data-type=block]", text: block_name)
 
-    click(session, query)
+    #
+    # The editor re-renders the diagram after an edit, so the element click/2
+    # resolves can detach before the click lands. That is a stale reference
+    # rather than a missing element, so it needs a retry rather than a longer
+    # wait - Wallaby will happily find the old node again.
+    #
+    Support.Browser.retry_on_stale(fn -> click(session, query) end)
+
+    session
   end
 
   def change_agent_env_type_for_pipeline(page, type) do
@@ -97,10 +105,15 @@ defmodule Support.Browser.WorkflowEditor do
   def select_pipeline(session, name) do
     query = Query.css("#workflow-editor-diagram [data-type=pipeline]", text: name)
 
-    session
-    |> find(query, fn e ->
-      e |> Wallaby.Element.click()
+    # Same re-render race as select_block/2 above.
+    Support.Browser.retry_on_stale(fn ->
+      session
+      |> find(query, fn e ->
+        e |> Wallaby.Element.click()
+      end)
     end)
+
+    session
   end
 
   def select_first_pipeline(page) do


### PR DESCRIPTION
Fixes #1195.

The Wallaby suite dropped roughly one test per full `test/browser` run, a different one each time, while passing at file and directory scope. That made any full-suite result ambiguous — a red run couldn't be told apart from a real regression without re-running.

## Root cause

Not the one I filed in #1195. The issue said the artifacts failure was `all/2` failing to block; it isn't.

`save/1` clicks "Save changes" and returns as soon as the form is submitted. `update_artifact_settings/2` re-renders instead of redirecting, so there is no flash to wait on either. The tests then re-open the page immediately:

```elixir
|> save()

params
|> open()          # visit/2, straight away
|> remove_policy(@project_policies, index: 0)
```

That navigation can preempt the in-flight POST, so the write is lost and the reloaded page has no policies at all. `save/1` now waits for the persisted policy to change — bounded at 5s and non-fatal, so a save that legitimately writes an identical policy doesn't become a timeout, and the real assertions still run.

## Also fixed

- **`select_block/2` and `select_pipeline/2`** — the editor re-renders the diagram after an edit, so the element `click/2` resolves can detach before the click lands. Wrapped in the existing `Support.Browser.retry_on_stale/1`. A longer wait wouldn't help here; Wallaby would just re-find the same detached node. Fixed in the shared helper so every caller benefits. `select_pipeline/2` was latent, found by matching the shape rather than by a failure.
- **`remove_policy/3`** — blocking `find` instead of `Enum.at(all(...), index)`. This was not the cause, but it converts a nil `FunctionClauseError` on `execute_query/2` into a `QueryError` naming the element it wanted, which is what made the lost write visible in the first place. Kept on that basis.
- **`assert_number_of_role_labels/2`** — was counting a non-blocking `all/2`, so it asserted against whatever happened to be rendered at that instant. Now a `count:` query that retries.

## Testing

Full `test/browser` runs, 186 tests each:

| Run | Seed | `save/1` fix | Result |
|---|---|---|---|
| 1 | random | before | 186 / 0 |
| 2 | 0 | before | 186 / **1 failure** |
| 3 | 0 | after | 186 / 0 |
| 4 | 424242 | after | 186 / 0 |
| 5 | 0 | after, rebased on current main | 186 / 0 |

Runs 2 → 3 are the ones that matter: seed 0 reproduced the failure before the fix and passes after it. Runs 1, 4 and 5 add breadth, but neither of those seeds had ever failed, so on their own they'd prove little. Run 2 is also what corrected the diagnosis — the first fix changed the error without fixing the test, which is what exposed the lost write.

`mix format --check-formatted` clean. Test-only; no application code touched.