### PR TITLE
fix(zebra): refresh feature flags for very new orgs before resolving job time limits

### DIFF
--- a/zebra/lib/zebra/apis/internal_task_api/schedule.ex
+++ b/zebra/lib/zebra/apis/internal_task_api/schedule.ex
@@ -11,6 +11,11 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
   @default_job_execution_time_limit 24 * 60 * 60
   # in minutes
   @max_job_execution_time_limit 24 * 60
+  # A just-created org's feature flags can be missing from a per-pod feature
+  # cache primed before provisioning finished (e.g. billing enabling a
+  # free-tier cap). Only orgs younger than this get a forced fresh feature
+  # read; see find_feature_based_job_time_limits/2.
+  @fresh_org_window_seconds 15 * 60
 
   @spec schedule(InternalApi.Task.Task.t()) :: {:ok, Zebra.Models.Task.t()}
   def schedule(req) do
@@ -358,14 +363,26 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
   end
 
   defp find_max_and_default_job_time_limits(org_id) do
-    if org_verified?(org_id) do
+    org = load_org(org_id)
+
+    if org_verified?(org) do
       {@max_job_execution_time_limit, @default_job_execution_time_limit}
     else
-      find_feature_based_job_time_limits(org_id)
+      find_feature_based_job_time_limits(org_id, org)
     end
   end
 
-  defp find_feature_based_job_time_limits(org_id) do
+  defp find_feature_based_job_time_limits(org_id, org) do
+    if fresh_org?(org) do
+      # Force one fresh read so a feature enabled early in the org's life
+      # (e.g. the free-tier job time limit) isn't hidden behind a cache
+      # entry primed before it was set. This only changes where the value
+      # comes from, never what an absent feature resolves to below: if the
+      # fresh fetch itself fails, it isn't cached, so the reads that follow
+      # behave exactly as they would have without this call.
+      FeatureProvider.list_features(reload: true, param: org_id)
+    end
+
     if FeatureProvider.feature_enabled?(:max_job_execution_time_limit, param: org_id) do
       max_limit = FeatureProvider.feature_quota(:max_job_execution_time_limit, param: org_id)
 
@@ -382,11 +399,22 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
     end
   end
 
-  defp org_verified?(org_id) do
+  defp load_org(org_id) do
     case Zebra.Workers.Scheduler.Org.load(org_id) do
-      {:ok, org} -> org.verified
-      _ -> false
+      {:ok, org} -> org
+      _ -> nil
     end
+  end
+
+  defp org_verified?(nil), do: false
+  defp org_verified?(org), do: org.verified
+
+  defp fresh_org?(nil), do: false
+  defp fresh_org?(%Zebra.Workers.Scheduler.Org{created_at: nil}), do: false
+
+  defp fresh_org?(%Zebra.Workers.Scheduler.Org{created_at: %{seconds: created_at_seconds}}) do
+    DateTime.utc_now() |> DateTime.to_unix() |> Kernel.-(created_at_seconds) <
+      @fresh_org_window_seconds
   end
 
   def encode_fail_fast_strategy(strategy) do

--- a/zebra/lib/zebra/apis/internal_task_api/schedule.ex
+++ b/zebra/lib/zebra/apis/internal_task_api/schedule.ex
@@ -16,6 +16,10 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
   # free-tier cap). Only orgs younger than this get a forced fresh feature
   # read; see find_feature_based_job_time_limits/2.
   @fresh_org_window_seconds 15 * 60
+  # TTL (ms) for the per-org "already reloaded" marker in maybe_reload_features/1.
+  # Matches the fresh-org window: once an org's forced reload has been
+  # attempted, it stays gated for the rest of that org's youth.
+  @fresh_org_reload_marker_ttl_ms @fresh_org_window_seconds * 1000
 
   @spec schedule(InternalApi.Task.Task.t()) :: {:ok, Zebra.Models.Task.t()}
   def schedule(req) do
@@ -380,7 +384,7 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
       # comes from, never what an absent feature resolves to below: if the
       # fresh fetch itself fails, it isn't cached, so the reads that follow
       # behave exactly as they would have without this call.
-      FeatureProvider.list_features(reload: true, param: org_id)
+      maybe_reload_features(org_id)
     end
 
     if FeatureProvider.feature_enabled?(:max_job_execution_time_limit, param: org_id) do
@@ -397,6 +401,36 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
     else
       {@max_job_execution_time_limit, @default_job_execution_time_limit}
     end
+  end
+
+  # `configure_execution_time_limit/2` runs once per job, inside the
+  # scheduling transaction. Without gating, a fresh org fanning out N jobs
+  # (one request or a burst of requests within the fresh-org window) would
+  # fire N synchronous FeatureProvider.list_features(reload: true, ...)
+  # calls -- each a real gRPC round trip held open inside that job's DB
+  # transaction, since `reload: true` never consults the cache first. Force
+  # at most one reload per org per fresh-org window instead, via a marker in
+  # the same Zebra.Cache the org load already uses.
+  #
+  # The marker is set on *attempt*, not on success: even if the reload
+  # itself errors, the marker still gets written so the rest of the burst
+  # doesn't retry it job-by-job. That means a reload failure leaves the org
+  # on today's default (24h) for the remainder of the window -- exactly
+  # today's pre-fix behavior -- and self-heals on the next window. A
+  # handful of jobs racing the first marker write may each trigger a reload
+  # before the marker lands; that's acceptable, the goal is killing the
+  # N-scale amplifier, not exactly-once semantics, so no locking here.
+  defp maybe_reload_features(org_id) do
+    Zebra.Cache.fetch!(
+      "feature-reload-done-#{org_id}",
+      @fresh_org_reload_marker_ttl_ms,
+      fn ->
+        FeatureProvider.list_features(reload: true, param: org_id)
+        {:commit, true}
+      end
+    )
+
+    :ok
   end
 
   defp load_org(org_id) do
@@ -416,6 +450,12 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
     DateTime.utc_now() |> DateTime.to_unix() |> Kernel.-(created_at_seconds) <
       @fresh_org_window_seconds
   end
+
+  # Defense-in-depth: the real proto's created_at is always either nil or a
+  # %Google.Protobuf.Timestamp{} (both handled above). A catch-all keeps any
+  # unexpected shape from raising a FunctionClauseError inside the schedule
+  # transaction.
+  defp fresh_org?(_), do: false
 
   def encode_fail_fast_strategy(strategy) do
     alias InternalApi.Task.ScheduleRequest.FailFast, as: FF

--- a/zebra/lib/zebra/apis/internal_task_api/schedule.ex
+++ b/zebra/lib/zebra/apis/internal_task_api/schedule.ex
@@ -11,15 +11,16 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
   @default_job_execution_time_limit 24 * 60 * 60
   # in minutes
   @max_job_execution_time_limit 24 * 60
-  # A just-created org's feature flags can be missing from a per-pod feature
-  # cache primed before provisioning finished (e.g. billing enabling a
-  # free-tier cap). Only orgs younger than this get a forced fresh feature
-  # read; see find_feature_based_job_time_limits/2.
+  # How long after creation an org is still too young to have had its job time
+  # limit lifted, so a feature that is visible but not enabled reads as "not
+  # provisioned yet"; see unprovisioned_org_job_time_limits/2.
   @fresh_org_window_seconds 15 * 60
-  # TTL (ms) for the per-org "already reloaded" marker in maybe_reload_features/1.
-  # Matches the fresh-org window: once an org's forced reload has been
-  # attempted, it stays gated for the rest of that org's youth.
-  @fresh_org_reload_marker_ttl_ms @fresh_org_window_seconds * 1000
+  # Tolerated clock skew between this pod and the organization API.
+  @clock_skew_tolerance_seconds 60
+  # In minutes. Lower bound for unprovisioned_org_job_time_limits/2: the quota
+  # it reads is configured in another service, and must not be able to shorten
+  # jobs below this.
+  @min_unprovisioned_org_job_time_limit 30
 
   @spec schedule(InternalApi.Task.Task.t()) :: {:ok, Zebra.Models.Task.t()}
   def schedule(req) do
@@ -53,6 +54,13 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
           {:ok, Zebra.Models.Task.t()} | {:error, :invalid_argument, String.t()}
   def create_task(req) do
     Watchman.benchmark("internal_task_api.schedule.create_task.duration", fn ->
+      # Resolved once per task, before the transaction opens: the job time
+      # limits are a property of the organization, identical for every job in
+      # the task, and resolving them can reach the organization and feature
+      # APIs over gRPC. Doing it per job inside Repo.transaction/1 would hold a
+      # DB connection open across that I/O.
+      time_limits = find_max_and_default_job_time_limits(req.org_id)
+
       result =
         Repo.transaction(fn ->
           copy_ctx = resolve_copy_context(req)
@@ -62,7 +70,7 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
           req.jobs
           |> Enum.with_index()
           |> Enum.each(fn {j, index} ->
-            create_task_job(task, req, j, index, copy_ctx)
+            create_task_job(task, req, j, index, copy_ctx, time_limits)
           end)
 
           task
@@ -120,10 +128,10 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
   end
 
   # Run vs copy decision for a single job spec, executed inside the transaction.
-  defp create_task_job(task, req, job_req, job_index, copy_ctx) do
+  defp create_task_job(task, req, job_req, job_index, copy_ctx, time_limits) do
     case classify_job(job_req, req, copy_ctx) do
       :run ->
-        run_job(task.id, req, job_req, job_index)
+        run_job(task.id, req, job_req, job_index, time_limits)
 
       {:copy, member} ->
         case Job.create_copy(member, task.id) do
@@ -139,8 +147,8 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
     end
   end
 
-  defp run_job(task_id, req, job_req, job_index) do
-    case create_job(task_id, req, job_req, job_index) do
+  defp run_job(task_id, req, job_req, job_index, time_limits) do
+    case create_job(task_id, req, job_req, job_index, time_limits) do
       {:ok, job} ->
         onprem_metrics(job)
 
@@ -289,7 +297,7 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
   defp present?(""), do: false
   defp present?(_), do: true
 
-  defp create_job(task_id, req, job_req, job_index) do
+  defp create_job(task_id, req, job_req, job_index, time_limits) do
     Watchman.benchmark("internal_task_api.schedule.create_job.duration", fn ->
       Zebra.Models.Job.create(
         name: job_req.name,
@@ -301,8 +309,7 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
         repository_id: req.repository_id,
         machine_type: job_req.agent.machine.type,
         machine_os_image: job_req.agent.machine.os_image,
-        execution_time_limit:
-          configure_execution_time_limit(req.org_id, job_req.execution_time_limit),
+        execution_time_limit: apply_job_time_limits(time_limits, job_req.execution_time_limit),
         priority: valid_priority(job_req.priority),
         spec:
           Spec.new(
@@ -357,12 +364,16 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
 
   # value of execution_time_limit is received in minutes and it is stored in seconds
   def configure_execution_time_limit(org_id, req_value) do
-    {max_job_time_limit, deafult_job_time_limit} = find_max_and_default_job_time_limits(org_id)
+    org_id
+    |> find_max_and_default_job_time_limits()
+    |> apply_job_time_limits(req_value)
+  end
 
+  defp apply_job_time_limits({max_job_time_limit, default_job_time_limit}, req_value) do
     if req_value > 0 and req_value <= max_job_time_limit do
       req_value * 60
     else
-      deafult_job_time_limit
+      default_job_time_limit
     end
   end
 
@@ -370,68 +381,54 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
     org = load_org(org_id)
 
     if org_verified?(org) do
-      {@max_job_execution_time_limit, @default_job_execution_time_limit}
+      unlimited_job_time_limits()
     else
       find_feature_based_job_time_limits(org_id, org)
     end
   end
 
+  # One read of the feature, not two: `feature_enabled?/2` followed by
+  # `feature_quota/2` consults the cache twice, and an entry expiring between
+  # them resolves to {0, 0} -- a job written with execution_time_limit: 0.
   defp find_feature_based_job_time_limits(org_id, org) do
-    if fresh_org?(org) do
-      # Force one fresh read so a feature enabled early in the org's life
-      # (e.g. the free-tier job time limit) isn't hidden behind a cache
-      # entry primed before it was set. This only changes where the value
-      # comes from, never what an absent feature resolves to below: if the
-      # fresh fetch itself fails, it isn't cached, so the reads that follow
-      # behave exactly as they would have without this call.
-      maybe_reload_features(org_id)
+    case FeatureProvider.find_feature(:max_job_execution_time_limit, param: org_id) do
+      # A limit provisioned for this org specifically.
+      {:ok, %FeatureProvider.Feature{state: :enabled, quantity: quota}}
+      when is_integer(quota) and quota > 0 ->
+        {quota, min(quota * 60, @default_job_execution_time_limit)}
+
+      # Not enabled, yet the response still carries a quota.
+      {:ok, %FeatureProvider.Feature{quantity: quota}} when is_integer(quota) and quota > 0 ->
+        unprovisioned_org_job_time_limits(quota, org)
+
+      # A zero quota, an absent feature, or a provider error. None of these
+      # authorise a cap.
+      _ ->
+        unlimited_job_time_limits()
     end
+  end
 
-    if FeatureProvider.feature_enabled?(:max_job_execution_time_limit, param: org_id) do
-      max_limit = FeatureProvider.feature_quota(:max_job_execution_time_limit, param: org_id)
+  # A feature that is not enabled but still carries a quota is the platform-wide
+  # default, served because the org has no limit of its own yet; a limit
+  # deliberately lifted for an org arrives with quota 0 and never reaches here.
+  # That only tells the two apart while the org is young -- an older org can
+  # show the same shape for unrelated reasons -- and self-hosted installs have
+  # no provisioning step at all, hence the explicit gate.
+  defp unprovisioned_org_job_time_limits(quota, org) do
+    if not Zebra.on_prem?() and fresh_org?(org) do
+      max_limit =
+        quota
+        |> max(@min_unprovisioned_org_job_time_limit)
+        |> min(@max_job_execution_time_limit)
 
-      default_limit =
-        if max_limit * 60 < @default_job_execution_time_limit do
-          max_limit * 60
-        else
-          @default_job_execution_time_limit
-        end
-
-      {max_limit, default_limit}
+      {max_limit, min(max_limit * 60, @default_job_execution_time_limit)}
     else
-      {@max_job_execution_time_limit, @default_job_execution_time_limit}
+      unlimited_job_time_limits()
     end
   end
 
-  # `configure_execution_time_limit/2` runs once per job, inside the
-  # scheduling transaction. Without gating, a fresh org fanning out N jobs
-  # (one request or a burst of requests within the fresh-org window) would
-  # fire N synchronous FeatureProvider.list_features(reload: true, ...)
-  # calls -- each a real gRPC round trip held open inside that job's DB
-  # transaction, since `reload: true` never consults the cache first. Force
-  # at most one reload per org per fresh-org window instead, via a marker in
-  # the same Zebra.Cache the org load already uses.
-  #
-  # The marker is set on *attempt*, not on success: even if the reload
-  # itself errors, the marker still gets written so the rest of the burst
-  # doesn't retry it job-by-job. That means a reload failure leaves the org
-  # on today's default (24h) for the remainder of the window -- exactly
-  # today's pre-fix behavior -- and self-heals on the next window. A
-  # handful of jobs racing the first marker write may each trigger a reload
-  # before the marker lands; that's acceptable, the goal is killing the
-  # N-scale amplifier, not exactly-once semantics, so no locking here.
-  defp maybe_reload_features(org_id) do
-    Zebra.Cache.fetch!(
-      "feature-reload-done-#{org_id}",
-      @fresh_org_reload_marker_ttl_ms,
-      fn ->
-        FeatureProvider.list_features(reload: true, param: org_id)
-        {:commit, true}
-      end
-    )
-
-    :ok
-  end
+  defp unlimited_job_time_limits,
+    do: {@max_job_execution_time_limit, @default_job_execution_time_limit}
 
   defp load_org(org_id) do
     case Zebra.Workers.Scheduler.Org.load(org_id) do
@@ -447,8 +444,13 @@ defmodule Zebra.Apis.InternalTaskApi.Schedule do
   defp fresh_org?(%Zebra.Workers.Scheduler.Org{created_at: nil}), do: false
 
   defp fresh_org?(%Zebra.Workers.Scheduler.Org{created_at: %{seconds: created_at_seconds}}) do
-    DateTime.utc_now() |> DateTime.to_unix() |> Kernel.-(created_at_seconds) <
-      @fresh_org_window_seconds
+    age_seconds = DateTime.utc_now() |> DateTime.to_unix() |> Kernel.-(created_at_seconds)
+
+    # The lower bound tolerates ordinary clock skew against the organization
+    # API: rejecting every future created_at would hand the default to the
+    # first job of a genuinely new org. Anything further ahead is not skew.
+    age_seconds >= -@clock_skew_tolerance_seconds and
+      age_seconds < @fresh_org_window_seconds
   end
 
   # Defense-in-depth: the real proto's created_at is always either nil or a

--- a/zebra/lib/zebra/workers/scheduler/org.ex
+++ b/zebra/lib/zebra/workers/scheduler/org.ex
@@ -9,7 +9,7 @@ defmodule Zebra.Workers.Scheduler.Org do
   # 15 minutes
   @cache_timeout :timer.minutes(15)
 
-  defstruct [:id, :username, :suspended, :verified, :machines, :features]
+  defstruct [:id, :username, :suspended, :verified, :machines, :features, :created_at]
 
   @doc """
   Returns quota information for the given organization.
@@ -71,7 +71,8 @@ defmodule Zebra.Workers.Scheduler.Org do
       id: org_id,
       username: org.org_username,
       suspended: org.suspended,
-      verified: org.verified
+      verified: org.verified,
+      created_at: org.created_at
     }
   end
 

--- a/zebra/test/zebra/apis/internal_task_api/schedule_test.exs
+++ b/zebra/test/zebra/apis/internal_task_api/schedule_test.exs
@@ -604,6 +604,13 @@ defmodule Zebra.Apis.InternalTaskApi.ScheduleTest do
   end
 
   describe ".configure_execution_time_limit for very new orgs (feature-cache bypass window)" do
+    # The forced reload is now gated through Zebra.Cache.fetch! (Cachex),
+    # whose fallback runs inside Cachex's own courier process rather than the
+    # test process. Mox's default per-process mode would reject those calls;
+    # global mode (same pattern as scheduler_test.exs) lets the stub answer
+    # regardless of which process calls it.
+    setup :set_mox_global
+
     setup do
       Cachex.clear(:zebra_cache)
       :ok
@@ -650,8 +657,26 @@ defmodule Zebra.Apis.InternalTaskApi.ScheduleTest do
       # created 20 minutes ago: outside the 15-minute fresh-org window
       stub_org_describe(org_username: "old-org", verified: false, age_seconds: 20 * 60)
 
-      stub(Support.MockedProvider, :provide_features, fn ^org_id, _opts ->
-        {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", [:hidden])]}
+      # Same stateful contract as the young-org test above, but this stub
+      # doesn't need an Agent: a reload read would find the feature PRESENT
+      # (quota 30) while a plain read stays absent. A stub that ignored
+      # `opts` (the previous version of this test) would pass even if
+      # fresh_org? were inverted -- it only proves "absent stays absent". If
+      # the old org ever triggered the reload, this would surface as 1800
+      # instead of the untouched default, so this actually falsifies a
+      # broken youth boundary.
+      stub(Support.MockedProvider, :provide_features, fn ^org_id, opts ->
+        if Keyword.get(opts, :reload) do
+          {:ok,
+           [
+             Support.StubbedProvider.feature("max_job_execution_time_limit", [
+               :enabled,
+               {:quantity, 30}
+             ])
+           ]}
+        else
+          {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", [:hidden])]}
+        end
       end)
 
       assert @default_job_execution_time_limit ==
@@ -673,6 +698,43 @@ defmodule Zebra.Apis.InternalTaskApi.ScheduleTest do
 
       assert @default_job_execution_time_limit ==
                Schedule.configure_execution_time_limit(org_id, 0)
+    end
+
+    test "young org scheduling many jobs only forces the reload once per window" do
+      org_id = UUID.uuid4()
+
+      # A fresh org fanning out several jobs calls configure_execution_time_limit
+      # once per job (see schedule.ex's create_job/create_task_job loop). Without
+      # the marker gate, each call would fire its own reload: true round trip.
+      stub_org_describe(org_username: "fresh-org-burst", verified: false, age_seconds: 60)
+
+      {:ok, reload_count} = Agent.start_link(fn -> 0 end)
+      {:ok, cache} = Agent.start_link(fn -> false end)
+
+      stub(Support.MockedProvider, :provide_features, fn ^org_id, opts ->
+        if Keyword.get(opts, :reload) do
+          Agent.update(reload_count, &(&1 + 1))
+          Agent.update(cache, fn _ -> true end)
+        end
+
+        if Agent.get(cache, & &1) do
+          {:ok,
+           [
+             Support.StubbedProvider.feature("max_job_execution_time_limit", [
+               :enabled,
+               {:quantity, 30}
+             ])
+           ]}
+        else
+          {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", [:hidden])]}
+        end
+      end)
+
+      for _ <- 1..5 do
+        assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 0)
+      end
+
+      assert Agent.get(reload_count, & &1) == 1
     end
   end
 

--- a/zebra/test/zebra/apis/internal_task_api/schedule_test.exs
+++ b/zebra/test/zebra/apis/internal_task_api/schedule_test.exs
@@ -1,6 +1,8 @@
 defmodule Zebra.Apis.InternalTaskApi.ScheduleTest do
   use Zebra.DataCase
 
+  import Mox
+
   alias Zebra.Apis.InternalTaskApi.Schedule
   alias Zebra.LegacyRepo, as: Repo
   alias Support.Factories
@@ -601,9 +603,101 @@ defmodule Zebra.Apis.InternalTaskApi.ScheduleTest do
     end
   end
 
+  describe ".configure_execution_time_limit for very new orgs (feature-cache bypass window)" do
+    setup do
+      Cachex.clear(:zebra_cache)
+      :ok
+    end
+
+    test "young org: feature absent on a plain read but present on the forced reload => feature limit applies" do
+      org_id = UUID.uuid4()
+
+      # created 60s ago: inside the 15-minute fresh-org window
+      stub_org_describe(org_username: "fresh-org", verified: false, age_seconds: 60)
+
+      # The test env's feature_provider has no cache in front of it (see
+      # config/runtime.exs), so a plain (non-reload) read and a reload read
+      # both hit this stub directly. To exercise the same "stale cache
+      # becomes visible" contract the fix relies on in production, model the
+      # cache with an Agent: the feature starts absent (as a stale cache
+      # entry primed before the org existed would show), and only the forced
+      # `reload: true` read "warms" it, matching what a real cache would do.
+      {:ok, cache} = Agent.start_link(fn -> false end)
+
+      stub(Support.MockedProvider, :provide_features, fn ^org_id, opts ->
+        if Keyword.get(opts, :reload), do: Agent.update(cache, fn _ -> true end)
+
+        if Agent.get(cache, & &1) do
+          {:ok,
+           [
+             Support.StubbedProvider.feature("max_job_execution_time_limit", [
+               :enabled,
+               {:quantity, 30}
+             ])
+           ]}
+        else
+          {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", [:hidden])]}
+        end
+      end)
+
+      # invalid request => falls to the default, which is now the feature's 30 min
+      assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 0)
+    end
+
+    test "old org: an absent feature is unaffected by the bypass, default stays 24h" do
+      org_id = UUID.uuid4()
+
+      # created 20 minutes ago: outside the 15-minute fresh-org window
+      stub_org_describe(org_username: "old-org", verified: false, age_seconds: 20 * 60)
+
+      stub(Support.MockedProvider, :provide_features, fn ^org_id, _opts ->
+        {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", [:hidden])]}
+      end)
+
+      assert @default_job_execution_time_limit ==
+               Schedule.configure_execution_time_limit(org_id, 0)
+    end
+
+    test "young org: the forced reload erroring falls open to the unchanged default (no crash)" do
+      org_id = UUID.uuid4()
+
+      stub_org_describe(org_username: "fresh-org-error", verified: false, age_seconds: 60)
+
+      stub(Support.MockedProvider, :provide_features, fn ^org_id, opts ->
+        if Keyword.get(opts, :reload) do
+          raise "simulated feature provider failure"
+        else
+          {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", [:hidden])]}
+        end
+      end)
+
+      assert @default_job_execution_time_limit ==
+               Schedule.configure_execution_time_limit(org_id, 0)
+    end
+  end
+
   #
   # Utils
   #
+
+  # Stubs the organization describe gRPC call with a `created_at` `age_seconds`
+  # in the past, so tests can exercise the young-vs-old org boundary.
+  defp stub_org_describe(org_username: org_username, verified: verified, age_seconds: age_seconds) do
+    created_at_seconds =
+      DateTime.utc_now() |> DateTime.add(-age_seconds, :second) |> DateTime.to_unix()
+
+    GrpcMock.stub(Support.FakeServers.OrganizationApi, :describe, fn _, _ ->
+      InternalApi.Organization.DescribeResponse.new(
+        status: InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+        organization:
+          InternalApi.Organization.Organization.new(
+            org_username: org_username,
+            verified: verified,
+            created_at: Google.Protobuf.Timestamp.new(seconds: created_at_seconds)
+          )
+      )
+    end)
+  end
 
   defp example_agent do
     alias InternalApi.Task.ScheduleRequest, as: R

--- a/zebra/test/zebra/apis/internal_task_api/schedule_test.exs
+++ b/zebra/test/zebra/apis/internal_task_api/schedule_test.exs
@@ -603,144 +603,281 @@ defmodule Zebra.Apis.InternalTaskApi.ScheduleTest do
     end
   end
 
-  describe ".configure_execution_time_limit for very new orgs (feature-cache bypass window)" do
-    # The forced reload is now gated through Zebra.Cache.fetch! (Cachex),
-    # whose fallback runs inside Cachex's own courier process rather than the
-    # test process. Mox's default per-process mode would reject those calls;
-    # global mode (same pattern as scheduler_test.exs) lets the stub answer
-    # regardless of which process calls it.
-    setup :set_mox_global
-
+  describe ".configure_execution_time_limit for orgs with no limit provisioned yet" do
     setup do
       Cachex.clear(:zebra_cache)
       :ok
     end
 
-    test "young org: feature absent on a plain read but present on the forced reload => feature limit applies" do
+    test "young org whose feature carries a quota but is not enabled => held at that quota" do
       org_id = UUID.uuid4()
 
-      # created 60s ago: inside the 15-minute fresh-org window
+      # created 60s ago: inside the 15-minute window
       stub_org_describe(org_username: "fresh-org", verified: false, age_seconds: 60)
 
-      # The test env's feature_provider has no cache in front of it (see
-      # config/runtime.exs), so a plain (non-reload) read and a reload read
-      # both hit this stub directly. To exercise the same "stale cache
-      # becomes visible" contract the fix relies on in production, model the
-      # cache with an Agent: the feature starts absent (as a stale cache
-      # entry primed before the org existed would show), and only the forced
-      # `reload: true` read "warms" it, matching what a real cache would do.
-      {:ok, cache} = Agent.start_link(fn -> false end)
+      # What an org with no limit of its own gets: not enabled, but still
+      # carrying the platform-wide quota. Contrast with [:hidden] alone,
+      # which is quantity 0.
+      stub_job_time_limit_feature(org_id, [:hidden, {:quantity, 30}])
 
-      stub(Support.MockedProvider, :provide_features, fn ^org_id, opts ->
-        if Keyword.get(opts, :reload), do: Agent.update(cache, fn _ -> true end)
+      # nothing requested => the default comes down together with the max
+      assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 0)
 
-        if Agent.get(cache, & &1) do
-          {:ok,
-           [
-             Support.StubbedProvider.feature("max_job_execution_time_limit", [
-               :enabled,
-               {:quantity, 30}
-             ])
-           ]}
-        else
-          {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", [:hidden])]}
-        end
+      # a request under the cap is still honoured
+      assert 15 * 60 == Schedule.configure_execution_time_limit(org_id, 15)
+
+      # a request over the cap falls back to the *capped* default, not to 24h.
+      # If only the max came down, this would hand the whole day straight back.
+      assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 24 * 60)
+    end
+
+    test "the same feature shape on an older org is left alone" do
+      org_id = UUID.uuid4()
+
+      # created 20 minutes ago: outside the window. Past it, "not enabled with
+      # a quota" is ambiguous -- an established org can show it too -- so
+      # nothing is capped.
+      stub_org_describe(org_username: "old-org", verified: false, age_seconds: 20 * 60)
+      stub_job_time_limit_feature(org_id, [:hidden, {:quantity, 30}])
+
+      assert @default_job_execution_time_limit ==
+               Schedule.configure_execution_time_limit(org_id, 0)
+
+      assert 180 * 60 == Schedule.configure_execution_time_limit(org_id, 180)
+    end
+
+    test "young org whose limit was deliberately lifted (quota 0) keeps the 24h default" do
+      org_id = UUID.uuid4()
+
+      # The shape an org gets when its limit is lifted: not enabled, quota 0.
+      # Age must not matter here.
+      stub_org_describe(org_username: "exempt-org", verified: false, age_seconds: 60)
+      stub_job_time_limit_feature(org_id, [:hidden])
+
+      assert @default_job_execution_time_limit ==
+               Schedule.configure_execution_time_limit(org_id, 0)
+
+      assert 180 * 60 == Schedule.configure_execution_time_limit(org_id, 180)
+    end
+
+    test "young org on an install that does not carry the feature keeps the 24h default" do
+      org_id = UUID.uuid4()
+
+      # A self-hosted install: max_job_execution_time_limit is not in the
+      # features YAML at all, so every org would otherwise look unprovisioned.
+      stub_org_describe(org_username: "self-hosted-org", verified: false, age_seconds: 60)
+
+      stub(Support.MockedProvider, :provide_features, fn
+        ^org_id, _opts -> {:ok, []}
+        other_org, opts -> Support.StubbedProvider.provide_features(other_org, opts)
       end)
 
-      # invalid request => falls to the default, which is now the feature's 30 min
+      assert @default_job_execution_time_limit ==
+               Schedule.configure_execution_time_limit(org_id, 0)
+
+      assert 180 * 60 == Schedule.configure_execution_time_limit(org_id, 180)
+    end
+
+    test "young org whose feature provider errors keeps the 24h default" do
+      org_id = UUID.uuid4()
+
+      # Capping the whole fleet during a FeatureHub outage would be worse than
+      # the leak this closes, so the error path stays fail-open.
+      stub_org_describe(org_username: "degraded-org", verified: false, age_seconds: 60)
+
+      stub(Support.MockedProvider, :provide_features, fn
+        ^org_id, _opts -> {:error, :timeout}
+        other_org, opts -> Support.StubbedProvider.provide_features(other_org, opts)
+      end)
+
+      assert @default_job_execution_time_limit ==
+               Schedule.configure_execution_time_limit(org_id, 0)
+
+      assert 180 * 60 == Schedule.configure_execution_time_limit(org_id, 180)
+    end
+
+    test "young org already provisioned uses the feature's own limit" do
+      org_id = UUID.uuid4()
+
+      stub_org_describe(org_username: "provisioned-org", verified: false, age_seconds: 60)
+      stub_job_time_limit_feature(org_id, [:enabled, {:quantity, 30}])
+
+      assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 0)
+      assert 15 * 60 == Schedule.configure_execution_time_limit(org_id, 15)
+    end
+
+    test "an enabled feature with a zero quota does not resolve to a zero time limit" do
+      org_id = UUID.uuid4()
+
+      stub_org_describe(org_username: "zero-quota-org", verified: false, age_seconds: 60)
+      stub_job_time_limit_feature(org_id, [:enabled, {:quantity, 0}])
+
+      assert @default_job_execution_time_limit ==
+               Schedule.configure_execution_time_limit(org_id, 0)
+    end
+
+    test "the production feature shape (:disabled, not :hidden) is capped the same way" do
+      org_id = UUID.uuid4()
+
+      # StubbedProvider's :hidden trait yields state: :hidden, but
+      # FeatureHubProvider maps the wire state to :disabled -- the atom
+      # :hidden never occurs in production. Assert the real shape too, so the
+      # other tests in this block cannot be the only thing pinning the clause.
+      stub_org_describe(org_username: "prod-shape-org", verified: false, age_seconds: 60)
+
+      stub(Support.MockedProvider, :provide_features, fn
+        ^org_id, _opts ->
+          {:ok,
+           [
+             %FeatureProvider.Feature{
+               type: "max_job_execution_time_limit",
+               state: :disabled,
+               quantity: 30
+             }
+           ]}
+
+        other_org, opts ->
+          Support.StubbedProvider.provide_features(other_org, opts)
+      end)
+
+      assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 0)
+      assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 24 * 60)
+    end
+
+    test "a quota below the floor cannot shorten jobs past the platform minimum" do
+      org_id = UUID.uuid4()
+
+      # the quota is configured elsewhere and has no floor of its own: a stray
+      # edit to 1 must not hand every young org one-minute jobs
+      stub_org_describe(org_username: "tiny-quota-org", verified: false, age_seconds: 60)
+      stub_job_time_limit_feature(org_id, [:hidden, {:quantity, 1}])
+
+      assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 0)
+      refute 60 == Schedule.configure_execution_time_limit(org_id, 0)
+    end
+
+    test "the fresh-org window boundary" do
+      org_id = UUID.uuid4()
+      stub_job_time_limit_feature(org_id, [:hidden, {:quantity, 30}])
+
+      stub_org_describe(org_username: "just-inside", verified: false, age_seconds: 15 * 60 - 5)
+      Cachex.clear(:zebra_cache)
+      assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 0)
+
+      stub_org_describe(org_username: "just-outside", verified: false, age_seconds: 15 * 60 + 5)
+      Cachex.clear(:zebra_cache)
+
+      assert @default_job_execution_time_limit ==
+               Schedule.configure_execution_time_limit(org_id, 0)
+    end
+
+    test "a created_at a few seconds in the future is still fresh" do
+      org_id = UUID.uuid4()
+
+      # Ordinary clock skew between this pod and the organization API. The very
+      # first job of a just-created org must not fall to 24h because the two
+      # clocks disagree by a second.
+      stub_org_describe(org_username: "skewed-org", verified: false, age_seconds: -5)
+      stub_job_time_limit_feature(org_id, [:hidden, {:quantity, 30}])
+
       assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 0)
     end
 
-    test "old org: an absent feature is unaffected by the bypass, default stays 24h" do
+    test "a created_at far in the future is not treated as fresh" do
       org_id = UUID.uuid4()
 
-      # created 20 minutes ago: outside the 15-minute fresh-org window
-      stub_org_describe(org_username: "old-org", verified: false, age_seconds: 20 * 60)
-
-      # Same stateful contract as the young-org test above, but this stub
-      # doesn't need an Agent: a reload read would find the feature PRESENT
-      # (quota 30) while a plain read stays absent. A stub that ignored
-      # `opts` (the previous version of this test) would pass even if
-      # fresh_org? were inverted -- it only proves "absent stays absent". If
-      # the old org ever triggered the reload, this would surface as 1800
-      # instead of the untouched default, so this actually falsifies a
-      # broken youth boundary.
-      stub(Support.MockedProvider, :provide_features, fn ^org_id, opts ->
-        if Keyword.get(opts, :reload) do
-          {:ok,
-           [
-             Support.StubbedProvider.feature("max_job_execution_time_limit", [
-               :enabled,
-               {:quantity, 30}
-             ])
-           ]}
-        else
-          {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", [:hidden])]}
-        end
-      end)
+      # An hour ahead is not skew. Fall through to the unchanged default.
+      stub_org_describe(org_username: "corrupt-org", verified: false, age_seconds: -3600)
+      stub_job_time_limit_feature(org_id, [:hidden, {:quantity, 30}])
 
       assert @default_job_execution_time_limit ==
                Schedule.configure_execution_time_limit(org_id, 0)
     end
 
-    test "young org: the forced reload erroring falls open to the unchanged default (no crash)" do
+    test "a self-hosted install is never capped, whatever its features YAML says" do
       org_id = UUID.uuid4()
 
-      stub_org_describe(org_username: "fresh-org-error", verified: false, age_seconds: 60)
+      # A YamlProvider entry of `enabled: false` with an explicit quantity
+      # produces the same not-enabled + non-zero shape as the SaaS fallback.
+      # Self-hosted has no provisioning step, so it must resolve to 24h anyway.
+      stub_org_describe(org_username: "onprem-org", verified: false, age_seconds: 60)
+      stub_job_time_limit_feature(org_id, [:hidden, {:quantity, 30}])
 
-      stub(Support.MockedProvider, :provide_features, fn ^org_id, opts ->
-        if Keyword.get(opts, :reload) do
-          raise "simulated feature provider failure"
-        else
-          {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", [:hidden])]}
-        end
-      end)
+      System.put_env("ON_PREM", "true")
+      on_exit(fn -> System.delete_env("ON_PREM") end)
 
       assert @default_job_execution_time_limit ==
                Schedule.configure_execution_time_limit(org_id, 0)
+
+      assert 180 * 60 == Schedule.configure_execution_time_limit(org_id, 180)
+    end
+  end
+
+  describe ".schedule job time limit resolution" do
+    setup do
+      Cachex.clear(:zebra_cache)
+      :ok
     end
 
-    test "young org scheduling many jobs only forces the reload once per window" do
+    test "resolves the org's limits once per task and applies them to every job" do
       org_id = UUID.uuid4()
+      req = %{construct_example_schedule_request(Ecto.UUID.generate()) | org_id: org_id}
 
-      # A fresh org fanning out several jobs calls configure_execution_time_limit
-      # once per job (see schedule.ex's create_job/create_task_job loop). Without
-      # the marker gate, each call would fire its own reload: true round trip.
-      stub_org_describe(org_username: "fresh-org-burst", verified: false, age_seconds: 60)
+      stub_org_describe(org_username: "fresh-org-task", verified: false, age_seconds: 60)
 
-      {:ok, reload_count} = Agent.start_link(fn -> 0 end)
-      {:ok, cache} = Agent.start_link(fn -> false end)
+      {:ok, calls} = Agent.start_link(fn -> 0 end)
 
-      stub(Support.MockedProvider, :provide_features, fn ^org_id, opts ->
-        if Keyword.get(opts, :reload) do
-          Agent.update(reload_count, &(&1 + 1))
-          Agent.update(cache, fn _ -> true end)
-        end
+      stub(Support.MockedProvider, :provide_features, fn
+        ^org_id, _opts ->
+          Agent.update(calls, &(&1 + 1))
 
-        if Agent.get(cache, & &1) do
           {:ok,
            [
              Support.StubbedProvider.feature("max_job_execution_time_limit", [
-               :enabled,
+               :hidden,
                {:quantity, 30}
              ])
            ]}
-        else
-          {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", [:hidden])]}
-        end
+
+        other_org, opts ->
+          Support.StubbedProvider.provide_features(other_org, opts)
       end)
 
-      for _ <- 1..5 do
-        assert 30 * 60 == Schedule.configure_execution_time_limit(org_id, 0)
-      end
+      assert {:ok, task} = Schedule.schedule(req)
+      task = Repo.preload(task, [:jobs])
 
-      assert Agent.get(reload_count, & &1) == 1
+      first_job = Enum.find(task.jobs, &(&1.name == "Papa"))
+      second_job = Enum.find(task.jobs, &(&1.name == "Papa2"))
+
+      # job 1 asks for 5 minutes, under the cap, and gets it
+      assert first_job.execution_time_limit == 5 * 60
+      # job 2 asks for 48h, over the cap, and falls to the capped default
+      assert second_job.execution_time_limit == 30 * 60
+
+      # Resolved once for the whole task, not once per job: the limits are a
+      # property of the org, and the lookup must not sit inside the
+      # scheduling transaction.
+      assert Agent.get(calls, & &1) == 1
     end
   end
 
   #
   # Utils
   #
+
+  # Stubs the max_job_execution_time_limit feature for one org, delegating
+  # every other org id to the default StubbedProvider. A stub that matched only
+  # `^org_id` would raise FunctionClauseError for any concurrent lookup of a
+  # different org, surfacing as unrelated tests failing on some seeds.
+  defp stub_job_time_limit_feature(org_id, traits) do
+    stub(Support.MockedProvider, :provide_features, fn
+      ^org_id, _opts ->
+        {:ok, [Support.StubbedProvider.feature("max_job_execution_time_limit", traits)]}
+
+      other_org, opts ->
+        Support.StubbedProvider.provide_features(other_org, opts)
+    end)
+  end
 
   # Stubs the organization describe gRPC call with a `created_at` `age_seconds`
   # in the past, so tests can exercise the young-vs-old org boundary.


### PR DESCRIPTION
## What

Caps job execution time for organizations that don't yet have a limit provisioned, instead of falling back to 24 hours.

## Why

An organization is usable in Front before its job time limit exists. During that gap the `max_job_execution_time_limit` feature resolves to not-enabled, and zebra reads that as "no limit configured" and grants the 24-hour default - so a brand-new organization can run 24-hour jobs.

## How

`find_feature_based_job_time_limits/2` now classifies the feature by state *and* quota. Enabled with a quota is a limit provisioned for that organization and is used as before. Not enabled but still carrying a quota is the platform-wide default, served because the organization has no limit of its own yet - if it is younger than 15 minutes, that quota is enforced rather than 24 hours. Both the max and the default come down together, so a pipeline cannot opt out with its own `execution_time_limit:`.

Everything ambiguous still resolves to 24 hours: quota 0 (a limit deliberately lifted), an absent feature, a provider error, a failed organization lookup, and self-hosted installs. Nothing in this path can shorten a job it shouldn't.

Three guards on the new branch: a 30-minute floor, since the quota is configured in another service and has no lower bound of its own; an explicit `Zebra.on_prem?()` gate rather than relying on the feature being absent from every self-hosted features YAML; and a bounded clock-skew tolerance, so a `created_at` a second ahead of this pod doesn't push a genuinely new organization's first job to 24 hours.

## Also in this PR

Limits are resolved once per task, before `Repo.transaction/1`, and threaded into `create_job` - previously each job resolved them inside the transaction, holding a DB connection across gRPC calls to the organization and feature APIs. The two feature-cache reads (`feature_enabled?` then `feature_quota`) collapse into one `find_feature/2`, closing the window where an entry expiring between them produced `execution_time_limit: 0`.
