### PR TITLE
chore(plumber): accept grpc 0.3.1 advisory GHSA-q8gf-9rvj-gmgj (ppl + block mix-audit)

### DIFF
--- a/plumber/block/.mix-audit.txt
+++ b/plumber/block/.mix-audit.txt
@@ -59,3 +59,11 @@ GHSA-pj7v-xfvx-wmjq
 #   GHSA-w4f7-4cxr-rv3c — HTTP request/response splitting (shared cowboy/gun advisory)
 GHSA-r53j-fjj5-mv77
 GHSA-w4f7-4cxr-rv3c
+
+# grpc — unbounded request body accumulation in read_full_body/3 enables an
+# unauthenticated DoS (GHSA-q8gf-9rvj-gmgj, high). The grpc 0.3.1 adapter itself,
+# the same old stack behind the cowboy/cowlib/gun advisories accepted above.
+# Patched in grpc 1.0.0, a major bump of the plumber gRPC stack — out of scope here
+# and tracked in semaphoreio/semaphore#1134. plumber's gRPC endpoints serve
+# internal-service traffic only; no user-controlled request bodies reach read_full_body/3.
+GHSA-q8gf-9rvj-gmgj

--- a/plumber/ppl/.mix-audit.txt
+++ b/plumber/ppl/.mix-audit.txt
@@ -60,3 +60,11 @@ GHSA-pj7v-xfvx-wmjq
 #   GHSA-w4f7-4cxr-rv3c — HTTP request/response splitting (shared cowboy/gun advisory)
 GHSA-r53j-fjj5-mv77
 GHSA-w4f7-4cxr-rv3c
+
+# grpc — unbounded request body accumulation in read_full_body/3 enables an
+# unauthenticated DoS (GHSA-q8gf-9rvj-gmgj, high). This is the grpc 0.3.1 adapter
+# itself, the same old stack behind the cowboy/cowlib/gun advisories accepted above.
+# Patched in grpc 1.0.0, a major bump of the plumber gRPC stack — out of scope here
+# and tracked in semaphoreio/semaphore#1134. plumber's gRPC server takes
+# internal-service calls only; no user-controlled request bodies reach read_full_body/3.
+GHSA-q8gf-9rvj-gmgj


### PR DESCRIPTION
## What

Accept `GHSA-q8gf-9rvj-gmgj` (grpc 0.3.1) in both plumber `.mix-audit.txt` allowlists — `plumber/ppl` and `plumber/block`.

## Why

`mix_audit` newly flags **grpc 0.3.1** for `GHSA-q8gf-9rvj-gmgj` — unbounded request body accumulation in `read_full_body/3`, high severity. It's the grpc adapter itself, from the same 0.3.1 stack whose transitive advisories (cowboy, cowlib, gun) are already accepted in both files. The real fix is a gRPC-stack major bump (grpc 1.0.0), out of scope here and tracked in semaphoreio/semaphore#1134. plumber's gRPC endpoints serve internal-service traffic only — no user-controlled request bodies reach `read_full_body/3` — so the DoS vector is not reachable in this deployment.

The advisory is pre-existing and repo-wide: neither `mix.lock` changes, so `main` currently fails the `Ppl: Deployment Preconditions` and `Blocks: Deployment Preconditions` dependency gates on it. Both ppl and block carry grpc 0.3.1 and run their own gate, so both need the entry. This restores those gates.

## Tested

`make check.ex.deps` (mix_audit) passes for ppl and block with the entries; no lockfile or code change.
