### PR TITLE
fix(front): audit page 500s from Resource=21 proto skew and a nil pipeline lookup

### DIFF
--- a/ee/audit/lib/internal_api/audit.pb.ex
+++ b/ee/audit/lib/internal_api/audit.pb.ex
@@ -73,6 +73,7 @@ defmodule InternalApi.Audit.Event.Resource do
           | :FlakyTests
           | :RBACRole
           | :ServiceAccount
+          | :Group
 
   field(:Project, 0)
 
@@ -115,6 +116,8 @@ defmodule InternalApi.Audit.Event.Resource do
   field(:RBACRole, 19)
 
   field(:ServiceAccount, 20)
+
+  field(:Group, 21)
 end
 
 defmodule InternalApi.Audit.Event.Operation do

--- a/ee/audit/lib/internal_api/repository_integrator.pb.ex
+++ b/ee/audit/lib/internal_api/repository_integrator.pb.ex
@@ -26,6 +26,22 @@ defmodule InternalApi.RepositoryIntegrator.IntegrationScope do
   field(:NO_CONNECTION, 2)
 end
 
+defmodule InternalApi.RepositoryIntegrator.RefreshRepositoriesResponse.SyncState do
+  @moduledoc false
+  use Protobuf, enum: true, syntax: :proto3
+  @type t :: integer | :SYNC_STATE_UNSPECIFIED | :STARTED | :ALREADY_RUNNING | :DONE | :FAILED
+
+  field(:SYNC_STATE_UNSPECIFIED, 0)
+
+  field(:STARTED, 1)
+
+  field(:ALREADY_RUNNING, 2)
+
+  field(:DONE, 3)
+
+  field(:FAILED, 4)
+end
+
 defmodule InternalApi.RepositoryIntegrator.GetTokenRequest do
   @moduledoc false
   use Protobuf, syntax: :proto3
@@ -233,6 +249,44 @@ defmodule InternalApi.RepositoryIntegrator.Repository do
   field(:description, 5, type: :string)
 end
 
+defmodule InternalApi.RepositoryIntegrator.RefreshRepositoriesRequest do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          user_id: String.t(),
+          integration_type: InternalApi.RepositoryIntegrator.IntegrationType.t(),
+          repository_slug: String.t(),
+          organization: String.t()
+        }
+
+  defstruct [:user_id, :integration_type, :repository_slug, :organization]
+
+  field(:user_id, 1, type: :string)
+  field(:integration_type, 2, type: InternalApi.RepositoryIntegrator.IntegrationType, enum: true)
+  field(:repository_slug, 3, type: :string)
+  field(:organization, 4, type: :string)
+end
+
+defmodule InternalApi.RepositoryIntegrator.RefreshRepositoriesResponse do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          sync_state: InternalApi.RepositoryIntegrator.RefreshRepositoriesResponse.SyncState.t(),
+          message: String.t()
+        }
+
+  defstruct [:sync_state, :message]
+
+  field(:sync_state, 1,
+    type: InternalApi.RepositoryIntegrator.RefreshRepositoriesResponse.SyncState,
+    enum: true
+  )
+
+  field(:message, 2, type: :string)
+end
+
 defmodule InternalApi.RepositoryIntegrator.RepositoryIntegratorService.Service do
   @moduledoc false
   use GRPC.Service, name: "InternalApi.RepositoryIntegrator.RepositoryIntegratorService"
@@ -277,6 +331,12 @@ defmodule InternalApi.RepositoryIntegrator.RepositoryIntegratorService.Service d
     :GetRepositories,
     InternalApi.RepositoryIntegrator.GetRepositoriesRequest,
     InternalApi.RepositoryIntegrator.GetRepositoriesResponse
+  )
+
+  rpc(
+    :RefreshRepositories,
+    InternalApi.RepositoryIntegrator.RefreshRepositoriesRequest,
+    InternalApi.RepositoryIntegrator.RefreshRepositoriesResponse
   )
 end
 

--- a/front/lib/front/audit/events_decorator/preloader.ex
+++ b/front/lib/front/audit/events_decorator/preloader.ex
@@ -18,7 +18,7 @@ defmodule Front.Audit.EventsDecorator.Preloader do
   def preload(events) do
     project_ids = extract_unique_id_list(events, :project_id)
     workflow_ids = extract_unique_id_list(events, :workflow_id)
-    pipeline_ids = extract_unique_id_list(events, :pipeline_id)
+    pipeline_ids = extract_unique_id_list(events, :pipeline_id) |> Enum.filter(&uuid?/1)
     job_ids = extract_unique_id_list(events, :job_id)
 
     projects = Front.Models.Project.find_many_by_ids(project_ids)
@@ -61,6 +61,22 @@ defmodule Front.Audit.EventsDecorator.Preloader do
     |> Enum.map(fn e -> Map.get(e, id_name) end)
     |> Enum.uniq()
   end
+
+  # Audit event metadata is free-form JSON, so the ids in it are not guaranteed
+  # to be well-formed. Plumber rejects the whole DescribeMany batch when a single
+  # id is not a UUID, which would cost us every pipeline link on the page.
+  defp uuid?(id) when is_binary(id) do
+    case UUID.info(id) do
+      {:ok, _} -> true
+      _ -> false
+    end
+  end
+
+  defp uuid?(_id), do: false
+
+  # A lookup can come back as nil (entity gone) or as a whole nil list when the
+  # upstream call failed for the batch. Neither is a linkable entity.
+  defp remove_nils(nil), do: []
 
   defp remove_nils(arr), do: Enum.filter(arr, fn e -> e != nil end)
 

--- a/front/lib/internal_api/audit.pb.ex
+++ b/front/lib/internal_api/audit.pb.ex
@@ -416,6 +416,7 @@ defmodule InternalApi.Audit.Event.Resource do
   field(:FlakyTests, 18)
   field(:RBACRole, 19)
   field(:ServiceAccount, 20)
+  field(:Group, 21)
 end
 
 defmodule InternalApi.Audit.Event.Operation do

--- a/front/lib/internal_api/billing.pb.ex
+++ b/front/lib/internal_api/billing.pb.ex
@@ -1644,6 +1644,52 @@ defmodule InternalApi.Billing.UpdateAddonResponse do
   defstruct []
 end
 
+defmodule InternalApi.Billing.EmailRule do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          pattern: String.t(),
+          match: integer,
+          kind: integer,
+          description: String.t(),
+          created_at: Google.Protobuf.Timestamp.t(),
+          updated_at: Google.Protobuf.Timestamp.t()
+        }
+  defstruct [:pattern, :match, :kind, :description, :created_at, :updated_at]
+
+  field(:pattern, 1, type: :string)
+  field(:match, 2, type: InternalApi.Billing.EmailRuleMatch, enum: true)
+  field(:kind, 3, type: InternalApi.Billing.EmailRuleKind, enum: true)
+  field(:description, 4, type: :string)
+  field(:created_at, 5, type: Google.Protobuf.Timestamp)
+  field(:updated_at, 6, type: Google.Protobuf.Timestamp)
+end
+
+defmodule InternalApi.Billing.ListEmailRulesRequest do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          kind: integer
+        }
+  defstruct [:kind]
+
+  field(:kind, 1, type: InternalApi.Billing.EmailRuleKind, enum: true)
+end
+
+defmodule InternalApi.Billing.ListEmailRulesResponse do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          rules: [InternalApi.Billing.EmailRule.t()]
+        }
+  defstruct [:rules]
+
+  field(:rules, 1, repeated: true, type: InternalApi.Billing.EmailRule)
+end
+
 defmodule InternalApi.Billing.PlanType do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto3
@@ -1745,6 +1791,25 @@ defmodule InternalApi.Billing.AddonGroupType do
   field(:ADDON_GROUP_TYPE_UNSPECIFIED, 0)
   field(:ADDON_GROUP_TYPE_EXCLUSIVE, 1)
   field(:ADDON_GROUP_TYPE_REGULAR, 2)
+end
+
+defmodule InternalApi.Billing.EmailRuleKind do
+  @moduledoc false
+  use Protobuf, enum: true, syntax: :proto3
+
+  field(:EMAIL_RULE_KIND_UNSPECIFIED, 0)
+  field(:EMAIL_RULE_KIND_BLOCK, 1)
+  field(:EMAIL_RULE_KIND_ALLOW, 2)
+end
+
+defmodule InternalApi.Billing.EmailRuleMatch do
+  @moduledoc false
+  use Protobuf, enum: true, syntax: :proto3
+
+  field(:EMAIL_RULE_MATCH_UNSPECIFIED, 0)
+  field(:EMAIL_RULE_MATCH_DOMAIN, 1)
+  field(:EMAIL_RULE_MATCH_ADDRESS, 2)
+  field(:EMAIL_RULE_MATCH_REGEX, 3)
 end
 
 defmodule InternalApi.Billing.BillingService.Service do
@@ -1879,6 +1944,12 @@ defmodule InternalApi.Billing.BillingService.Service do
     :UpdateAddon,
     InternalApi.Billing.UpdateAddonRequest,
     InternalApi.Billing.UpdateAddonResponse
+  )
+
+  rpc(
+    :ListEmailRules,
+    InternalApi.Billing.ListEmailRulesRequest,
+    InternalApi.Billing.ListEmailRulesResponse
   )
 end
 

--- a/front/lib/internal_api/periodic_scheduler.pb.ex
+++ b/front/lib/internal_api/periodic_scheduler.pb.ex
@@ -411,10 +411,7 @@ defmodule InternalApi.PeriodicScheduler.HistoryRequest do
 
   field(:periodic_id, 1, type: :string)
 
-  field(:cursor_type, 2,
-    type: InternalApi.PeriodicScheduler.HistoryRequest.CursorType,
-    enum: true
-  )
+  field(:cursor_type, 2, type: InternalApi.PeriodicScheduler.HistoryRequest.CursorType, enum: true)
 
   field(:cursor_value, 3, type: :uint64)
   field(:filters, 4, type: InternalApi.PeriodicScheduler.HistoryRequest.Filters)
@@ -529,10 +526,7 @@ defmodule InternalApi.PeriodicScheduler.ListKeysetRequest do
   field(:page_token, 3, type: :string)
   field(:page_size, 4, type: :int32)
 
-  field(:direction, 5,
-    type: InternalApi.PeriodicScheduler.ListKeysetRequest.Direction,
-    enum: true
-  )
+  field(:direction, 5, type: InternalApi.PeriodicScheduler.ListKeysetRequest.Direction, enum: true)
 
   field(:order, 6, type: InternalApi.PeriodicScheduler.ListOrder, enum: true)
   field(:query, 7, type: :string)
@@ -641,6 +635,84 @@ defmodule InternalApi.PeriodicScheduler.VersionResponse do
   field(:version, 1, type: :string)
 end
 
+defmodule InternalApi.PeriodicScheduler.BulkUpsertAndPruneRequest do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          organization_id: String.t(),
+          project_id: String.t(),
+          requester_id: String.t(),
+          periodics: [
+            InternalApi.PeriodicScheduler.BulkUpsertAndPruneRequest.PeriodicDefinition.t()
+          ]
+        }
+  defstruct [:organization_id, :project_id, :requester_id, :periodics]
+
+  field(:organization_id, 1, type: :string)
+  field(:project_id, 2, type: :string)
+  field(:requester_id, 3, type: :string)
+
+  field(:periodics, 4,
+    repeated: true,
+    type: InternalApi.PeriodicScheduler.BulkUpsertAndPruneRequest.PeriodicDefinition
+  )
+end
+
+defmodule InternalApi.PeriodicScheduler.BulkUpsertAndPruneRequest.PeriodicDefinition do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          name: String.t(),
+          description: String.t(),
+          recurring: boolean,
+          reference: String.t(),
+          at: String.t(),
+          pipeline_file: String.t(),
+          parameters: [InternalApi.PeriodicScheduler.Periodic.Parameter.t()],
+          state: integer
+        }
+  defstruct [
+    :id,
+    :name,
+    :description,
+    :recurring,
+    :reference,
+    :at,
+    :pipeline_file,
+    :parameters,
+    :state
+  ]
+
+  field(:id, 1, type: :string)
+  field(:name, 2, type: :string)
+  field(:description, 3, type: :string)
+  field(:recurring, 4, type: :bool)
+  field(:reference, 5, type: :string)
+  field(:at, 6, type: :string)
+  field(:pipeline_file, 7, type: :string)
+  field(:parameters, 8, repeated: true, type: InternalApi.PeriodicScheduler.Periodic.Parameter)
+  field(:state, 9, type: InternalApi.PeriodicScheduler.PersistRequest.ScheduleState, enum: true)
+end
+
+defmodule InternalApi.PeriodicScheduler.BulkUpsertAndPruneResponse do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          status: InternalApi.Status.t(),
+          upserted: [InternalApi.PeriodicScheduler.Periodic.t()],
+          deleted_ids: [String.t()]
+        }
+  defstruct [:status, :upserted, :deleted_ids]
+
+  field(:status, 1, type: InternalApi.Status)
+  field(:upserted, 2, repeated: true, type: InternalApi.PeriodicScheduler.Periodic)
+  field(:deleted_ids, 3, repeated: true, type: :string)
+end
+
 defmodule InternalApi.PeriodicScheduler.ListOrder do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto3
@@ -729,6 +801,12 @@ defmodule InternalApi.PeriodicScheduler.PeriodicService.Service do
     :Version,
     InternalApi.PeriodicScheduler.VersionRequest,
     InternalApi.PeriodicScheduler.VersionResponse
+  )
+
+  rpc(
+    :BulkUpsertAndPrune,
+    InternalApi.PeriodicScheduler.BulkUpsertAndPruneRequest,
+    InternalApi.PeriodicScheduler.BulkUpsertAndPruneResponse
   )
 end
 

--- a/front/lib/internal_api/repository.pb.ex
+++ b/front/lib/internal_api/repository.pb.ex
@@ -321,9 +321,10 @@ defmodule InternalApi.Repository.CreateBuildStatusRequest do
           status: integer,
           url: String.t(),
           description: String.t(),
-          context: String.t()
+          context: String.t(),
+          source_id: String.t()
         }
-  defstruct [:repository_id, :commit_sha, :status, :url, :description, :context]
+  defstruct [:repository_id, :commit_sha, :status, :url, :description, :context, :source_id]
 
   field(:repository_id, 1, type: :string)
   field(:commit_sha, 2, type: :string)
@@ -331,6 +332,7 @@ defmodule InternalApi.Repository.CreateBuildStatusRequest do
   field(:url, 4, type: :string)
   field(:description, 5, type: :string)
   field(:context, 6, type: :string)
+  field(:source_id, 7, type: :string)
 end
 
 defmodule InternalApi.Repository.CreateBuildStatusRequest.Status do
@@ -348,11 +350,13 @@ defmodule InternalApi.Repository.CreateBuildStatusResponse do
   use Protobuf, syntax: :proto3
 
   @type t :: %__MODULE__{
-          code: integer
+          code: integer,
+          skipped: boolean
         }
-  defstruct [:code]
+  defstruct [:code, :skipped]
 
   field(:code, 1, type: InternalApi.Repository.CreateBuildStatusResponse.Code, enum: true)
+  field(:skipped, 2, type: :bool)
 end
 
 defmodule InternalApi.Repository.CreateBuildStatusResponse.Code do

--- a/front/test/front/audit/events_decorator/preloader_test.exs
+++ b/front/test/front/audit/events_decorator/preloader_test.exs
@@ -1,0 +1,86 @@
+defmodule Front.Audit.EventsDecorator.PreloaderTest do
+  use ExUnit.Case, async: false
+
+  alias Front.Audit.EventsDecorator
+  alias InternalApi.Audit.Event.{Medium, Operation, Resource}
+  alias InternalApi.Plumber.DescribeManyResponse
+  alias InternalApi.Plumber.ResponseStatus
+  alias InternalApi.Plumber.ResponseStatus.ResponseCode
+
+  setup do
+    Support.Stubs.init()
+    Support.Stubs.build_shared_factories()
+
+    :ok
+  end
+
+  defp event(opts) do
+    %{
+      resource: Resource.value(:Pipeline),
+      operation: Operation.value(:Added),
+      medium: Medium.value(:API),
+      user_id: UUID.uuid4(),
+      username: "shiroyasha",
+      ip_address: "189.0.12.2",
+      operation_id: UUID.uuid4(),
+      timestamp: Google.Protobuf.Timestamp.new(seconds: 1_522_754_259),
+      resource_id: UUID.uuid4(),
+      resource_name: "my-pipeline",
+      description: "Added a pipeline",
+      metadata: Poison.encode!(%{})
+    }
+    |> Map.merge(Map.new(opts))
+    |> InternalApi.Audit.Event.new()
+  end
+
+  defp stub_describe_many_bad_param do
+    GrpcMock.stub(PipelineMock, :describe_many, fn _req, _stream ->
+      DescribeManyResponse.new(
+        response_status:
+          ResponseStatus.new(
+            code: ResponseCode.value(:BAD_PARAM),
+            message: "Pipeline with id: 0e0e0e0e-0e0e-4e0e-8e0e-0e0e0e0e0e0e not found"
+          )
+      )
+    end)
+  end
+
+  test "renders events when plumber rejects the whole DescribeMany batch" do
+    stub_describe_many_bad_param()
+
+    events = [event(metadata: Poison.encode!(%{"pipeline_id" => UUID.uuid4()}))]
+
+    assert [decorated] = EventsDecorator.decorate(events)
+    assert decorated.has_pipeline == false
+    assert decorated.pipeline == nil
+  end
+
+  test "does not send malformed pipeline ids to plumber" do
+    GrpcMock.stub(PipelineMock, :describe_many, fn req, _stream ->
+      assert req.ppl_ids == []
+
+      DescribeManyResponse.new(
+        response_status: ResponseStatus.new(code: ResponseCode.value(:OK)),
+        pipelines: []
+      )
+    end)
+
+    events = [event(metadata: Poison.encode!(%{"pipeline_id" => ""}))]
+
+    assert [decorated] = EventsDecorator.decorate(events)
+    assert decorated.has_pipeline == false
+  end
+
+  test "decorates a Group resource event" do
+    events = [
+      event(
+        resource: Resource.value(:Group),
+        operation: Operation.value(:Added),
+        resource_name: "backend-team"
+      )
+    ]
+
+    assert [decorated] = EventsDecorator.decorate(events)
+    assert decorated.resource == :Group
+  end
+end


### PR DESCRIPTION
## 📝 Description

`/audit` returned 500 and `/audit/csv` silently returned a header-only CSV with HTTP 200, for any org with RBAC group events or an audit event referencing a pipeline that no longer resolves.

There were two independent causes. Front and ee/audit were missing the audit `Resource.Group = 21` enum value that `public-api/v1alpha` already emits, and `Preloader.remove_nils/1` couldn't handle the nil that `Pipeline.find_many/2` returns when plumber rejects a `DescribeMany` batch.

This regenerates the vendored `internal_api` protos for both services and makes the preloader tolerate the nil while filtering metadata `pipeline_id`s to valid UUIDs. `Pipeline.find_many/2`'s contract is left alone, since its other callers already absorb the nil themselves.

Added `preloader_test.exs`, which reproduces both crashes and fails on `main`. Verified on preprod before and after deploying both images: `/audit` went 500 → 200, CSV export went 112 bytes → 55 KB, and create/modify/delete of a group via `/api/v1alpha/groups` now renders correctly.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
