### PR TITLE
ci(zebra): unblock the zebra pipeline

### DIFF
--- a/zebra/.mix-audit.txt
+++ b/zebra/.mix-audit.txt
@@ -20,3 +20,30 @@ GHSA-gp9c-pm5m-5cxr
 GHSA-j9wq-vxxc-94wf
 GHSA-mp55-p8c9-rfw2
 GHSA-pj7v-xfvx-wmjq
+
+# --- grpc 0.5.0-beta.1 advisories, all first patched in grpc 1.0.0 ---
+# grpc 1.0.0 is a breaking major shared across the monorepo and is handled as a coordinated
+# migration (front/.mix-audit.txt carries the list), not a patch bump on a single app.
+# Reachability below is specific to the 0.5.0-beta.1 line and must be re-derived on any bump:
+# later lines auto-register codecs/compressors that this one does not.
+#
+# UNREACHABLE — RCE / atom-table exhaustion via :erlang.binary_to_term in
+# GRPC.Codec.Erlpack.decode/2 (critical). GRPC.Server defaults codecs to [GRPC.Codec.Proto] and
+# zebra registers none (grep for Erlpack, GRPC.Codec and `codecs:` across lib/ and config/ returns
+# nothing), so find_codec/2 rejects application/grpc+erlpack before decode/2 is reached. All 18
+# GRPC.Stub.connect sites pass no codec either.
+GHSA-grp7-v8xh-rj7h
+
+# UNREACHABLE — unbounded gzip decompression (decompression bomb). On this grpc line the server
+# compressor list defaults to [] and zebra registers none, so find_compressor/2 answers
+# :unimplemented for any grpc-encoding and a compressed frame is rejected as :invalid_argument
+# before GRPC.Compressor.Gzip.decompress/1 is called. Note the advisory's PoC pins ~> 0.9, where
+# the compressor IS auto-registered — this stanza does not transfer to apps on that line.
+GHSA-6ccx-9c9f-327w
+
+# REACHABLE, BOUNDED — unbounded request-body accumulation in read_full_body/3 on the default
+# unary ingress path; there is no running total and no cap. Availability-only: worst case is
+# memory exhaustion in the receiving process, with no data exposure and no code execution. The
+# remaining bound is network-level rather than anything in this dependency. Accepted until the
+# grpc 1.0.0 migration; this is the stanza to revisit first.
+GHSA-q8gf-9rvj-gmgj

--- a/zebra/Dockerfile
+++ b/zebra/Dockerfile
@@ -18,6 +18,11 @@ RUN apt-get update && \
 RUN mix local.hex --force \
   && mix local.rebar --force
 
+ENV GIT_TERMINAL_PROMPT=0 \
+    GIT_CONFIG_COUNT=1 \
+    GIT_CONFIG_KEY_0=http.https://github.com/.version \
+    GIT_CONFIG_VALUE_0=HTTP/1.1
+
 RUN mkdir -p ~/.ssh
 RUN touch ~/.ssh/known_hosts
 RUN ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
Two independent gates stop any zebra change from going green, neither related to application code. Split out of semaphoreio/semaphore#1216 so the fix there reviews on its own.

The builder image ships git 2.34.1, which cannot parse GitHub's protocol-v2 ref listing over HTTP/2 — it aborts with `expected flush after ref listing` and falls back to a credential prompt, so `mix deps.get` fails on every git-sourced dependency and no image builds from a cold cache. Reproduced in the base image against unrelated public repositories: protocol v0 and HTTP/1.1 both succeed, HTTP/2 does not. Pinned per-host so a future non-GitHub remote is not silently downgraded, and via `GIT_CONFIG_*` so it stays a build-time override rather than state baked into the image. The runtime stage does not derive from `base`, so none of it reaches the shipped image. **Temporary — revert once the upstream behaviour clears.**

The dependency gate fails on three grpc advisories, all first patched in the breaking grpc 1.0.0 major that is already handled as a coordinated migration. Reachability was re-derived against the pinned 0.5.0-beta.1 source rather than the advisory text: the Erlpack RCE and the gzip bomb are unreachable because no codec and no compressor are registered on this line, and `read_full_body` is genuinely reachable and accepted as availability-only. The gzip argument is version-specific and does not transfer to apps on later grpc lines — noted inline, since a bump invalidates it.