### PR TITLE
fix(zebra): apply cache TTL atomically so entries cannot be cached forever

### DIFF
--- a/zebra/lib/zebra/cache.ex
+++ b/zebra/lib/zebra/cache.ex
@@ -1,18 +1,17 @@
 defmodule Zebra.Cache do
   require Logger
 
-  def fetch!(key, timeout, callback) do
-    case Cachex.fetch(:zebra_cache, key, callback) do
-      # from cache
+  def fetch!(key, timeout, callback) when is_integer(timeout) do
+    case Cachex.fetch(:zebra_cache, key, fn -> with_ttl(callback.(), timeout) end) do
       {:ok, value} ->
         value
 
-      # from fallback
       {:commit, value} ->
-        Cachex.expire(:zebra_cache, key, timeout)
         value
 
-      # from fallback
+      {:commit, value, _options} ->
+        value
+
       {:ignore, value} ->
         value
 
@@ -20,4 +19,15 @@ defmodule Zebra.Cache do
         e
     end
   end
+
+  defp with_ttl(result = {:error, _reason}, _timeout), do: result
+
+  defp with_ttl(result = {:ignore, _value}, _timeout), do: result
+
+  defp with_ttl({:commit, value}, timeout), do: {:commit, value, ttl: timeout}
+
+  defp with_ttl({:commit, value, options}, timeout),
+    do: {:commit, value, Keyword.put_new(options, :ttl, timeout)}
+
+  defp with_ttl(value, timeout), do: {:commit, value, ttl: timeout}
 end

--- a/zebra/test/zebra/cache_test.exs
+++ b/zebra/test/zebra/cache_test.exs
@@ -32,4 +32,82 @@ defmodule Zebra.CacheTest do
     assert Zebra.Cache.fetch!("t5", :timer.seconds(5), fn -> {:commit, "A"} end) == "A"
     assert Zebra.Cache.fetch!("t5", :timer.seconds(5), fn -> "B" end) == "A"
   end
+
+  test "if fallback returns {:error, value} it's not cached" do
+    assert Zebra.Cache.fetch!("t8", :timer.seconds(10), fn -> {:error, :boom} end) ==
+             {:error, :boom}
+
+    assert Zebra.Cache.fetch!("t8", :timer.seconds(5), fn -> "B" end) == "B"
+  end
+
+  test "a {:commit, value} entry keeps its ttl when the caller dies mid-fetch" do
+    assert_ttl_survives_caller_death("t6", fn -> {:commit, "A"} end)
+  end
+
+  test "a bare value entry keeps its ttl when the caller dies mid-fetch" do
+    assert_ttl_survives_caller_death("t7", fn -> "A" end)
+  end
+
+  test "a waiting caller's entry keeps its ttl when the fetch owner dies mid-fallback" do
+    key = "t9"
+    test_pid = self()
+
+    {owner, owner_ref} =
+      spawn_monitor(fn ->
+        Zebra.Cache.fetch!(key, :timer.seconds(60), fn ->
+          send(test_pid, :fallback_running)
+          :timer.sleep(500)
+          {:commit, "A"}
+        end)
+      end)
+
+    assert_receive :fallback_running, 1_000
+
+    spawn(fn ->
+      send(test_pid, {:waiter, Zebra.Cache.fetch!(key, :timer.seconds(60), fn -> "B" end)})
+    end)
+
+    :timer.sleep(100)
+    Process.exit(owner, :kill)
+    assert_receive {:DOWN, ^owner_ref, :process, ^owner, :killed}, 1_000
+
+    assert_receive {:waiter, "A"}, 2_000
+
+    assert {:ok, ttl} = Cachex.ttl(:zebra_cache, key)
+    assert_in_delta ttl, :timer.seconds(60), :timer.seconds(5)
+  end
+
+  defp assert_ttl_survives_caller_death(key, fallback) do
+    {pid, ref} =
+      spawn_monitor(fn ->
+        Zebra.Cache.fetch!(key, :timer.seconds(60), fn ->
+          :timer.sleep(300)
+          fallback.()
+        end)
+      end)
+
+    :timer.sleep(100)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 1_000
+
+    assert wait_until(fn -> Cachex.get(:zebra_cache, key) == {:ok, "A"} end),
+           "fallback value was never committed to the cache"
+
+    assert {:ok, ttl} = Cachex.ttl(:zebra_cache, key)
+    assert_in_delta ttl, :timer.seconds(60), :timer.seconds(5)
+  end
+
+  defp wait_until(condition, attempts \\ 20) do
+    cond do
+      condition.() ->
+        true
+
+      attempts == 0 ->
+        false
+
+      true ->
+        :timer.sleep(100)
+        wait_until(condition, attempts - 1)
+    end
+  end
 end


### PR DESCRIPTION
`Zebra.Cache.fetch!/3` wrote the cache entry through `Cachex.fetch/3` and then applied the TTL in a second, separate call from the caller process. `:zebra_cache` has no default expiration, so if the caller died in between — a linked `Task.async` raising while a job is being validated is enough, and `DBConnection.ConnectionError` supplies hundreds of those a day — the entry was retained with no TTL and served for the remaining life of the pod. Cachex 3.6 accepts `{:commit, value, ttl: ...}`, so the TTL now travels with the value and is applied at write time regardless of what happens to the caller. The duration is unchanged; it is simply applied reliably.

In production this froze the self-hosted agent-type list on some job workers, so jobs for an agent type created after the snapshot were force-finished as `Unknown self-hosted agent type` on those workers while running fine on others. The org quota cache reads through the same helper and had the same exposure.

Tested by a regression test that kills the caller mid-fetch and asserts the entry still carries a TTL — it fails on the previous code, where the entry comes back with `ttl: nil`, and covers both the `{:commit, value}` and bare-value paths. Full zebra suite green.

Two commits here are incidental. `zebra/.mix-audit.txt` accepts the three grpc advisories, matching what front, guard, notifications, hooks_processor, ee/rbac and ee/audit already do — the dependency gate otherwise blocks any zebra change, and grpc 1.0.0 is the coordinated breaking major tracked separately. The `git config --global http.version HTTP/1.1` line in `zebra/Dockerfile` is **temporary**: git 2.34.1 on the jammy builder cannot parse GitHub's protocol-v2 ref listing over HTTP/2 and falls back to prompting for credentials, so `mix deps.get` fails and no zebra image builds from a cold cache. Revert it once that clears.
