### PR TITLE
chore(ee/rbac): accept internal-only grpc advisories in mix_audit

### DIFF
--- a/ee/rbac/.mix-audit.txt
+++ b/ee/rbac/.mix-audit.txt
@@ -45,3 +45,27 @@ GHSA-mp55-p8c9-rfw2
 # ee/rbac's gRPC traffic is internal service-to-service with no user-controlled request lines or
 # headers. Real fix tracked for the fleet-wide dep-bump branch.
 GHSA-w4f7-4cxr-rv3c
+
+# --- grpc 0.8.1 advisories, all first patched in grpc 1.0.0 ---
+# Unlike front (see front/.mix-audit.txt), ee/rbac does run a gRPC server, so two of the four
+# below are reachable code paths rather than dead ones. Both of those are availability-only, and
+# the gRPC service is an internal endpoint: it is not internet-facing and is reached only by
+# sibling services within the same deployment, never by end users.
+# The real fix is grpc 1.0.0, a breaking major shared across the monorepo, tracked as a
+# coordinated migration (see ee/audit and notifications .mix-audit.txt), not a patch bump.
+#
+# UNREACHABLE — RCE / atom-table exhaustion via :erlang.binary_to_term in
+# GRPC.Codec.Erlpack.decode/2 (critical). Requires a server that registers the Erlpack codec and
+# accepts application/grpc+erlpack; ee/rbac registers no custom codec (grep for Erlpack,
+# GRPC.Codec and `codecs:` across lib/ and config/ returns nothing).
+GHSA-grp7-v8xh-rj7h
+# REACHABLE, BOUNDED — decompression bomb in GRPC.Compressor.Gzip.decompress/1 (high). Fires on
+# frames arriving at the server with grpc-encoding: gzip. Availability-only, and reachable only
+# by internal callers per the note above.
+GHSA-6ccx-9c9f-327w
+# REACHABLE, BOUNDED — unbounded request-body accumulation in read_full_body/3 (high), the server
+# request read loop. Availability-only, internal callers only.
+GHSA-q8gf-9rvj-gmgj
+# UNREACHABLE — path bindings overridable by query string and request body (high). Requires HTTP
+# transcoding of gRPC path bindings, which ee/rbac does not expose.
+GHSA-mwr4-5g34-j5cq


### PR DESCRIPTION
`mix_audit` began failing `RBAC EE: Deployment Preconditions` on four `grpc` 0.8.1 advisories whose version ranges widened after the last green run on this directory. Nothing in `ee/rbac` changed — the block only runs on `change_in('/ee/rbac')`, so the first branch to touch that directory inherits the red. This excludes the four from the scan rather than patching, with the rationale inline in `ee/rbac/.mix-audit.txt` alongside the existing entries.

## Reachability

Unlike `front` (semaphoreio/semaphore#1194, which runs no gRPC server), `ee/rbac` does run one — so two of these four are live code paths rather than dead ones. Both are availability-only, and the gRPC service is an internal endpoint: not internet-facing, reached only by sibling services within the same deployment, never by end users.

| Advisory | Severity | Vulnerable path | Status in `ee/rbac` |
|---|---|---|---|
| GHSA-grp7-v8xh-rj7h | critical | `:erlang.binary_to_term` in `GRPC.Codec.Erlpack.decode/2` | **Unreachable.** Requires a server that registers the Erlpack codec and accepts `application/grpc+erlpack`. `ee/rbac` registers no custom codec — grep for `Erlpack`, `GRPC.Codec` and `codecs:` across `lib/` and `config/` returns nothing. |
| GHSA-6ccx-9c9f-327w | high | `GRPC.Compressor.Gzip.decompress/1` | **Reachable, bounded.** Fires on frames arriving with `grpc-encoding: gzip`. Availability-only, internal callers only. |
| GHSA-q8gf-9rvj-gmgj | high | `read_full_body/3`, the server request read loop | **Reachable, bounded.** Availability-only, internal callers only. |
| GHSA-mwr4-5g34-j5cq | high | path bindings overridable by query string and request body | **Unreachable.** Requires HTTP transcoding of gRPC path bindings, which `ee/rbac` does not expose. |

## Why not upgrade

All four are first patched in `grpc` 1.0.0 — a breaking major shared across the monorepo, already tracked as a coordinated migration (see the notes in `ee/audit/.mix-audit.txt` and `notifications/.mix-audit.txt`). It belongs on that dep-bump branch rather than riding along with a scanner unblock.

## Scope

One file, comments plus four ids. Split out deliberately so the branch that surfaced this stays a pure behaviour change and this acceptance can be reviewed on its own terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
