### PR TITLE
fix(plumber/ppl): suppress grpc DoS advisory GHSA-q8gf-9rvj-gmgj

### DIFF
--- a/plumber/ppl/.mix-audit.txt
+++ b/plumber/ppl/.mix-audit.txt
@@ -60,3 +60,16 @@ GHSA-pj7v-xfvx-wmjq
 #   GHSA-w4f7-4cxr-rv3c — HTTP request/response splitting (shared cowboy/gun advisory)
 GHSA-r53j-fjj5-mv77
 GHSA-w4f7-4cxr-rv3c
+
+# grpc — unbounded request body accumulation in the server read loop read_full_body/3
+# (GHSA-q8gf-9rvj-gmgj, high). Direct dep `{:grpc, "~> 0.3"}` -> 0.3.1; first patched in
+# grpc 1.0.0, a breaking major that also moves the gun/cowboy/cowlib/ranch stack, so it is
+# the coordinated fleet-wide grpc upgrade tracked in semaphoreio/semaphore#1134, not a patch.
+# REACHABLE (unlike the cowboy/cowlib entries above): plumber/ppl runs internal gRPC servers
+# (GRPC.Server.Supervisor on :50053, config start_server: true), and read_full_body/3 is on
+# the request path of every unary RPC. Accepted on exposure + impact, not unreachability:
+# availability-only (single-pod memory exhaustion, supervisor restarts), and the endpoint is
+# internal NodePort with no ingress and no external clients — reachable only by in-cluster
+# sibling services. Mirrors the accepted rationale in ee/rbac, ee/audit, guard, front,
+# notifications and hooks_processor .mix-audit.txt.
+GHSA-q8gf-9rvj-gmgj


### PR DESCRIPTION
## What

Suppress dependency advisory **GHSA-q8gf-9rvj-gmgj** (`grpc` 0.3.1, high) in `plumber/ppl/.mix-audit.txt`.

Unbounded request-body accumulation in the gRPC server read loop `read_full_body/3` — the cowboy adapter concatenates HTTP/2 body chunks (`body <> data`) with no size cap.

## Why

The advisory postdated the suppression file and was the only unsuppressed entry in `plumber/ppl`. Investigation outcome: **suppress with rationale**, folded into the coordinated `grpc` 1.0.0 migration.

- **Reachable** — plumber/ppl runs internal gRPC servers (`GRPC.Server.Supervisor` on :50053, `start_server: true`); the read loop is on the request path of every unary RPC. Rationale states this honestly rather than claiming a dead path (unlike the sibling cowboy/cowlib entries).
- **Exposure** — internal only. Services are `type: NodePort` on :50053, no Ingress/LoadBalancer, no server-side auth interceptor. Reachable only by in-cluster siblings.
- **Impact** — availability only (single-pod memory exhaustion; OTP supervisor restarts). No confidentiality/integrity impact.
- **Fix** — `grpc` 1.0.0 is a breaking major that also moves the gun/cowboy/cowlib/ranch stack; must land as the fleet-wide migration, not a point bump. Tracked in semaphoreio/semaphore#1134.
