### PR TITLE
fix(front): highlight the current project in the Projects menu

### DIFF
--- a/front/assets/js/jump_to/component.js
+++ b/front/assets/js/jump_to/component.js
@@ -31,7 +31,7 @@ export class Component {
   }
 
   getResults() {
-    return _.sortBy(this.model.results, function(r) { return r.name.toLocaleLowerCase(); });
+    return this.model.orderedResults()
   }
 
   getSelectedIndex() {
@@ -43,7 +43,9 @@ export class Component {
     let node = nodes[nodes.length - 1]
     const selectedResultElement = node.querySelector(`[aria-selected="true"] a`)
 
-    window.location = selectedResultElement.href
+    if (selectedResultElement) {
+      window.location = selectedResultElement.href
+    }
   }
 
   onlySelectionChanged() {
@@ -81,8 +83,15 @@ export class Component {
     let nodes = document.querySelectorAll(this.outputDivSelector)
     let node = nodes[nodes.length - 1]
 
-    let currentlySelected = node.querySelector(`li[aria-selected="true"]`).removeAttribute("aria-selected")
-    node.querySelectorAll(`li`)[this.model.selectedIndex].setAttribute("aria-selected", true)
+    let currentlySelected = node.querySelector(`li[aria-selected="true"]`)
+    if (currentlySelected) {
+      currentlySelected.removeAttribute("aria-selected")
+    }
+
+    let nextSelected = node.querySelectorAll(`li`)[this.model.selectedIndex]
+    if (nextSelected) {
+      nextSelected.setAttribute("aria-selected", true)
+    }
   }
 
   handleFilterInput() {

--- a/front/assets/js/jump_to/jump_to.js
+++ b/front/assets/js/jump_to/jump_to.js
@@ -11,7 +11,18 @@ export class JumpTo {
     let config = {
       starred: window.InjectedDataByBackend.JumpTo.Starred,
       projects: InjectedDataByBackend.JumpTo.Projects,
-      dashboards: InjectedDataByBackend.JumpTo.Dashboards
+      dashboards: InjectedDataByBackend.JumpTo.Dashboards,
+
+      //
+      // The page the user is on, used to pre-select the matching entry.
+      // The project id is authoritative - it also covers workflow and job
+      // pages, whose URLs say nothing about the project. The path is the
+      // fallback that catches dashboards.
+      //
+      current: {
+        id: InjectedDataByBackend.JumpTo.CurrentProjectId,
+        path: window.location.pathname
+      }
     }
 
     return new JumpTo(config)
@@ -26,7 +37,7 @@ export class JumpTo {
   }
 
   setUpModelComponentEventLoop() {
-    this.model = new Model(this.config.starred, this.config.projects, this.config.dashboards)
+    this.model = new Model(this.config.starred, this.config.projects, this.config.dashboards, this.config.current)
 
     let divs = {
       results: "#jump-to-results",

--- a/front/assets/js/jump_to/model.js
+++ b/front/assets/js/jump_to/model.js
@@ -4,13 +4,14 @@ import _ from "lodash";
 import { Notice } from "../notice"
 
 export class Model {
-  constructor(starred, projects, dashboards) {
+  constructor(starred, projects, dashboards, current) {
     this.items = _.concat(this.injectType(starred, "starred"), this.injectType(projects, "project"), this.injectType(dashboards, "dashboard"))
 
+    this.current = current || {}
     this.filter = ""
     this.filtering = false
-    this.selectedIndex = 0
     this.results = this.items
+    this.selectedIndex = this.defaultSelectedIndex()
   }
 
   injectType(items, type) {
@@ -19,6 +20,46 @@ export class Model {
 
       return item
     })
+  }
+
+  //
+  // The results in the order the template lays them out: a flat alphabetical
+  // list while filtering, otherwise grouped starred → projects → dashboards.
+  //
+  // selectedIndex is an offset into this list, so anything that computes or
+  // resolves a selection has to go through here.
+  //
+  orderedResults() {
+    let sorted = _.sortBy(this.results, (r) => r.name.toLocaleLowerCase())
+
+    if(this.filtering) {
+      return sorted
+    }
+
+    let groups = _.groupBy(sorted, (item) => item.kind)
+
+    return _.concat(groups.starred || [], groups.project || [], groups.dashboard || [])
+  }
+
+  //
+  // Start the selection on the item the user is currently looking at, so that
+  // the highlight matches the page instead of always pointing at the first
+  // starred item. Falls back to the top of the list off a project page.
+  //
+  defaultSelectedIndex() {
+    let index = this.orderedResults().findIndex((item) => this.isCurrent(item))
+
+    return index === -1 ? 0 : index
+  }
+
+  isCurrent(item) {
+    if(this.current.id) {
+      return item.id === this.current.id
+    }
+
+    let path = this.current.path
+
+    return !!path && (path === item.path || path.startsWith(`${item.path}/`))
   }
 
   addStar(kind, id) {
@@ -37,7 +78,6 @@ export class Model {
   removeStar(kind, id) {
     let req = this.updateStar("unstar", id, kind)
     this.transferItem(kind, id, kind)
-    this.selectedIndex = 0
     this.changeFilter(this.filter)
 
     req.fail(() => {
@@ -58,10 +98,10 @@ export class Model {
   changeFilter(filter) {
     this.filter = filter
     this.filtering = filter.length > 0
-    this.selectedIndex = 0
     this.results = this.items.filter(item => {
       return item.name.toLowerCase().includes(filter.toLowerCase())
     })
+    this.selectedIndex = this.filtering ? 0 : this.defaultSelectedIndex()
 
     this.afterUpdate()
   }

--- a/front/assets/js/jump_to/model.spec.js
+++ b/front/assets/js/jump_to/model.spec.js
@@ -1,0 +1,106 @@
+import { expect } from "chai"
+
+import { Model } from "./model"
+
+const project = (id, name) => ({ id: id, type: "project", name: name, path: `/projects/${name}` })
+const dashboard = (id, name) => ({ id: id, type: "dashboard", name: name, path: `/dashboards/${name}` })
+
+describe("JumpTo Model", () => {
+  //
+  // Mirrors the backend payload: starred items first, then the unstarred
+  // projects and dashboards, each group already sorted alphabetically.
+  //
+  const build = (current) =>
+    new Model(
+      [project("backend-id", "Backend")],
+      [project("frontend-id", "Frontend"), project("zebra-id", "Zebra")],
+      [dashboard("dash-id", "My Dashboard")],
+      current
+    )
+
+  describe("selectedIndex", () => {
+    it("starts on the project of the current page", () => {
+      expect(build({ id: "frontend-id", path: "/projects/Frontend" }).selectedIndex).to.equal(1)
+    })
+
+    it("finds the current project on a nested page", () => {
+      const model = build({ id: "zebra-id", path: "/workflows/aa-bb-cc" })
+
+      expect(model.selectedIndex).to.equal(2)
+    })
+
+    it("falls back to the path when there is no current project id", () => {
+      const model = build({ id: null, path: "/dashboards/My Dashboard" })
+
+      expect(model.selectedIndex).to.equal(3)
+    })
+
+    it("matches a path below the item path", () => {
+      const model = build({ id: null, path: "/projects/Frontend/settings" })
+
+      expect(model.selectedIndex).to.equal(1)
+    })
+
+    it("does not match a project whose path is a prefix of the current one", () => {
+      const model = new Model([], [project("front-id", "front")], [], {
+        id: null,
+        path: "/projects/frontend"
+      })
+
+      expect(model.selectedIndex).to.equal(0)
+    })
+
+    it("selects the first item off a project page", () => {
+      expect(build({ id: null, path: "/" }).selectedIndex).to.equal(0)
+    })
+
+    it("selects the first item when nothing is passed in", () => {
+      expect(build(undefined).selectedIndex).to.equal(0)
+    })
+  })
+
+  describe("changeFilter", () => {
+    it("selects the first match while filtering", () => {
+      const model = build({ id: "frontend-id", path: "/projects/Frontend" })
+
+      model.changeFilter("z")
+
+      expect(model.selectedIndex).to.equal(0)
+      expect(model.results.map((r) => r.name)).to.deep.equal(["Zebra"])
+    })
+
+    it("returns to the current project when the filter is cleared", () => {
+      const model = build({ id: "frontend-id", path: "/projects/Frontend" })
+
+      model.changeFilter("z")
+      model.changeFilter("")
+
+      expect(model.selectedIndex).to.equal(1)
+    })
+  })
+
+  describe("orderedResults", () => {
+    it("groups starred, then projects, then dashboards", () => {
+      const model = build({})
+
+      expect(model.orderedResults().map((r) => r.name)).to.deep.equal([
+        "Backend",
+        "Frontend",
+        "Zebra",
+        "My Dashboard"
+      ])
+    })
+
+    it("is a flat alphabetical list while filtering", () => {
+      const model = build({})
+
+      model.changeFilter("a")
+
+      expect(model.orderedResults().map((r) => r.name)).to.deep.equal([
+        "Backend",
+        "My Dashboard",
+        "Zebra"
+      ])
+    })
+  })
+})

--- a/front/lib/front_web/templates/layout/_page_header.html.eex
+++ b/front/lib/front_web/templates/layout/_page_header.html.eex
@@ -3,6 +3,7 @@
   window.InjectedDataByBackend.JumpTo.Starred = <%= raw Poison.encode!(@layout_model.starred_items) %>;
   window.InjectedDataByBackend.JumpTo.Projects = <%= raw Poison.encode!(@layout_model.unstarred_projects) %>;
   window.InjectedDataByBackend.JumpTo.Dashboards = <%= raw Poison.encode!(@layout_model.unstarred_dashboards) %>;
+  window.InjectedDataByBackend.JumpTo.CurrentProjectId = <%= raw Poison.encode!(@conn.assigns[:project] && @conn.assigns.project.id) %>;
   <%= if FeatureProvider.feature_enabled?(:billing, param: @conn.assigns[:organization_id]) do %>
     <%= if FrontWeb.BillingView.with_plan_overlay?(@conn) do %>
       window.InjectedDataByBackend.InitialPlan = <%= raw FrontWeb.BillingView.initial_plan_config(@conn) %>


### PR DESCRIPTION
The green highlight in the Projects dropdown is the keyboard cursor, and `Model` hardcoded it to index `0`. It always sat on the first starred item, no matter which project you were on — and Enter jumped there. As you can see in the screenshot, i am on the Frontend project, but Backend is still highlighted: 

<img width="1148" height="338" alt="image" src="https://github.com/user-attachments/assets/73e7acb0-9848-4bc7-8de7-2fad31157cc8" />


Now the entry matching the current page is pre-selected, keyed on the project id from the conn (which also covers workflow and job pages, where the URL doesn't name the project), with a path fallback for dashboards.

Also in here: index math now goes through one `orderedResults()` helper, and two spots in `component.js` that dereferenced possibly-null nodes are guarded.

Not a Turbo regression — `selectedIndex = 0` dates back to the initial commit. It's been like this since we started using Semaphore; I just wanted to fix it while I was in here.

### Testing
`front/assets`: 485 passing, 11 of them new in `js/jump_to/model.spec.js`. The one failure (`Formatter.duration`) fails identically on a clean tree.