### PR TITLE
feat(front): render job logs through Turbo Drive

### DIFF
--- a/front/assets/js/app.js
+++ b/front/assets/js/app.js
@@ -561,6 +561,7 @@ export var App = {
     Pollman.stop();
     Timer.stop();
     DiagramDrag.stop();
+    JobLogs.stop();
     unmountIslands();
 
     if (window.FaviconUpdater) {

--- a/front/assets/js/job_logs/events.js
+++ b/front/assets/js/job_logs/events.js
@@ -4,6 +4,19 @@ let running = true;
 let items = [];
 
 export var Events = {
+  //
+  // Returns the module to its initial state.
+  //
+  // Both `running` and `items` are module level, so under Turbo Drive they
+  // survive the visit. Without this, arriving at a second job page would
+  // inherit `running == false` from the previous finished job, and Render.tick
+  // would exit immediately and never draw a line.
+  //
+  reset() {
+    running = true
+    items = []
+  },
+
   stop() {
     running = false
   },

--- a/front/assets/js/job_logs/events_fetcher.js
+++ b/front/assets/js/job_logs/events_fetcher.js
@@ -1,8 +1,15 @@
 import { State } from "./state"
 import { Events } from "./events"
 
+// Thrown to unwind the fetch chain when the loop is stopped mid-flight.
+class StoppedError extends Error {}
+
 export var EventsFetcher = {
   init(options) {
+    // Drop a loop left over from a previous job page before starting a new one.
+    this.stop()
+
+    this.stopped = false
     this.next = 0
     this.consecutiveErrorsCounter = 0
     this.maxConsecutiveErrors = options.maxConsecutiveErrors
@@ -14,9 +21,34 @@ export var EventsFetcher = {
     State.set("fetching", "in_progress")
   },
 
+  //
+  // Cancels the loop.
+  //
+  // The next tick is scheduled from inside the promise chain, so clearing the
+  // pending timeout is not enough on its own - a fetch that is already in
+  // flight would resolve afterwards and schedule another one. The flag makes
+  // those continuations return instead.
+  //
+  stop() {
+    this.stopped = true
+
+    clearTimeout(this.timeout)
+    this.timeout = null
+  },
+
+  scheduleTick(interval) {
+    if (this.stopped) { return }
+
+    this.timeout = setTimeout(this.tick.bind(this), interval)
+  },
+
   tick() {
+    if (this.stopped) { return }
+
     fetch(this.fetchUrl(), {credentials: 'same-origin', headers: this.fetchHeaders()})
     .then((response) => {
+      if (this.stopped) { throw new StoppedError() }
+
       if (response.status == 200) {
         return response.json()
       }
@@ -33,16 +65,18 @@ export var EventsFetcher = {
         this.finish()
         this.afterFinish()
       } else if (data.events.length > 0) {
-        setTimeout(this.tick.bind(this), this.regularInterval)
+        this.scheduleTick(this.regularInterval)
       } else if (data.events.length == 0) {
-        setTimeout(this.tick.bind(this), this.backOffInterval)
+        this.scheduleTick(this.backOffInterval)
       }
     })
-    .catch(() => {
+    .catch((error) => {
+      if (this.stopped || error instanceof StoppedError) { return }
+
       this.consecutiveErrorsCounter += 1
 
       if (this.consecutiveErrorsCounter < this.maxConsecutiveErrors) {
-        setTimeout(this.tick.bind(this), this.backOffInterval)
+        this.scheduleTick(this.backOffInterval)
       } else {
         this.setFailureState()
         this.afterFinish()

--- a/front/assets/js/job_logs/highlight.js
+++ b/front/assets/js/job_logs/highlight.js
@@ -5,6 +5,13 @@ let highlighted = false
 let last_selected_line = null
 
 export var Highlight = {
+  disconnect() {
+    if (this.observer) {
+      this.observer.disconnect()
+      this.observer = null
+    }
+  },
+
   init(containerSelector) {
     const container = document.querySelector(containerSelector)
     const config = { childList: true, subtree: true }
@@ -21,9 +28,13 @@ export var Highlight = {
       }
     }.bind(this);
 
-    const observer = new MutationObserver(callback);
+    // Kept on the module so the Turbo teardown can disconnect it. The observed
+    // node lives in the body and goes away with it, but an observer nothing
+    // holds a reference to can never be stopped explicitly.
+    this.disconnect()
+    this.observer = new MutationObserver(callback);
 
-    observer.observe(container, config);
+    this.observer.observe(container, config);
   },
 
   highlightLines() {

--- a/front/assets/js/job_logs/live.js
+++ b/front/assets/js/job_logs/live.js
@@ -2,6 +2,13 @@ import { State } from "./state"
 import { Scroll } from "./scroll"
 
 export var Live = {
+  disconnect() {
+    if (this.observer) {
+      this.observer.disconnect()
+      this.observer = null
+    }
+  },
+
   init(containerSelector) {
     const container = document.querySelector(containerSelector)
     const config = { childList: true, subtree: true }
@@ -18,9 +25,13 @@ export var Live = {
       }
     };
 
-    const observer = new MutationObserver(callback);
+    // Kept on the module so the Turbo teardown can disconnect it. The observed
+    // node lives in the body and goes away with it, but an observer nothing
+    // holds a reference to can never be stopped explicitly.
+    this.disconnect()
+    this.observer = new MutationObserver(callback);
 
-    observer.observe(container, config);
+    this.observer.observe(container, config);
 
     // https://stackoverflow.com/a/31223774/3887547
     let lastScrollTop = 0;

--- a/front/assets/js/job_logs/logs.js
+++ b/front/assets/js/job_logs/logs.js
@@ -15,6 +15,7 @@ import { LiveSettings } from "./components/live_settings"
 import { EventsFetcher } from "./events_fetcher"
 import { Render } from "./render"
 import { SleepDetector } from "../sleep_detector"
+import { Events } from "./events"
 
 export class JobLogs {
   static init() {
@@ -29,12 +30,35 @@ export class JobLogs {
     return new JobLogs(config)
   }
 
+  //
+  // Releases everything this page owns, so a Turbo visit does not leave a log
+  // stream, a render loop or a sleep detector running against a body that has
+  // been swapped out. The click handlers are delegated off document.body,
+  // which Turbo replaces, so they go away on their own.
+  //
+  static stop() {
+    if (JobLogs.pendingTimeout) {
+      clearTimeout(JobLogs.pendingTimeout)
+      JobLogs.pendingTimeout = null
+    }
+
+    EventsFetcher.stop()
+    Render.stop()
+    SleepDetector.stop()
+    Live.disconnect()
+    Highlight.disconnect()
+    Timer.stop()
+    Events.reset()
+  }
+
   constructor(config) {
     this.slept = false
     this.config = config
     this.startTime = performance.now();
     this.metricTags = [];
 
+    // Module level singletons that outlive the page under Turbo.
+    JobLogs.stop()
     State.init(config.logState)
 
     SleepDetector.init(() => {
@@ -47,7 +71,7 @@ export class JobLogs {
 
   start() {
     if (State.get("state") == "pending") {
-      setTimeout(this.start.bind(this), 5000)
+      JobLogs.pendingTimeout = setTimeout(this.start.bind(this), 5000)
       return
     }
 

--- a/front/assets/js/job_logs/render.js
+++ b/front/assets/js/job_logs/render.js
@@ -15,18 +15,36 @@ export var Render = {
   },
 
   start(options) {
+    // Drop a loop left over from a previous job page before starting a new one.
+    this.stop();
+
+    this.stopped = false;
     this.init(options);
     this.tick();
   },
 
+  //
+  // Cancels the render loop. tick() reschedules itself at 0ms while events are
+  // still arriving, so under Turbo this would otherwise keep spinning against
+  // a detached container for as long as the tab stayed open.
+  //
+  stop() {
+    this.stopped = true;
+
+    clearTimeout(this.timeout);
+    this.timeout = null;
+  },
+
   tick() {
+    if (this.stopped) { return }
+
     let events = Events.getAllItems();
     if(events.length > 0) {
       this.process(events)
     }
 
     if(Events.isRunning() || Events.notEmpty()) {
-      setTimeout(this.tick.bind(this), 0);
+      this.timeout = setTimeout(this.tick.bind(this), 0);
     } else {
       this.afterFinish()
     }

--- a/front/assets/js/job_logs/teardown.spec.js
+++ b/front/assets/js/job_logs/teardown.spec.js
@@ -1,0 +1,109 @@
+import { expect } from "chai"
+import { Events } from "./events"
+import { EventsFetcher } from "./events_fetcher"
+import { Render } from "./render"
+import { SleepDetector } from "../sleep_detector"
+
+global.fetch = require("node-fetch")
+
+//
+// Turbo keeps window and document alive across visits, so everything the job
+// log page starts has to be stoppable. These cover the contract JobLogs.stop
+// depends on, one module at a time.
+//
+describe("job log teardown", () => {
+  describe("Events.reset", () => {
+    it("clears items left over from the previous job", () => {
+      Events.addItems([{ event: "one" }, { event: "two" }])
+
+      Events.reset()
+
+      expect(Events.size()).to.equal(0)
+    })
+
+    it("marks the stream running again after a finished job stopped it", () => {
+      Events.stop()
+      expect(Events.isRunning()).to.equal(false)
+
+      Events.reset()
+
+      expect(Events.isRunning()).to.equal(true)
+    })
+  })
+
+  describe("EventsFetcher.stop", () => {
+    it("stops the loop from scheduling another tick", () => {
+      EventsFetcher.init({
+        url: "localhost",
+        maxConsecutiveErrors: 5,
+        backOffInterval: 0,
+        regularInterval: 0
+      })
+
+      EventsFetcher.stop()
+      EventsFetcher.scheduleTick(0)
+
+      expect(EventsFetcher.timeout).to.equal(null)
+    })
+
+    it("makes tick a no-op once stopped", () => {
+      EventsFetcher.init({
+        url: "localhost",
+        maxConsecutiveErrors: 5,
+        backOffInterval: 0,
+        regularInterval: 0
+      })
+      EventsFetcher.stop()
+
+      // Would otherwise start a fetch and reschedule itself.
+      expect(() => EventsFetcher.tick()).to.not.throw()
+      expect(EventsFetcher.timeout).to.equal(null)
+    })
+
+    it("clears the stopped flag when a new job page initialises", () => {
+      EventsFetcher.stop()
+      expect(EventsFetcher.stopped).to.equal(true)
+
+      EventsFetcher.init({
+        url: "localhost",
+        maxConsecutiveErrors: 5,
+        backOffInterval: 0,
+        regularInterval: 0
+      })
+
+      expect(EventsFetcher.stopped).to.equal(false)
+    })
+  })
+
+  describe("Render.stop", () => {
+    it("stops the render loop rescheduling itself", () => {
+      Render.init({ div: "#job-log", isJobFinished: true })
+      Render.stop()
+
+      Render.tick()
+
+      expect(Render.timeout).to.equal(null)
+    })
+  })
+
+  describe("SleepDetector.stop", () => {
+    it("clears the interval", () => {
+      SleepDetector.init(() => {})
+      expect(SleepDetector.ticker).to.not.equal(null)
+
+      SleepDetector.stop()
+
+      expect(SleepDetector.ticker).to.equal(null)
+    })
+
+    it("does not stack an interval when a second page initialises", () => {
+      SleepDetector.init(() => {})
+      const first = SleepDetector.ticker
+
+      SleepDetector.init(() => {})
+
+      expect(SleepDetector.ticker).to.not.equal(first)
+      SleepDetector.stop()
+    })
+  })
+})

--- a/front/assets/js/sleep_detector.js
+++ b/front/assets/js/sleep_detector.js
@@ -1,13 +1,23 @@
 export var SleepDetector = {
   init: function(callback) {
+    // Drop the interval from a previous page before starting another one.
+    this.stop()
+
     this.callback = callback
     this.lastTime = this.getTime()
 
     this.tick()
   },
 
+  stop: function() {
+    if (this.ticker) {
+      clearInterval(this.ticker)
+      this.ticker = null
+    }
+  },
+
   tick: function() {
-    setInterval(function() {
+    this.ticker = setInterval(function() {
       var currentTime = this.getTime()
 
       if(this.justWokeUp()) {

--- a/front/lib/front_web/views/layout_view.ex
+++ b/front/lib/front_web/views/layout_view.ex
@@ -3,12 +3,16 @@ defmodule FrontWeb.LayoutView do
   alias Front.Async
 
   #
-  # Pages that own long lived client state - Monaco and ace in the workflow
-  # editor, the streaming log viewer on a job - and would have to tear it all
-  # down to survive a Turbo render. They are cheap to opt out of, so navigating
-  # to one performs a normal full page load instead.
+  # Pages that own long lived client state and would have to tear it all down to
+  # survive a Turbo render. The workflow editor holds Monaco and ace, which have
+  # no teardown path here, so navigating to it performs a normal full page load.
   #
-  @turbo_full_reload_pages ~w(workflow_editor logs)
+  # The job log page used to be listed here too. It now releases its log stream,
+  # render loop and sleep detector from JobLogs.stop/0, so it renders through
+  # Turbo like any other page - which matters because reaching a job from the
+  # workflow graph is one of the most travelled paths in the app.
+  #
+  @turbo_full_reload_pages ~w(workflow_editor)
 
   def turbo_full_reload_page?(conn) do
     to_string(conn.assigns[:js]) in @turbo_full_reload_pages

--- a/front/test/front_web/views/layout_view_test.exs
+++ b/front/test/front_web/views/layout_view_test.exs
@@ -58,11 +58,14 @@ defmodule FrontWeb.LayoutViewTest do
 
     test "opts pages owning long lived client state out of Turbo rendering" do
       assert FrontWeb.LayoutView.turbo_full_reload_page?(conn_with_js(:workflow_editor))
-      assert FrontWeb.LayoutView.turbo_full_reload_page?(conn_with_js(:logs))
     end
 
     test "matches the assign whether it is an atom or a string" do
       assert FrontWeb.LayoutView.turbo_full_reload_page?(conn_with_js("workflow_editor"))
+    end
+
+    test "lets the job log page render through Turbo now that it tears itself down" do
+      refute FrontWeb.LayoutView.turbo_full_reload_page?(conn_with_js(:logs))
     end
 
     test "lets every other page render through Turbo" do


### PR DESCRIPTION
Follow-up to #1187. Clicking a job in the workflow graph was still a full page load, because the job log page opts out via `turbo-visit-control: reload`. That's one of the most common navigations we make day to day, so it's a nice one to have.

The opt-out was right at the time — the page owns a log stream and had no teardown path. This adds one.

**What it releases on teardown:** the log stream poll loop (`EventsFetcher`), the render loop (`Render`), the sleep detector, and the pending-job retry. `Live`/`Highlight` observers get disconnected too. All are module-level and previously kept running after you navigated away.

**One correctness fix:** `Events.running` is module-level and `stop()` never sets it back. Once this page renders through Turbo, going from a finished job to a running one would leave it `false`, `Render.tick` would exit immediately, and the logs would never render.

**Testing:** JS 483 passing (8 new specs on the teardown contract), tsc and lint clean, `layout_view_test` 12/0, browser suite 186/0.

Caveat worth stating: `ui_turbo_navigation` isn't provisioned in the test environment, so Turbo never starts during the suite and none of this is covered end to end. kvist has the flag on, so we'll exercise it in production.