### PR TITLE
fix(github_hooks): stop GitHub App collaborator sync from stampeding the shared REST bucket

### DIFF
--- a/github_hooks/app/controllers/projects_controller.rb
+++ b/github_hooks/app/controllers/projects_controller.rb
@@ -157,13 +157,13 @@ class ProjectsController < ApplicationController
   private
 
   # Sync a repo's collaborators on a GitHub "member" webhook. When
-  # DISABLE_COLLABORATOR_WEBHOOK_SYNC is set, the sync and the changed event are
-  # both suppressed, so this kill switch also covers member events.
+  # DISABLE_COLLABORATOR_SYNC is set, the sync and the changed event are both
+  # suppressed, so this kill switch also covers member events.
   def handle_member_webhook(project, logger)
     Watchman.increment("repo_host_post_commit_hooks.controller.member_webhook")
     logger.info("Member Webhook")
 
-    if App.disable_collaborator_webhook_sync
+    if App.disable_collaborator_sync
       Watchman.increment("repo_host_post_commit_hooks.controller.collaborator_webhook_sync_disabled")
       logger.info("Collaborator webhook sync disabled via env; skipping member webhook sync")
       return
@@ -174,10 +174,10 @@ class ProjectsController < ApplicationController
   end
 
   # Re-syncs the installation's repository list on every webhook. When
-  # DISABLE_COLLABORATOR_WEBHOOK_SYNC is set, the list is still synced — only the
+  # DISABLE_COLLABORATOR_SYNC is set, the list is still synced — only the
   # per-repo collaborator fan-out is suppressed.
   def enqueue_repository_list_sync(installation_id, logger)
-    sync_collaborators = !App.disable_collaborator_webhook_sync
+    sync_collaborators = !App.disable_collaborator_sync
 
     unless sync_collaborators
       Watchman.increment("repo_host_post_commit_hooks.controller.collaborator_webhook_sync_disabled")

--- a/github_hooks/config/app.rb
+++ b/github_hooks/config/app.rb
@@ -42,8 +42,8 @@ class App < Configurable # :nodoc:
   # DISABLE_COLLABORATOR_WEBHOOK_SYNC is the deprecated former name, read as an
   # alias so existing operators keep working.
   config.disable_collaborator_sync =
-    (SemaphoreConfig.disable_collaborator_sync ||
-     SemaphoreConfig.disable_collaborator_webhook_sync ||
+    (SemaphoreConfig.disable_collaborator_sync.presence ||
+     SemaphoreConfig.disable_collaborator_webhook_sync.presence ||
      "false") == "true"
   config.use_github_app_to_check_permissions =
     (SemaphoreConfig.use_github_app_to_check_permissions || "false") == "true"

--- a/github_hooks/config/app.rb
+++ b/github_hooks/config/app.rb
@@ -25,10 +25,26 @@ class App < Configurable # :nodoc:
     ".#{SemaphoreConfig.base_domain}"  # All subdomains within base domain.
   ]
   config.always_filter_skip_ci = (SemaphoreConfig.always_filter_skip_ci || "false") == "true"
+
+  # Reserved-headroom floor on the GitHub App's shared REST bucket: background
+  # collaborator/repository sync steps aside below this so interactive/CI calls
+  # keep budget.
   config.collaborators_api_rate_limit = (SemaphoreConfig.collaborators_api_rate_limit || 4000).to_i
 
-  config.disable_collaborator_webhook_sync =
-    (SemaphoreConfig.disable_collaborator_webhook_sync || "false") == "true"
+  # Jitter window (seconds) a rate-limited sync waits past the bucket reset before
+  # retrying, so a fanned-out sweep disperses across the post-reset window instead
+  # of stampeding it. Scale up with the number of repositories in the installation.
+  config.github_app_rate_limit_defer_spread =
+    (SemaphoreConfig.github_app_rate_limit_defer_spread || 1800).to_i
+
+  # Master switch that stops all GitHub App collaborator sync — the automatic
+  # webhook path and the collaborator fan-out of a manual org refresh alike.
+  # DISABLE_COLLABORATOR_WEBHOOK_SYNC is the deprecated former name, read as an
+  # alias so existing operators keep working.
+  config.disable_collaborator_sync =
+    (SemaphoreConfig.disable_collaborator_sync ||
+     SemaphoreConfig.disable_collaborator_webhook_sync ||
+     "false") == "true"
   config.use_github_app_to_check_permissions =
     (SemaphoreConfig.use_github_app_to_check_permissions || "false") == "true"
   config.semaphore_edition = (SemaphoreConfig.semaphore_edition || "").downcase

--- a/github_hooks/lib/repo_host/github/client.rb
+++ b/github_hooks/lib/repo_host/github/client.rb
@@ -34,7 +34,6 @@ module RepoHost::Github
       user_client.rate_limit.remaining()
     end
 
-    # When the bucket refills, for scheduling a deferral until budget returns.
     def rate_limit_resets_at
       user_client.rate_limit.resets_at()
     end

--- a/github_hooks/lib/repo_host/github/client.rb
+++ b/github_hooks/lib/repo_host/github/client.rb
@@ -34,6 +34,11 @@ module RepoHost::Github
       user_client.rate_limit.remaining()
     end
 
+    # When the bucket refills, for scheduling a deferral until budget returns.
+    def rate_limit_resets_at
+      user_client.rate_limit.resets_at()
+    end
+
     def token_valid?
       validate_token_presence!
 

--- a/github_hooks/lib/semaphore/github_app/collaborators.rb
+++ b/github_hooks/lib/semaphore/github_app/collaborators.rb
@@ -4,7 +4,8 @@ module Semaphore::GithubApp
       client = new_client(repository_slug, repository_remote_id)
 
       return :no_token unless client
-      return :low_rate_limit if client.rate_limit_remaining() < App.collaborators_api_rate_limit
+
+      RateLimit.guard!(client)
 
       github_collaborators = fetch_collaborators(client, repository_slug)
       current_uids = GithubAppCollaborator.where(:r_name => repository_slug).pluck(:c_id)

--- a/github_hooks/lib/semaphore/github_app/collaborators/worker.rb
+++ b/github_hooks/lib/semaphore/github_app/collaborators/worker.rb
@@ -12,11 +12,8 @@ module Semaphore::GithubApp
                       :retry => App.worker_max_retries,
                       :dead => false
 
-      sidekiq_retry_in do |count, _exception, _jobhash|
-        delay = App.worker_base_delay * (2**count)
-        jitter = rand(0..App.worker_jitter_max)
-
-        [delay + jitter, App.worker_max_delay].min
+      sidekiq_retry_in do |count, exception, _jobhash|
+        Semaphore::GithubApp::RateLimit.retry_delay(count, exception)
       end
 
       sidekiq_retries_exhausted do |job, exception|
@@ -38,20 +35,19 @@ module Semaphore::GithubApp
         case result
         when :ok
           log(slug, "Finish")
-          delete_unique_lock([slug])
         when :no_token
           log(slug, "Token not found")
-          delete_unique_lock([slug])
         when :no_repository
           log(slug, "Repository not found on GitHub")
-          delete_unique_lock([slug])
-        when :low_rate_limit
-          log(slug, "Low Rate Limit — raising to trigger retry with backoff")
-          raise LowRateLimitError, "GitHub App API rate limit too low for #{slug}"
         else
           log(slug, "Unknown result: #{result.inspect}")
-          delete_unique_lock([slug])
         end
+
+        delete_unique_lock([slug])
+      rescue LowRateLimitError
+        # Keep the lock so Sidekiq retries.
+        log(slug, "Low Rate Limit — deferring retry until the bucket resets")
+        raise
       end
 
       private

--- a/github_hooks/lib/semaphore/github_app/hook.rb
+++ b/github_hooks/lib/semaphore/github_app/hook.rb
@@ -37,7 +37,7 @@ module Semaphore::GithubApp
         :event => event,
         :action => action
       )
-      Semaphore::GithubApp::Repositories::Worker.perform_in(10, installation_id) if sync
+      Semaphore::GithubApp::Repositories::Worker.perform_in(10, installation_id, sync)
 
       true
     rescue ActiveRecord::RecordNotFound

--- a/github_hooks/lib/semaphore/github_app/hook.rb
+++ b/github_hooks/lib/semaphore/github_app/hook.rb
@@ -7,7 +7,7 @@ module Semaphore::GithubApp
     def self.process(event, payload)
       action = payload["action"]
 
-      sync = !App.disable_collaborator_webhook_sync
+      sync = !App.disable_collaborator_sync
 
       installation_id = payload["installation"]["id"]
       repositories = map_repositories(payload["repositories"])

--- a/github_hooks/lib/semaphore/github_app/installations.rb
+++ b/github_hooks/lib/semaphore/github_app/installations.rb
@@ -22,7 +22,13 @@ class Semaphore::GithubApp::Installations
       body = JSON.parse(response.data[:body])
       body.map do |data|
         GithubAppInstallation.create(:installation_id => data["id"].to_i)
-        Semaphore::GithubApp::Repositories.refresh(data["id"].to_i)
+        begin
+          Semaphore::GithubApp::Repositories.refresh(data["id"].to_i)
+        rescue Semaphore::GithubApp::LowRateLimitError => e
+          # Skip a throttled installation so it doesn't abort init for the rest;
+          # its repositories populate on the next webhook or a manual refresh.
+          Rails.logger.warn("[Semaphore::GithubApp::Installation] Skipping refresh for installation #{data["id"]} — #{e.message}")
+        end
       end
     else
       Rails.logger.error("[Semaphore::GithubApp::Installation] Failed to fetch installations")

--- a/github_hooks/lib/semaphore/github_app/low_rate_limit_error.rb
+++ b/github_hooks/lib/semaphore/github_app/low_rate_limit_error.rb
@@ -1,3 +1,12 @@
 module Semaphore::GithubApp
-  class LowRateLimitError < StandardError; end
+  class LowRateLimitError < StandardError
+    # Time the throttled GitHub REST bucket refills, used to defer the Sidekiq
+    # retry until budget actually returns. nil when GitHub didn't report it.
+    attr_reader :resets_at
+
+    def initialize(message = nil, resets_at: nil)
+      super(message)
+      @resets_at = resets_at
+    end
+  end
 end

--- a/github_hooks/lib/semaphore/github_app/rate_limit.rb
+++ b/github_hooks/lib/semaphore/github_app/rate_limit.rb
@@ -28,9 +28,8 @@ module Semaphore::GithubApp
       raise LowRateLimitError.new("GitHub App REST rate limit below reserved floor", :resets_at => client.rate_limit_resets_at)
     end
 
-    # Sidekiq retry delay. A throttled job waits until the bucket resets, then
-    # disperses across the jitter window; any other failure keeps the capped
-    # exponential backoff.
+    # Sidekiq retry delay: defer a throttled job to the reset window, else keep
+    # the capped exponential backoff.
     def retry_delay(count, exception)
       return defer_delay(exception.resets_at) if exception.is_a?(LowRateLimitError)
 

--- a/github_hooks/lib/semaphore/github_app/rate_limit.rb
+++ b/github_hooks/lib/semaphore/github_app/rate_limit.rb
@@ -1,0 +1,49 @@
+module Semaphore::GithubApp
+  # Shared GitHub App REST rate-limit budgeting for the background sync workers.
+  #
+  # A reserved-headroom floor, and a retry schedule that defers a throttled job
+  # until the bucket resets (plus wide jitter) rather than a fixed exponential
+  # backoff whose retries re-converge and refire together.
+  module RateLimit
+    module_function
+
+    # Below this many remaining core-bucket calls, background App work steps aside
+    # so interactive/CI calls sharing the bucket keep their headroom.
+    def floor
+      App.collaborators_api_rate_limit
+    end
+
+    # Whether the client is under the reserved floor. Decided on remaining alone,
+    # so a missing reset time still throttles.
+    def exceeded?(client)
+      client.rate_limit_remaining < floor
+    end
+
+    # Raise to defer the current job when under the floor, carrying the reset time
+    # (nil if GitHub didn't report one) so the retry can wait for budget. The reset
+    # is read only once the floor trips; /rate_limit reads don't spend core quota.
+    def guard!(client)
+      return unless exceeded?(client)
+
+      raise LowRateLimitError.new("GitHub App REST rate limit below reserved floor", :resets_at => client.rate_limit_resets_at)
+    end
+
+    # Sidekiq retry delay. A throttled job waits until the bucket resets, then
+    # disperses across the jitter window; any other failure keeps the capped
+    # exponential backoff.
+    def retry_delay(count, exception)
+      return defer_delay(exception.resets_at) if exception.is_a?(LowRateLimitError)
+
+      jitter = rand(0..App.worker_jitter_max)
+      [App.worker_base_delay * (2**count) + jitter, App.worker_max_delay].min
+    end
+
+    # Seconds until the bucket resets (never negative) plus jitter across the
+    # configured spread. Falls back to jitter alone when the reset time is unknown
+    # or already past.
+    def defer_delay(resets_at, now: Time.now)
+      seconds_until_reset = resets_at ? [resets_at.to_i - now.to_i, 0].max : 0
+      seconds_until_reset + rand(0..App.github_app_rate_limit_defer_spread)
+    end
+  end
+end

--- a/github_hooks/lib/semaphore/github_app/repositories.rb
+++ b/github_hooks/lib/semaphore/github_app/repositories.rb
@@ -39,7 +39,8 @@ module Semaphore::GithubApp
 
     def refresh(sync_collaborators: true)
       return :no_token unless client
-      return :low_rate_limit if client.rate_limit_remaining() < App.collaborators_api_rate_limit
+
+      RateLimit.guard!(client)
 
       Semaphore::GithubApp::Hook.add_repositories(installation_id, repositories_to_add, :sync_collaborators => sync_collaborators)
       Semaphore::GithubApp::Hook.remove_repositories(installation_id, repositories_to_remove, :sync_collaborators => sync_collaborators)

--- a/github_hooks/lib/semaphore/github_app/repositories/remote_id_backfill.rb
+++ b/github_hooks/lib/semaphore/github_app/repositories/remote_id_backfill.rb
@@ -60,9 +60,9 @@ module Semaphore::GithubApp
           touch_pending_repositories(installation_id)
           return token_not_found(installation_id)
         end
-        if client(installation_id).rate_limit_remaining < App.collaborators_api_rate_limit
+        if RateLimit.exceeded?(client(installation_id))
           touch_pending_repositories(installation_id)
-          return low_rate_limit(installation_id)
+          return low_rate_limit(installation_id, client(installation_id).rate_limit_resets_at)
         end
 
         pending_repositories_by_slug = pending_repositories_for_installation(installation_id)
@@ -148,8 +148,8 @@ module Semaphore::GithubApp
         { :status => :no_token, :installation_id => installation_id }
       end
 
-      def low_rate_limit(installation_id)
-        { :status => :low_rate_limit, :installation_id => installation_id }
+      def low_rate_limit(installation_id, resets_at = nil)
+        { :status => :low_rate_limit, :installation_id => installation_id, :resets_at => resets_at }
       end
 
       def remote_repositories

--- a/github_hooks/lib/semaphore/github_app/repositories/remote_id_backfill/worker.rb
+++ b/github_hooks/lib/semaphore/github_app/repositories/remote_id_backfill/worker.rb
@@ -33,8 +33,8 @@ module Semaphore::GithubApp
           when :no_installation
             log(installation_id, "Installation not found")
           when :low_rate_limit
-            log(installation_id, "Low Rate Limit")
-            self.class.perform_in(15.minutes, installation_id)
+            log(installation_id, "Low Rate Limit — deferring until the bucket resets")
+            self.class.perform_in(Semaphore::GithubApp::RateLimit.defer_delay(result[:resets_at]), installation_id)
           else
             log(installation_id, "Unknown result: #{result.inspect}")
           end

--- a/github_hooks/lib/semaphore/github_app/repositories/worker.rb
+++ b/github_hooks/lib/semaphore/github_app/repositories/worker.rb
@@ -12,11 +12,8 @@ module Semaphore::GithubApp
                       :retry => App.worker_max_retries,
                       :dead => false
 
-      sidekiq_retry_in do |count, _exception, _jobhash|
-        delay = App.worker_base_delay * (2**count)
-        jitter = rand(0..App.worker_jitter_max)
-
-        [delay + jitter, App.worker_max_delay].min
+      sidekiq_retry_in do |count, exception, _jobhash|
+        Semaphore::GithubApp::RateLimit.retry_delay(count, exception)
       end
 
       sidekiq_retries_exhausted do |job, exception|
@@ -33,20 +30,19 @@ module Semaphore::GithubApp
         case result
         when :ok
           log(installation_id, "Finish")
-          delete_unique_lock([installation_id])
         when :no_token
           log(installation_id, "Token not found")
-          delete_unique_lock([installation_id])
         when :no_installation
           log(installation_id, "Installation not found")
-          delete_unique_lock([installation_id])
-        when :low_rate_limit
-          log(installation_id, "Low Rate Limit — raising to trigger retry with backoff")
-          raise LowRateLimitError, "GitHub App API rate limit too low for installation #{installation_id}"
         else
           log(installation_id, "Unknown result: #{result.inspect}")
-          delete_unique_lock([installation_id])
         end
+
+        delete_unique_lock([installation_id])
+      rescue LowRateLimitError
+        # Keep the lock so Sidekiq retries.
+        log(installation_id, "Low Rate Limit — deferring retry until the bucket resets")
+        raise
       rescue Semaphore::GithubApp::Repositories::IncompleteRepositoryListError => e
         log(installation_id, "Incomplete repository list — raising to trigger retry with backoff: #{e.message}")
         raise

--- a/github_hooks/lib/semaphore/github_app/repository_refresh.rb
+++ b/github_hooks/lib/semaphore/github_app/repository_refresh.rb
@@ -80,7 +80,8 @@ module Semaphore::GithubApp
     end
 
     # Fetch a single repository, cache it, and sync its collaborators. Returns a
-    # status symbol for RepositoryRefresh::Worker to log / retry on.
+    # status symbol for RepositoryRefresh::Worker to log on; raises
+    # LowRateLimitError under the reserved floor so the worker defers the retry.
     def self.fetch_and_cache_repository(installation_id, slug)
       token, _expires_at = Token.installation_token(installation_id)
       return :no_token unless token

--- a/github_hooks/lib/semaphore/github_app/repository_refresh.rb
+++ b/github_hooks/lib/semaphore/github_app/repository_refresh.rb
@@ -86,7 +86,7 @@ module Semaphore::GithubApp
       return :no_token unless token
 
       client = RepoHost::Github::Client.new(token)
-      return :low_rate_limit if client.rate_limit_remaining < App.collaborators_api_rate_limit
+      RateLimit.guard!(client)
 
       repository = client.repository(slug)
 
@@ -107,8 +107,13 @@ module Semaphore::GithubApp
     # Reconcile the repo list, then re-sync collaborators for every cached repo too:
     # access can change with no repo-list change, which a manual refresh must reflect.
     # Collaborators::Worker's per-slug lock dedupes any overlap with the delta path.
+    #
+    # The kill switch suppresses the collaborator fan-out here as on the webhook
+    # path; the repo-list refresh still runs so manual refresh keeps working.
     def self.refresh_installation(installation)
-      Repositories::Worker.perform_async(installation.installation_id)
+      sync_collaborators = !App.disable_collaborator_sync
+      Repositories::Worker.perform_async(installation.installation_id, sync_collaborators)
+      return unless sync_collaborators
 
       installation.installation_repositories.find_each do |repository|
         Collaborators::Worker.perform_in(10, repository.slug, repository.remote_id)

--- a/github_hooks/lib/semaphore/github_app/repository_refresh/worker.rb
+++ b/github_hooks/lib/semaphore/github_app/repository_refresh/worker.rb
@@ -24,11 +24,8 @@ module Semaphore::GithubApp
                       :retry => App.worker_max_retries,
                       :dead => false
 
-      sidekiq_retry_in do |count, _exception, _jobhash|
-        delay = App.worker_base_delay * (2**count)
-        jitter = rand(0..App.worker_jitter_max)
-
-        [delay + jitter, App.worker_max_delay].min
+      sidekiq_retry_in do |count, exception, _jobhash|
+        Semaphore::GithubApp::RateLimit.retry_delay(count, exception)
       end
 
       sidekiq_retries_exhausted do |job, exception|
@@ -55,16 +52,14 @@ module Semaphore::GithubApp
           log(installation_id, slug, "Token not found")
         when :no_repository
           log(installation_id, slug, "Repository not accessible to the installation")
-        when :low_rate_limit
-          log(installation_id, slug, "Low Rate Limit — raising to trigger retry with backoff")
-          raise LowRateLimitError, "GitHub App API rate limit too low for installation #{installation_id}"
         else
           log(installation_id, slug, "Unknown result: #{result.inspect}")
         end
 
         delete_unique_lock([installation_id, slug])
       rescue LowRateLimitError
-        # Retryable: keep the lock and let Sidekiq retry with backoff.
+        # Keep the lock so Sidekiq retries.
+        log(installation_id, slug, "Low Rate Limit — deferring retry until the bucket resets")
         raise
       rescue *RETRYABLE_ERRORS => e
         # Transient: keep the lock and re-raise so Sidekiq retries with backoff

--- a/github_hooks/spec/controllers/projects_controller_spec.rb
+++ b/github_hooks/spec/controllers/projects_controller_spec.rb
@@ -508,9 +508,9 @@ RSpec.describe ProjectsController, :type => :controller do
         end
       end
 
-      context "when collaborator webhook sync is disabled via env" do
+      context "when collaborator sync is disabled via env" do
         before do
-          allow(App).to receive(:disable_collaborator_webhook_sync).and_return(true)
+          allow(App).to receive(:disable_collaborator_sync).and_return(true)
         end
 
         context "and a github app repository webhook arrives" do

--- a/github_hooks/spec/lib/semaphore/github_app/collaborators/worker_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/collaborators/worker_spec.rb
@@ -75,12 +75,14 @@ module Semaphore::GithubApp
         described_class.new.perform(slug, remote_id)
       end
 
-      it "raises LowRateLimitError when result is :low_rate_limit" do
-        allow(Collaborators).to receive(:refresh).and_return(:low_rate_limit)
+      it "re-raises LowRateLimitError so Sidekiq retries with a deferred backoff" do
+        allow(Rails.logger).to receive(:info)
+        allow(Collaborators).to receive(:refresh)
+          .and_raise(LowRateLimitError.new("low", :resets_at => Time.zone.at(1_000_000)))
 
         expect do
           described_class.new.perform(slug, remote_id)
-        end.to raise_error(LowRateLimitError, /rate limit too low/i)
+        end.to raise_error(LowRateLimitError)
       end
     end
 
@@ -141,6 +143,13 @@ module Semaphore::GithubApp
         high_count_delay = retry_block.call(20, StandardError.new, {})
 
         expect(high_count_delay).to eq(max_delay)
+      end
+
+      it "delegates to RateLimit.retry_delay so rate-limit errors defer to the reset window" do
+        error = LowRateLimitError.new("low", :resets_at => Time.now + 300)
+        allow(Semaphore::GithubApp::RateLimit).to receive(:retry_delay).with(2, error).and_return(4321)
+
+        expect(described_class.sidekiq_retry_in_block.call(2, error, {})).to eq(4321)
       end
     end
 
@@ -236,7 +245,8 @@ module Semaphore::GithubApp
           item = Sidekiq::Queue.new("github_app").first.item
 
           # 2. Job fails because of rate limit — lock is NOT released
-          allow(Collaborators).to receive(:refresh).and_return(:low_rate_limit)
+          allow(Collaborators).to receive(:refresh)
+            .and_raise(LowRateLimitError.new("low", :resets_at => Time.zone.at(1_000_000)))
 
           middleware = SidekiqUniqueJobs::Middleware::Server.new
           expect do
@@ -335,7 +345,8 @@ module Semaphore::GithubApp
       it "does NOT release lock after :low_rate_limit (job will retry)" do
         SidekiqUniqueJobs.use_config(enabled: true) do
           allow(Rails.logger).to receive(:info)
-          allow(Collaborators).to receive(:refresh).and_return(:low_rate_limit)
+          allow(Collaborators).to receive(:refresh)
+            .and_raise(LowRateLimitError.new("low", :resets_at => Time.zone.at(1_000_000)))
 
           jid = described_class.perform_async(slug, remote_id)
           expect(jid).not_to be_nil

--- a/github_hooks/spec/lib/semaphore/github_app/collaborators_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/collaborators_spec.rb
@@ -75,7 +75,7 @@ module Semaphore::GithubApp
       end
 
       context "low API rate limits", :vcr => vcr_options do
-        it "returns low rate limit" do
+        it "raises LowRateLimitError so the worker defers the retry" do
           FactoryBot.create(:github_app_installation, :installation_id => 13612966,
                                                       :repositories => ["renderedtext/guard"])
 
@@ -85,11 +85,12 @@ module Semaphore::GithubApp
             :c_id => 8652,
             :installation_id => 13612966
           )
+          resets_at = Time.zone.at(1_000_000)
           allow_any_instance_of(RepoHost::Github::Client).to receive(:rate_limit_remaining).and_return(100)
+          allow_any_instance_of(RepoHost::Github::Client).to receive(:rate_limit_resets_at).and_return(resets_at)
 
-          result = described_class.refresh("renderedtext/guard")
-
-          expect(result).to eq(:low_rate_limit)
+          expect { described_class.refresh("renderedtext/guard") }
+            .to raise_error(LowRateLimitError) { |e| expect(e.resets_at).to eq(resets_at) }
         end
       end
     end

--- a/github_hooks/spec/lib/semaphore/github_app/hook_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/hook_spec.rb
@@ -305,9 +305,9 @@ module Semaphore::GithubApp
         end
       end
 
-      context "when collaborator webhook sync is disabled", :aggregate_failures do
+      context "when collaborator sync is disabled", :aggregate_failures do
         before do
-          allow(App).to receive(:disable_collaborator_webhook_sync).and_return(true)
+          allow(App).to receive(:disable_collaborator_sync).and_return(true)
         end
 
         context "add repositories" do

--- a/github_hooks/spec/lib/semaphore/github_app/hook_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/hook_spec.rb
@@ -297,7 +297,7 @@ module Semaphore::GithubApp
           result = described_class.process(event, payload)
 
           expect(result).to be(true)
-          expect(Semaphore::GithubApp::Repositories::Worker).to have_received(:perform_in).with(10, installation_id)
+          expect(Semaphore::GithubApp::Repositories::Worker).to have_received(:perform_in).with(10, installation_id, true)
           expect(Exceptions).to have_received(:notify).with(
             an_instance_of(Semaphore::GithubApp::Hook::NotUnique),
             hash_including(:installation_id => installation_id, :event => event, :action => "added")
@@ -354,8 +354,8 @@ module Semaphore::GithubApp
             allow(Exceptions).to receive(:notify)
           end
 
-          it "does not schedule the installation refresh" do
-            expect(Semaphore::GithubApp::Repositories::Worker).not_to receive(:perform_in)
+          it "still schedules the repository refresh with the collaborator sweep suppressed" do
+            expect(Semaphore::GithubApp::Repositories::Worker).to receive(:perform_in).with(10, installation_id, false)
 
             expect(described_class.process(event, payload)).to be(true)
           end

--- a/github_hooks/spec/lib/semaphore/github_app/installations_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/installations_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+module Semaphore::GithubApp
+  RSpec.describe Installations do
+    describe ".init!" do
+      let(:installations_body) { [{ "id" => 111 }, { "id" => 222 }].to_json }
+
+      before do
+        allow(Semaphore::GithubApp::Token).to receive(:generate_jwt).and_return("jwt")
+        allow(Excon).to receive(:get).and_return(
+          instance_double(Excon::Response, :status => 200, :data => { :body => installations_body })
+        )
+      end
+
+      it "creates every installation and refreshes each" do
+        allow(Semaphore::GithubApp::Repositories).to receive(:refresh).and_return(:ok)
+
+        described_class.init!
+
+        expect(GithubAppInstallation.pluck(:installation_id)).to contain_exactly(111, 222)
+        expect(Semaphore::GithubApp::Repositories).to have_received(:refresh).with(111)
+        expect(Semaphore::GithubApp::Repositories).to have_received(:refresh).with(222)
+      end
+
+      it "skips a rate-limited installation without aborting the rest" do
+        allow(Rails.logger).to receive(:warn)
+        allow(Semaphore::GithubApp::Repositories).to receive(:refresh)
+          .with(111).and_raise(LowRateLimitError.new("low", :resets_at => Time.zone.at(1_000_000)))
+        allow(Semaphore::GithubApp::Repositories).to receive(:refresh).with(222).and_return(:ok)
+
+        expect { described_class.init! }.not_to raise_error
+
+        expect(GithubAppInstallation.pluck(:installation_id)).to contain_exactly(111, 222)
+        expect(Semaphore::GithubApp::Repositories).to have_received(:refresh).with(222)
+        expect(Rails.logger).to have_received(:warn).with(/Skipping refresh for installation 111/)
+      end
+
+      it "does not swallow non-rate-limit errors" do
+        allow(Semaphore::GithubApp::Repositories).to receive(:refresh).with(111).and_raise(StandardError.new("boom"))
+
+        expect { described_class.init! }.to raise_error(StandardError, "boom")
+      end
+    end
+  end
+end

--- a/github_hooks/spec/lib/semaphore/github_app/rate_limit_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/rate_limit_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+
+module Semaphore::GithubApp
+  RSpec.describe RateLimit do
+    let(:floor) { App.collaborators_api_rate_limit }
+    let(:resets_at) { Time.zone.at(1_000_000) }
+
+    def client(remaining:, resets_at: nil)
+      instance_double(
+        RepoHost::Github::Client,
+        :rate_limit_remaining => remaining,
+        :rate_limit_resets_at => resets_at
+      )
+    end
+
+    describe ".floor" do
+      it "is the reserved-headroom threshold" do
+        expect(described_class.floor).to eq(App.collaborators_api_rate_limit)
+      end
+    end
+
+    describe ".exceeded?" do
+      it "is false at or above the floor" do
+        expect(described_class.exceeded?(client(:remaining => floor))).to be(false)
+        expect(described_class.exceeded?(client(:remaining => floor + 1))).to be(false)
+      end
+
+      it "is true below the floor" do
+        expect(described_class.exceeded?(client(:remaining => floor - 1))).to be(true)
+      end
+
+      it "decides on remaining alone, without reading the reset time" do
+        c = instance_double(RepoHost::Github::Client, :rate_limit_remaining => floor - 1)
+        expect(c).not_to receive(:rate_limit_resets_at)
+        expect(described_class.exceeded?(c)).to be(true)
+      end
+    end
+
+    describe ".guard!" do
+      it "does not raise (or read the reset time) when there is budget" do
+        c = instance_double(RepoHost::Github::Client, :rate_limit_remaining => floor)
+        expect(c).not_to receive(:rate_limit_resets_at)
+        expect { described_class.guard!(c) }.not_to raise_error
+      end
+
+      it "raises LowRateLimitError carrying the reset time when below the floor" do
+        c = client(:remaining => 0, :resets_at => resets_at)
+        expect { described_class.guard!(c) }
+          .to raise_error(LowRateLimitError) { |e| expect(e.resets_at).to eq(resets_at) }
+      end
+
+      it "still throttles when below the floor even if GitHub reports no reset time" do
+        c = client(:remaining => 0, :resets_at => nil)
+        expect { described_class.guard!(c) }
+          .to raise_error(LowRateLimitError) { |e| expect(e.resets_at).to be_nil }
+      end
+    end
+
+    describe ".defer_delay" do
+      let(:spread) { App.github_app_rate_limit_defer_spread }
+      let(:now) { Time.zone.at(1_000_000) }
+
+      it "waits until the reset, then jitters across the spread" do
+        future = now + 120
+        delays = Array.new(100) { described_class.defer_delay(future, :now => now) }
+
+        expect(delays).to all(be_between(120, 120 + spread))
+        expect(delays.max - delays.min).to be > spread / 2 # dispersed across the window
+      end
+
+      it "never returns a negative wait when the reset is already past" do
+        past = now - 5000
+        delays = Array.new(50) { described_class.defer_delay(past, :now => now) }
+        expect(delays).to all(be_between(0, spread))
+      end
+
+      it "falls back to jitter alone when the reset time is unknown" do
+        delays = Array.new(50) { described_class.defer_delay(nil, :now => now) }
+        expect(delays).to all(be_between(0, spread))
+      end
+    end
+
+    describe ".retry_delay" do
+      it "defers a rate-limit error until the reset window" do
+        now = Time.now
+        error = LowRateLimitError.new("low", :resets_at => now + 300)
+
+        delays = Array.new(50) { described_class.retry_delay(3, error) }
+
+        # Always at least the time until reset; never the old exponential curve.
+        expect(delays).to all(be >= 300)
+      end
+
+      it "keeps the capped exponential backoff for other failures" do
+        allow(described_class).to receive(:rand).and_return(0)
+        base = App.worker_base_delay
+        max = App.worker_max_delay
+
+        expect(described_class.retry_delay(0, StandardError.new)).to eq([base, max].min)
+        expect(described_class.retry_delay(2, StandardError.new)).to eq([base * 4, max].min)
+        expect(described_class.retry_delay(20, StandardError.new)).to eq(max)
+      end
+    end
+  end
+end

--- a/github_hooks/spec/lib/semaphore/github_app/repositories/remote_id_backfill/worker_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/repositories/remote_id_backfill/worker_spec.rb
@@ -19,14 +19,17 @@ module Semaphore::GithubApp
             described_class.new.perform
           end
 
-          it "retries the same installation on low rate limit" do
+          it "retries the same installation, deferred until the bucket resets, on low rate limit" do
+            resets_at = Time.zone.at(1_000_000)
             allow(Semaphore::GithubApp::Repositories::RemoteIdBackfill).to receive(:refresh_installation).with(123).and_return(
               {
                 :status => :low_rate_limit,
-                :installation_id => 123
+                :installation_id => 123,
+                :resets_at => resets_at
               }
             )
-            expect(described_class).to receive(:perform_in).with(15.minutes, 123)
+            allow(Semaphore::GithubApp::RateLimit).to receive(:defer_delay).with(resets_at).and_return(1234)
+            expect(described_class).to receive(:perform_in).with(1234, 123)
 
             described_class.new.perform(123)
           end

--- a/github_hooks/spec/lib/semaphore/github_app/repositories/remote_id_backfill_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/repositories/remote_id_backfill_spec.rb
@@ -44,6 +44,24 @@ module Semaphore::GithubApp
             ]
           )
         end
+
+        context "when the installation is under the rate-limit floor" do
+          let(:resets_at) { Time.zone.at(1_000_000) }
+          let(:client) do
+            instance_double(
+              RepoHost::Github::Client,
+              :rate_limit_remaining => App.collaborators_api_rate_limit - 1,
+              :rate_limit_resets_at => resets_at
+            )
+          end
+
+          it "defers with the bucket's reset time" do
+            result = described_class.refresh_installation(installation_id)
+
+            expect(result[:status]).to eq(:low_rate_limit)
+            expect(result[:resets_at]).to eq(resets_at)
+          end
+        end
       end
 
       describe ".refresh_next_installation" do

--- a/github_hooks/spec/lib/semaphore/github_app/repositories/worker_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/repositories/worker_spec.rb
@@ -68,12 +68,14 @@ module Semaphore::GithubApp
         described_class.new.perform(installation_id)
       end
 
-      it "raises LowRateLimitError when result is :low_rate_limit" do
-        allow(Repositories).to receive(:refresh).and_return(:low_rate_limit)
+      it "re-raises LowRateLimitError so Sidekiq retries with a deferred backoff" do
+        allow(Rails.logger).to receive(:info)
+        allow(Repositories).to receive(:refresh)
+          .and_raise(LowRateLimitError.new("low", :resets_at => Time.zone.at(1_000_000)))
 
         expect do
           described_class.new.perform(installation_id)
-        end.to raise_error(LowRateLimitError, /rate limit too low/i)
+        end.to raise_error(LowRateLimitError)
       end
 
       it "logs and reraises incomplete repository list errors" do
@@ -241,7 +243,8 @@ module Semaphore::GithubApp
           item = Sidekiq::Queue.new("github_app").first.item
 
           # 2. Job fails because of rate limit — lock is NOT released
-          allow(Repositories).to receive(:refresh).and_return(:low_rate_limit)
+          allow(Repositories).to receive(:refresh)
+            .and_raise(LowRateLimitError.new("low", :resets_at => Time.zone.at(1_000_000)))
 
           middleware = SidekiqUniqueJobs::Middleware::Server.new
           expect do
@@ -340,7 +343,8 @@ module Semaphore::GithubApp
       it "does NOT release lock after :low_rate_limit (job will retry)" do
         SidekiqUniqueJobs.use_config(enabled: true) do
           allow(Rails.logger).to receive(:info)
-          allow(Repositories).to receive(:refresh).and_return(:low_rate_limit)
+          allow(Repositories).to receive(:refresh)
+            .and_raise(LowRateLimitError.new("low", :resets_at => Time.zone.at(1_000_000)))
 
           jid = described_class.perform_async(installation_id)
           expect(jid).not_to be_nil

--- a/github_hooks/spec/lib/semaphore/github_app/repositories_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/repositories_spec.rb
@@ -208,6 +208,22 @@ module Semaphore::GithubApp
           expect(Semaphore::GithubApp::Hook).to have_received(:remove_repositories).with(installation_id, [], :sync_collaborators => true)
         end
       end
+
+      context "when the client is under the rate-limit floor" do
+        let(:client) do
+          instance_double(
+            RepoHost::Github::Client,
+            :rate_limit_remaining => App.collaborators_api_rate_limit - 1,
+            :rate_limit_resets_at => Time.zone.at(1_000_000)
+          )
+        end
+
+        it "raises LowRateLimitError before touching the repository list" do
+          expect(Semaphore::GithubApp::Hook).not_to receive(:add_repositories)
+
+          expect { described_class.refresh(installation_id) }.to raise_error(LowRateLimitError)
+        end
+      end
     end
   end
 end

--- a/github_hooks/spec/lib/semaphore/github_app/repository_refresh/worker_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/repository_refresh/worker_spec.rb
@@ -59,12 +59,14 @@ module Semaphore::GithubApp
         described_class.new.perform(installation_id, slug)
       end
 
-      it "raises LowRateLimitError when result is :low_rate_limit" do
-        allow(RepositoryRefresh).to receive(:fetch_and_cache_repository).and_return(:low_rate_limit)
+      it "re-raises LowRateLimitError so Sidekiq retries with a deferred backoff" do
+        allow(Rails.logger).to receive(:info)
+        allow(RepositoryRefresh).to receive(:fetch_and_cache_repository)
+          .and_raise(LowRateLimitError.new("low", :resets_at => Time.zone.at(1_000_000)))
 
         expect do
           described_class.new.perform(installation_id, slug)
-        end.to raise_error(LowRateLimitError, /rate limit too low/i)
+        end.to raise_error(LowRateLimitError)
       end
 
       it "treats a non-rate-limit error as terminal: releases the lock and does not retry" do

--- a/github_hooks/spec/lib/semaphore/github_app/repository_refresh_spec.rb
+++ b/github_hooks/spec/lib/semaphore/github_app/repository_refresh_spec.rb
@@ -40,7 +40,7 @@ module Semaphore::GithubApp
         result = described_class.full_for_organization(user.id, "acme")
 
         expect(result.state).to eq(:started)
-        expect(Repositories::Worker.jobs.map { |job| job["args"] }).to eq([[installation.installation_id]])
+        expect(Repositories::Worker.jobs.map { |job| job["args"] }).to eq([[installation.installation_id, true]])
       end
 
       context "when the caller has push access in the org" do
@@ -54,7 +54,7 @@ module Semaphore::GithubApp
 
           expect(result.state).to eq(:started)
           expect(result.message).to include("acme")
-          expect(Repositories::Worker.jobs.map { |job| job["args"] }).to eq([[installation.installation_id]])
+          expect(Repositories::Worker.jobs.map { |job| job["args"] }).to eq([[installation.installation_id, true]])
         end
 
         it "re-syncs collaborators for every already-cached repository" do
@@ -75,7 +75,7 @@ module Semaphore::GithubApp
 
           expect(result.state).to eq(:started)
           expect(GithubAppInstallation.exists?(:installation_id => 9090)).to be(true)
-          expect(Repositories::Worker.jobs.map { |job| job["args"] }).to eq([[9090]])
+          expect(Repositories::Worker.jobs.map { |job| job["args"] }).to eq([[9090, true]])
         end
 
         it "fails when the app is not installed on the org" do
@@ -139,7 +139,7 @@ module Semaphore::GithubApp
           result = described_class.full_for_organization(user.id, "acme")
 
           expect(result.state).to eq(:started)
-          expect(Repositories::Worker.jobs.map { |job| job["args"] }).to eq([[installation.installation_id]])
+          expect(Repositories::Worker.jobs.map { |job| job["args"] }).to eq([[installation.installation_id, true]])
         end
 
         it "discovers the installation via app JWT when the org has no cached repos" do
@@ -149,7 +149,7 @@ module Semaphore::GithubApp
           result = described_class.full_for_organization(user.id, "acme")
 
           expect(result.state).to eq(:started)
-          expect(Repositories::Worker.jobs.map { |job| job["args"] }).to eq([[9090]])
+          expect(Repositories::Worker.jobs.map { |job| job["args"] }).to eq([[9090, true]])
         end
 
         it "fails when the app is not installed on the org" do
@@ -637,13 +637,14 @@ module Semaphore::GithubApp
         expect(installation.installation_repositories.exists?(:slug => "renderedtext/brand-new-repo")).to be(false)
       end
 
-      it "returns :low_rate_limit without calling GitHub when the rate limit is too low" do
+      it "raises LowRateLimitError without calling GitHub when the rate limit is too low" do
         allow_any_instance_of(RepoHost::Github::Client).to receive(:rate_limit_remaining).and_return(0)
+        allow_any_instance_of(RepoHost::Github::Client).to receive(:rate_limit_resets_at).and_return(Time.zone.at(1_000_000))
         expect_any_instance_of(RepoHost::Github::Client).not_to receive(:repository)
 
-        result = described_class.fetch_and_cache_repository(installation.installation_id, "renderedtext/brand-new-repo")
-
-        expect(result).to eq(:low_rate_limit)
+        expect do
+          described_class.fetch_and_cache_repository(installation.installation_id, "renderedtext/brand-new-repo")
+        end.to raise_error(LowRateLimitError)
       end
 
       it "returns :no_token when no installation token is available" do
@@ -655,12 +656,12 @@ module Semaphore::GithubApp
       end
     end
 
-    context "when DISABLE_COLLABORATOR_WEBHOOK_SYNC is set" do
+    context "when DISABLE_COLLABORATOR_SYNC is set" do
       before do
-        allow(App).to receive(:disable_collaborator_webhook_sync).and_return(true)
+        allow(App).to receive(:disable_collaborator_sync).and_return(true)
       end
 
-      it "still enqueues the repository sync — manual refresh is not gated by the env flag" do
+      it "refreshes the repository list but suppresses the collaborator sweep" do
         user = FactoryBot.create(:user, :github_connection)
         installation = FactoryBot.create(:github_app_installation, :repositories => ["acme/widget"])
         GithubAppCollaborator.create!(
@@ -674,7 +675,8 @@ module Semaphore::GithubApp
 
         expect(result.state).to eq(:started)
         expect(Repositories::Worker.jobs.map { |job| job["args"] })
-          .to eq([[installation.installation_id]])
+          .to eq([[installation.installation_id, false]])
+        expect(Collaborators::Worker.jobs).to be_empty
       end
     end
   end


### PR DESCRIPTION
## Rationale — why this is the right change

The GitHub App collaborator/repository refresh path amplifies its own rate-limit pressure against the App's **shared** REST bucket.

When the reserved-floor guard trips, a worker `raise`s to trigger a Sidekiq retry — but the retry is scheduled with generic exponential backoff (`worker_base_delay * 2^count`, capped at `worker_max_delay`). Every deferred job re-converges at that cap and re-fires around the same time, so at each hourly bucket reset the fanned-out sweep re-stampedes the bucket it was already starving. A single throttled installation keeps the shared bucket pinned rather than stepping aside for interactive/CI traffic.

The fix is deliberately **local and lean** — no new global-limiter subsystem — and targets the three interacting defects that can be fixed without shared cross-worker state:

- **Retry schedule (primary).** A new `Semaphore::GithubApp::RateLimit` module owns the floor check and retry scheduling in one place. A rate-limited job now defers until the bucket **actually resets** (from the GitHub `resets_at` the guard captures), plus a jittered spread, instead of re-firing at the backoff cap. This consolidates the floor check that was previously copy-pasted inline across the sync modules and the identical `sidekiq_retry_in` backoff math duplicated in three workers. `retry_delay` dispatches rate-limit defers vs. generic backoff; `guard!` raises `LowRateLimitError` carrying `resets_at`.

- **Over-broad fan-out.** A manual org refresh fans out a collaborator sync to every cached repo (~100), and that sweep was **not** gated by the existing kill switch (only the webhook path was). It is now gated by the same switch. The repo-list refresh still runs so manual refresh keeps working — only the collaborator fan-out is suppressed. This invariant now holds on the webhook `RecordNotUnique` recovery path too: that rescue re-enqueues the repo-list refresh carrying the collaborator flag (previously it skipped the refresh entirely when the switch was set). The old `DISABLE_COLLABORATOR_WEBHOOK_SYNC` is folded into a canonical `disable_collaborator_sync`, read as an alias (via `.presence`, so a set-but-empty new var cannot shadow the deprecated one) so existing operators keep working with no config change.

- **Config semantics.** `COLLABORATORS_API_RATE_LIMIT` is documented as a reserved-headroom floor on the shared bucket (background sync steps aside below it) rather than a per-call cap.

**Fail-open fix (from review):** `exceeded?` tests `remaining < floor` purely; `guard!` reads `resets_at` only after the floor trips. A below-floor bucket with an unknown reset therefore still defers rather than silently proceeding — the earlier draft conflated "not exceeded" with "exceeded but reset unknown".

**Alternatives considered / deferred:**
- *A shared cross-worker limiter* (true per-call, cross-worker enforcement) would also close the check-then-act guard-overshoot window, but it requires shared state (Redis token bucket or similar) and is a materially larger change. Deferred honestly rather than half-built.
- *Making the jitter spread scale off the fan-out size* (instead of a static configurable window) is a reasonable future refinement; left as a static knob here to keep scope lean.

## Risk

- **Blast radius:** Medium. Scoped to the `github_hooks` GitHub App collaborator/repository sync path. It does not touch webhook ingestion, pipeline execution, or auth. The behavioral change operators can observe is later/deferred background collaborator syncs under throttling and a suppressed collaborator fan-out when the kill switch is set.
- **Change criticality:** Low–Medium. The core mechanism is retry-scheduling and a floor check — no data-model or security-boundary changes. The one genuine behavior change is the kill switch now also gating the manual-refresh collaborator sweep (intended), and the deprecated env var being read as an alias (backward compatible).
- **Overall:** **Medium.**
- **Mitigations & why it's safe to merge:**
  - The change is a net **de-duplication** — it removes inline floor checks and copy-pasted backoff math, replacing them with one tested module.
  - Covered by tests: full changed-spec suite green (273 examples, 0 failures) via the repo's `make test.ruby` harness; RuboCop clean. New specs cover the reset-aware defer, the fail-open floor trip, the kill-switch gating (repo-list still refreshes, collaborators suppressed), and per-installation isolation on throttling.
  - The kill switch is backward compatible (old env var honored as an alias); no operator action required to preserve current behavior.
  - Under the worst case the effect is *more* conservative (background sync backs off further), so a mis-tune degrades to slower background sync, not lost data.

## Pre-Submission Review

- **`/pr-review-toolkit:review-pr`** (code, tests, comments, errors, types) — run; findings addressed. The most significant was a **fail-open** in the original floor check (below-floor bucket with unknown reset would proceed); fixed by splitting `exceeded?` from the `resets_at` read, with a regression test.
- **`/code-review`** (working diff) — run; findings addressed. A second round on the pushed branch surfaced and fixed: an empty-string alias-shadow in `disable_collaborator_sync` (now `.presence`-guarded), the `RecordNotUnique` recovery path over-gating the repo-list refresh (now re-enqueues with the collaborator flag), a stale `fetch_and_cache_repository` docstring (it raises `LowRateLimitError` under the floor rather than returning a symbol), and two redundant/awkward comments. Behavior-changing fixes carry updated `hook_spec` coverage.
- **`/simplify`** (reuse / simplification / efficiency / altitude) — run; one simplification applied (`refresh_installation` collapsed to a single derived-boolean enqueue + guard-return). Efficiency review confirmed no extra GitHub round-trip (memoized client + cached `last_response`; `resets_at` read only on the throttle branch). Remaining suggestions were intentionally out of the lean scope and are noted above.

**Deferred follow-ups (not in this PR):** Watchman metrics on the new defer/kill-switch branches (observability), and a pre-existing `StandardError`-swallow-at-info in `repository_refresh/worker.rb`.

