### PR TITLE
fix(github_notifier): retry slow dependency fetches instead of crashing with {:badmatch, nil}

### DIFF
--- a/github_notifier/config/config.exs
+++ b/github_notifier/config/config.exs
@@ -3,6 +3,9 @@ import Config
 config :logger, :console, metadata: [:request_id]
 
 config :github_notifier,
+  # Upper bound (ms) for each dependency fetch, matching the 30s gRPC deadline
+  # the Models use. See GithubNotifier.Notifier for why.
+  fetch_timeout: 30_000,
   pipeline_grpc_endpoint: "0.0.0.0:50052",
   projecthub_grpc_endpoint: "0.0.0.0:50052",
   organization_grpc_endpoint: "0.0.0.0:50052",

--- a/github_notifier/config/test.exs
+++ b/github_notifier/config/test.exs
@@ -2,6 +2,9 @@ import Config
 
 config :github_notifier, environment: :test
 
+# Keep the fetch-timeout tests fast and deterministic.
+config :github_notifier, fetch_timeout: 200
+
 config :logger, level: :debug
 
 config :junit_formatter,

--- a/github_notifier/lib/github_notifier/notifier.ex
+++ b/github_notifier/lib/github_notifier/notifier.ex
@@ -1,82 +1,103 @@
 defmodule GithubNotifier.Notifier do
+  require Logger
+
   alias GithubNotifier.TaskSupervisor
   alias GithubNotifier.Models
 
+  # Most Models.*.find/1 calls issue gRPC requests with a 30s deadline (see
+  # models/repo_proxy.ex, models/pipeline.ex); bound each surrounding task to
+  # the same budget (this also caps the otherwise-unbounded PipelineSummary
+  # lookup).
+  #
+  # Previously each fetch was `async_nolink(...) |> Task.yield()`, and
+  # `Task.yield/1` defaults to a 5s timeout. When a `describe` was merely slow
+  # (5-30s, e.g. while a dependency's DB pool is saturated during a burst),
+  # `Task.yield` returned `nil` while the call was still in flight, and the
+  # strict `{:ok, x} = fetch_*(...)` match then raised `{:badmatch, nil}`.
+  # That crash skipped `Status.create`, so the commit status was never posted
+  # and the PR's required check hung until a human re-pushed.
+  @default_fetch_timeout 30_000
+
   def notify(request_id, pipeline_id, block_id \\ nil) do
-    {:ok, pipeline} = fetch_pipeline(pipeline_id)
-    {:ok, repo_proxy} = fetch_repo_proxy(pipeline.hook_id)
-    {:ok, project} = fetch_project(pipeline.project_id)
+    with {:ok, pipeline} <- fetch_pipeline(pipeline_id),
+         {:ok, repo_proxy} <- fetch_repo_proxy(pipeline.hook_id),
+         {:ok, project} <- fetch_project(pipeline.project_id) do
+      case project do
+        nil ->
+          nil
 
-    case project do
-      nil ->
-        nil
-
-      project ->
-        data = GithubNotifier.Extractor.extract(pipeline, block_id, repo_proxy, project)
-        GithubNotifier.Status.create(data, request_id)
+        project ->
+          data = GithubNotifier.Extractor.extract(pipeline, block_id, repo_proxy, project)
+          GithubNotifier.Status.create(data, request_id)
+      end
+    else
+      {:error, stage} -> retry!(stage, pipeline_id)
     end
   end
 
   def notify_with_summary(request_id, pipeline_id) do
-    {:ok, pipeline} = fetch_pipeline(pipeline_id)
-    {:ok, repo_proxy} = fetch_repo_proxy(pipeline.hook_id)
-    {:ok, project} = fetch_project(pipeline.project_id)
-    {:ok, pipeline_summary} = fetch_pipeline_summary(pipeline_id)
+    with {:ok, pipeline} <- fetch_pipeline(pipeline_id),
+         {:ok, repo_proxy} <- fetch_repo_proxy(pipeline.hook_id),
+         {:ok, project} <- fetch_project(pipeline.project_id),
+         {:ok, pipeline_summary} <- fetch_pipeline_summary(pipeline_id) do
+      case project do
+        nil ->
+          nil
 
-    case project do
-      nil ->
-        nil
+        project ->
+          data =
+            GithubNotifier.Extractor.extract_with_summary(
+              pipeline,
+              repo_proxy,
+              project,
+              pipeline_summary
+            )
 
-      project ->
-        data =
-          GithubNotifier.Extractor.extract_with_summary(
-            pipeline,
-            repo_proxy,
-            project,
-            pipeline_summary
-          )
-
-        GithubNotifier.Status.create(data, request_id)
+          GithubNotifier.Status.create(data, request_id)
+      end
+    else
+      {:error, stage} -> retry!(stage, pipeline_id)
     end
   end
 
-  defp fetch_pipeline_summary(pipeline_id) do
-    Task.Supervisor.async_nolink(
-      TaskSupervisor,
-      fn ->
-        Models.PipelineSummary.find(pipeline_id)
-      end
-    )
-    |> Task.yield()
+  # Raise so the Tackle consumer redelivers the message (retry_delay /
+  # retry_limit) instead of dropping the status. A transient backend slowdown
+  # then simply retries once the dependency recovers; only a sustained outage
+  # exhausts the retry budget and dead-letters.
+  defp retry!(stage, pipeline_id) do
+    raise "github_notifier: #{stage} fetch unavailable for pipeline #{pipeline_id}; will retry"
   end
 
-  defp fetch_repo_proxy(hook_id) do
-    Task.Supervisor.async_nolink(
-      TaskSupervisor,
-      fn ->
-        Models.RepoProxy.find(hook_id)
-      end
-    )
-    |> Task.yield()
+  defp fetch_pipeline_summary(pipeline_id),
+    do: fetch(:pipeline_summary, fn -> Models.PipelineSummary.find(pipeline_id) end)
+
+  defp fetch_repo_proxy(hook_id), do: fetch(:repo_proxy, fn -> Models.RepoProxy.find(hook_id) end)
+
+  defp fetch_project(project_id), do: fetch(:project, fn -> Models.Project.find(project_id) end)
+
+  defp fetch_pipeline(pipeline_id),
+    do: fetch(:pipeline, fn -> Models.Pipeline.find(pipeline_id) end)
+
+  # Runs `fun` in a supervised task bounded by the fetch timeout.
+  #
+  # Returns `{:ok, result}` when the call completes (`result` may be `nil` when
+  # the record is genuinely absent — callers already handle that), or
+  # `{:error, stage}` when the call times out or the task crashes, so the
+  # caller can retry rather than crash with `{:badmatch, nil}`.
+  defp fetch(stage, fun) do
+    task = Task.Supervisor.async_nolink(TaskSupervisor, fun)
+
+    case Task.yield(task, fetch_timeout()) || Task.shutdown(task) do
+      {:ok, result} ->
+        {:ok, result}
+
+      other ->
+        Logger.error("Fetch #{stage} failed or timed out: #{inspect(other)}")
+        {:error, stage}
+    end
   end
 
-  defp fetch_project(project_id) do
-    Task.Supervisor.async_nolink(
-      TaskSupervisor,
-      fn ->
-        Models.Project.find(project_id)
-      end
-    )
-    |> Task.yield()
-  end
-
-  defp fetch_pipeline(pipeline_id) do
-    Task.Supervisor.async_nolink(
-      TaskSupervisor,
-      fn ->
-        Models.Pipeline.find(pipeline_id)
-      end
-    )
-    |> Task.yield()
+  defp fetch_timeout do
+    Application.get_env(:github_notifier, :fetch_timeout, @default_fetch_timeout)
   end
 end

--- a/github_notifier/test/github_notifier/notifier_test.exs
+++ b/github_notifier/test/github_notifier/notifier_test.exs
@@ -1,0 +1,40 @@
+defmodule GithubNotifier.NotifierTest do
+  use ExUnit.Case
+
+  alias GithubNotifier.Notifier
+
+  # Regression tests for the "build passed but no status posted to GitHub"
+  # failure: a dependency `describe` that is slower than the fetch timeout used
+  # to return `nil` from `Task.yield/1` and crash with `{:badmatch, nil}`,
+  # skipping `Status.create`. It must now raise a retryable error instead, so
+  # the Tackle consumer redelivers rather than silently dropping the status.
+  #
+  # `:fetch_timeout` is set to 200ms in config/test.exs; the slow stubs sleep
+  # well past that to trip the timeout deterministically.
+
+  describe "notify/3 when a dependency fetch exceeds the fetch timeout" do
+    test "retries (raises) instead of crashing with {:badmatch, nil} when the pipeline describe is slow" do
+      GrpcMock.stub(PipelineMock, :describe, fn _req, _stream ->
+        Process.sleep(800)
+        Support.Factories.pipeline_describe_response()
+      end)
+
+      assert_raise RuntimeError, ~r/pipeline fetch unavailable/, fn ->
+        Notifier.notify("req-id", "pipeline-id")
+      end
+    end
+
+    test "raises when a later fetch (repo_proxy) is slow even though the pipeline resolved" do
+      GrpcMock.stub(PipelineMock, :describe, Support.Factories.pipeline_describe_response())
+
+      GrpcMock.stub(RepoProxyMock, :describe, fn _req, _stream ->
+        Process.sleep(800)
+        Support.Factories.repo_proxy_describe_response()
+      end)
+
+      assert_raise RuntimeError, ~r/repo_proxy fetch unavailable/, fn ->
+        Notifier.notify("req-id", "pipeline-id")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When a pipeline finishes, `github_notifier` posts the commit status back to GitHub. We regularly see builds that **pass but whose status is never posted** — the PR's required check hangs as "expected/pending" until the author pushes again. In the consumer logs this shows up as:

```
[error] Consumption failed: {:badmatch, nil}
    GithubNotifier.Notifier.notify/3            (notifier.ex:7)
    GithubNotifier.Notifier.notify_with_summary/2 (notifier.ex:22)
```

## Root cause

`Notifier` fetches each dependency (pipeline, repo_proxy, project, pipeline_summary) as:

```elixir
Task.Supervisor.async_nolink(TaskSupervisor, fn -> Models.X.find(...) end)
|> Task.yield()
```

`Task.yield/1` defaults to a **5s** timeout, but the underlying gRPC `describe` calls in `models/*.ex` use a **30s** deadline (`timeout: 30_000`). When a `describe` is merely slow — e.g. 5–30s while a dependency's DB connection pool is saturated during a burst — `Task.yield` returns bare `nil` while the call is still in flight. The strict `{:ok, x} = fetch_*(...)` match then raises `{:badmatch, nil}`, which happens **before** `Status.create`, so the commit status is never sent. Because the abandoned task keeps running to its 30s deadline and the next retry hits the same 5s wall, the status stays missing until a human re-pushes.

## Fix

- Add a configurable `:fetch_timeout` (default **30_000**, matching the gRPC deadline) and bound each fetch with `Task.yield(task, fetch_timeout()) || Task.shutdown(task)`, so a slow-but-healthy `describe` is given the time it was already allowed, and the abandoned task is shut down rather than leaked.
- On timeout/crash, return `{:error, stage}` and re-raise a clear, retryable error via a `with/else`, instead of crashing with `{:badmatch, nil}`. The `Tackle.Consumer`s already redeliver on exceptions (`retry_delay: 30`, `retry_limit: 30`, ~15 min before dead-lettering), so a transient slowdown now simply retries and the status is delivered once the dependency recovers.

## Why it is safe

- **Found-but-`nil` records behave exactly as before.** A genuine "not found" returns `{:ok, nil}` (a truthy tuple), which is passed through unchanged — only a real timeout (`nil`) or task crash (`{:exit, _}`) maps to `{:error, stage}`. The existing `case project do nil -> nil` path is untouched.
- **No new drop path.** Previously a slow fetch crashed (and Tackle retried); now it still raises (and Tackle retries) — but each attempt gets the full 30s, so it succeeds instead of repeatedly timing out at 5s. Behavior only *improves* for the slow case.
- Raising (rather than silently returning) is consistent with the consumers' documented intent ("ride out provider outages instead of dropping the status").

## Testing

- New `test/github_notifier/notifier_test.exs` covers the timeout path: a `describe` slower than `:fetch_timeout` now raises a retryable error rather than `{:badmatch, nil}` (both the first fetch and a later fetch).
- Verified locally on the pinned toolchain (Elixir 1.20.2 / OTP 29.0.4):
  - `mix compile` — clean, no warnings
  - `mix format --check-formatted` — passes
  - `mix test` — **72 existing + 2 new = all pass**, no regressions

## Notes / out of scope

- The `pipeline == nil` → `pipeline.hook_id` path (when `Pipeline.find` returns `{:ok, nil}` for a BAD_PARAM) is unchanged; it still raises and retries as before. Happy to fold in a guard if preferred.
- `:fetch_timeout` is configurable so operators can tune it without a code change.
