### PR TITLE
fix(zebra): set GIT_TERMINAL_PROMPT=0 on hosted jobs

### DIFF
--- a/zebra/lib/zebra/workers/job_request_factory.ex
+++ b/zebra/lib/zebra/workers/job_request_factory.ex
@@ -191,7 +191,8 @@ defmodule Zebra.Workers.JobRequestFactory do
     if Job.hosted?(job.machine_type) do
       [
         JobRequest.env_var("PAGER", "cat"),
-        JobRequest.env_var("DISPLAY", ":99")
+        JobRequest.env_var("DISPLAY", ":99"),
+        JobRequest.env_var("GIT_TERMINAL_PROMPT", "0")
       ] ++ common_vars
     else
       common_vars

--- a/zebra/test/zebra/workers/job_request_factory_test.exs
+++ b/zebra/test/zebra/workers/job_request_factory_test.exs
@@ -313,6 +313,10 @@ defmodule Zebra.Workers.JobRequestFactoryTest do
                "value" => Base.encode64(":99")
              },
              %{
+               "name" => "GIT_TERMINAL_PROMPT",
+               "value" => Base.encode64("0")
+             },
+             %{
                "name" => "TERM",
                "value" => Base.encode64("xterm")
              },
@@ -553,6 +557,10 @@ defmodule Zebra.Workers.JobRequestFactoryTest do
              %{
                "name" => "DISPLAY",
                "value" => Base.encode64(":99")
+             },
+             %{
+               "name" => "GIT_TERMINAL_PROMPT",
+               "value" => Base.encode64("0")
              },
              %{
                "name" => "TERM",
@@ -1034,6 +1042,10 @@ defmodule Zebra.Workers.JobRequestFactoryTest do
              %{
                "name" => "DISPLAY",
                "value" => Base.encode64(":99")
+             },
+             %{
+               "name" => "GIT_TERMINAL_PROMPT",
+               "value" => Base.encode64("0")
              },
              %{
                "name" => "TERM",


### PR DESCRIPTION
Hosted CI jobs build their environment in `Zebra.Workers.JobRequestFactory.env_vars/4`, which already injects hosted-only defaults (`PAGER`, `DISPLAY`). This adds `GIT_TERMINAL_PROMPT=0` to that set.

When a git operation in a hosted job hits an HTTP 401 — recently seen intermittently on unauthenticated clones of public GitHub repos over HTTP/2 (https://github.com/orgs/community/discussions/206581) — git falls back to prompting for a username on stdin. In CI there is no terminal, so the job blocks on that prompt and sits in RUNNING until it times out, instead of failing fast with a clear error. `GIT_TERMINAL_PROMPT=0` makes git fail immediately, which frees the agent and surfaces the real error.

Scope is hosted agents only (`Job.hosted?/1`); self-hosted (`s1-*`) agents run on the customer's own network and are untouched. User pipelines can still override the value — the pipeline's own `env_vars` are applied last and win.

Tests: the three hosted `env_vars` assertions in `job_request_factory_test.exs` now include the new variable; the self-hosted assertion is unchanged and asserts the variable is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
