### PR TITLE
fix(zebra): keep get_agent_payload idempotent for the job's lifetime

### DIFF
--- a/zebra/lib/zebra/apis/internal_job_api.ex
+++ b/zebra/lib/zebra/apis/internal_job_api.ex
@@ -296,13 +296,9 @@ defmodule Zebra.Apis.InternalJobApi do
 
       case Job.find(req.job_id) do
         {:ok, job} ->
-          # Now that the self-hosted agent will receive the job request, we can sanitize it.
-          Task.start(
-            Zebra.Models.Job,
-            :sanitize_job_request,
-            [job.id]
-          )
-
+          # Agents refetch this payload when a response is lost in transit, so it
+          # has to stay identical for the whole life of the job. The request is
+          # sanitized when the job reaches a terminal state instead.
           InternalApi.ServerFarm.Job.GetAgentPayloadResponse.new(
             payload: Poison.encode!(job.request)
           )

--- a/zebra/lib/zebra/models/job.ex
+++ b/zebra/lib/zebra/models/job.ex
@@ -602,20 +602,6 @@ defmodule Zebra.Models.Job do
     }
   end
 
-  def sanitize_job_request(job_id) do
-    case find(job_id) do
-      {:ok, job} ->
-        if !JobRequest.sanitized?(job.request) do
-          update(job, %{
-            request: JobRequest.sanitize(job.request)
-          })
-        end
-
-      {:error, :not_found} ->
-        Logger.error("Error sanitizing '#{job_id}': not found")
-    end
-  end
-
   def finish(job, result) do
     if result == nil do
       {:error, :result_cant_be_nil}

--- a/zebra/lib/zebra/models/job.ex
+++ b/zebra/lib/zebra/models/job.ex
@@ -324,7 +324,8 @@ defmodule Zebra.Models.Job do
         aasm_state: state_finished(),
         finished_at: now,
         result: result_failed(),
-        failure_reason: reason
+        failure_reason: reason,
+        request: JobRequest.sanitize(job.request)
       })
 
     optimisticaly_finish_task(job)
@@ -625,7 +626,8 @@ defmodule Zebra.Models.Job do
         params = %{
           aasm_state: state_finished(),
           finished_at: now,
-          result: result
+          result: result,
+          request: JobRequest.sanitize(job.request)
         }
 
         case update(job, params) do

--- a/zebra/lib/zebra/models/job.ex
+++ b/zebra/lib/zebra/models/job.ex
@@ -325,7 +325,7 @@ defmodule Zebra.Models.Job do
         finished_at: now,
         result: result_failed(),
         failure_reason: reason,
-        request: JobRequest.sanitize(job.request)
+        request: sanitized_request(job)
       })
 
     optimisticaly_finish_task(job)
@@ -362,7 +362,7 @@ defmodule Zebra.Models.Job do
         finished_at: now,
         result: result_failed(),
         failure_reason: reason,
-        request: JobRequest.sanitize(j.request)
+        request: sanitized_request(j)
       }
 
       case update(j, params) do
@@ -598,8 +598,23 @@ defmodule Zebra.Models.Job do
       port: agent.ssh_port,
       agent_ctrl_port: agent.ctrl_port,
       agent_auth_token: agent.auth_token,
-      request: JobRequest.sanitize(job.request)
+      request: sanitized_request(job)
     }
+  end
+
+  # Sanitization is what keeps secrets from being left at rest, but a raise here
+  # would abort the transition that invoked it: the job would never leave its
+  # current state, and the stop request the terminator files would be retried
+  # forever. Drop the whole request instead, and make the shape that caused it
+  # alertable rather than silent.
+  defp sanitized_request(job) do
+    JobRequest.sanitize(job.request)
+  rescue
+    e ->
+      Logger.error("Failed to sanitize request of '#{job.id}': #{inspect(e)}")
+      Watchman.increment("job.request_sanitize.failed")
+
+      %{}
   end
 
   def finish(job, result) do
@@ -613,7 +628,7 @@ defmodule Zebra.Models.Job do
           aasm_state: state_finished(),
           finished_at: now,
           result: result,
-          request: JobRequest.sanitize(job.request)
+          request: sanitized_request(job)
         }
 
         case update(job, params) do
@@ -647,7 +662,7 @@ defmodule Zebra.Models.Job do
         aasm_state: state_finished(),
         finished_at: now,
         result: result_stopped(),
-        request: JobRequest.sanitize(job.request),
+        request: sanitized_request(job),
         machine_type: job.machine_type || ""
       }
 

--- a/zebra/lib/zebra/workers/job_request_factory/job_request.ex
+++ b/zebra/lib/zebra/workers/job_request_factory/job_request.ex
@@ -213,12 +213,16 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequest do
 
   defp sanitize_env_vars(env_vars) do
     env_vars
-    |> Enum.map(fn env_var ->
-      if sensitive_env_var?(env_var["name"]) do
-        sanitize_env_var(env_var)
-      else
+    |> Enum.map(fn
+      env_var when is_map(env_var) ->
+        if sensitive_env_var?(env_var["name"]) do
+          sanitize_env_var(env_var)
+        else
+          env_var
+        end
+
+      env_var ->
         env_var
-      end
     end)
   end
 
@@ -234,6 +238,14 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequest do
   defp sanitize_env_var(%{"value" => _, "name" => name}) do
     env_var(name, @sanitized, encode_to_base64: false)
   end
+
+  # Fail closed: an env var we do not recognise still must not keep its value.
+  defp sanitize_env_var(env_var) do
+    env_var(env_var["name"], @sanitized, encode_to_base64: false)
+  end
+
+  # Fail closed: a name we cannot inspect is treated as sensitive.
+  defp sensitive_env_var?(name) when not is_binary(name), do: true
 
   defp sensitive_env_var?(name) do
     cond do
@@ -296,12 +308,14 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequest do
   defp sanitize_containers(nil), do: nil
 
   defp sanitize_containers(containers) do
-    Enum.map(containers, fn container ->
-      %{
+    Enum.map(containers, fn
+      container when is_map(container) ->
         container
-        | "env_vars" => sanitize_env_vars(container["env_vars"]),
-          "files" => sanitize_files(container["files"])
-      }
+        |> sanitize_if_present("env_vars", fn v -> sanitize_env_vars(v) end)
+        |> sanitize_if_present("files", fn v -> sanitize_files(v) end)
+
+      container ->
+        container
     end)
   end
 

--- a/zebra/lib/zebra/workers/job_request_factory/job_request.ex
+++ b/zebra/lib/zebra/workers/job_request_factory/job_request.ex
@@ -164,7 +164,7 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequest do
     end
   end
 
-  def sanitize(nil), do: nil
+  def sanitize(request) when not is_map(request), do: request
 
   def sanitize(request) do
     request
@@ -202,16 +202,13 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequest do
 
   defp sanitize_logger(logger), do: logger
 
-  defp sanitize_keys(nil), do: nil
-  defp sanitize_keys([]), do: []
-
-  defp sanitize_keys(keys) do
+  defp sanitize_keys(keys) when is_list(keys) do
     Enum.map(keys, fn _key -> @sanitized end)
   end
 
-  defp sanitize_env_vars(nil), do: nil
+  defp sanitize_keys(keys), do: keys
 
-  defp sanitize_env_vars(env_vars) do
+  defp sanitize_env_vars(env_vars) when is_list(env_vars) do
     env_vars
     |> Enum.map(fn
       env_var when is_map(env_var) ->
@@ -225,6 +222,8 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequest do
         env_var
     end)
   end
+
+  defp sanitize_env_vars(env_vars), do: env_vars
 
   # When sanitizing old requests, we should keep the same old structure, instead of mixing the two.
   defp sanitize_env_var(%{"unencrypted_content" => _, "name" => name}) do
@@ -267,9 +266,7 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequest do
     end
   end
 
-  defp sanitize_files(nil), do: nil
-
-  defp sanitize_files(files) do
+  defp sanitize_files(files) when is_list(files) do
     files
     |> Enum.map(fn file ->
       cond do
@@ -290,6 +287,8 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequest do
     end)
   end
 
+  defp sanitize_files(files), do: files
+
   defp sanitize_compose(
          compose = %{
            "containers" => containers,
@@ -305,9 +304,7 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequest do
 
   defp sanitize_compose(compose), do: compose
 
-  defp sanitize_containers(nil), do: nil
-
-  defp sanitize_containers(containers) do
+  defp sanitize_containers(containers) when is_list(containers) do
     Enum.map(containers, fn
       container when is_map(container) ->
         container
@@ -319,16 +316,22 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequest do
     end)
   end
 
-  defp sanitize_image_pull_credentials(nil), do: nil
+  defp sanitize_containers(containers), do: containers
 
-  defp sanitize_image_pull_credentials(credentials) do
-    Enum.map(credentials, fn credential ->
-      %{
-        "env_vars" => sanitize_env_vars(credential["env_vars"]),
-        "files" => sanitize_files(credential["files"])
-      }
+  defp sanitize_image_pull_credentials(credentials) when is_list(credentials) do
+    Enum.map(credentials, fn
+      credential when is_map(credential) ->
+        %{
+          "env_vars" => sanitize_env_vars(credential["env_vars"]),
+          "files" => sanitize_files(credential["files"])
+        }
+
+      credential ->
+        credential
     end)
   end
+
+  defp sanitize_image_pull_credentials(credentials), do: credentials
 
   #
   # On November 1st 2020, DockerHub introduced rate limits for pulling Docker

--- a/zebra/test/zebra/apis/internal_job_api_test.exs
+++ b/zebra/test/zebra/apis/internal_job_api_test.exs
@@ -929,7 +929,12 @@ defmodule Zebra.Api.InternalJobApiTest do
       alias InternalApi.ServerFarm.Job.GetAgentPayloadResponse, as: Response
       alias InternalApi.ServerFarm.Job.JobService.Stub, as: Stub
 
-      {:ok, job} = Support.Factories.Job.create(:started, %{request: agent_job_request()})
+      # GetAgentPayload is pulled by self-hosted agents; hosted jobs are pushed.
+      {:ok, job} =
+        Support.Factories.Job.create(:started, %{
+          machine_type: "s1-test",
+          request: agent_job_request()
+        })
 
       {:ok, channel} = GRPC.Stub.connect("localhost:50051")
 

--- a/zebra/test/zebra/apis/internal_job_api_test.exs
+++ b/zebra/test/zebra/apis/internal_job_api_test.exs
@@ -923,6 +923,31 @@ defmodule Zebra.Api.InternalJobApiTest do
       assert {:error, %GRPC.RPCError{message: "Not found", status: 5}} =
                Stub.get_agent_payload(channel, request)
     end
+
+    test "when the job is fetched twice => both payloads are intact" do
+      alias InternalApi.ServerFarm.Job.GetAgentPayloadRequest, as: Request
+      alias InternalApi.ServerFarm.Job.GetAgentPayloadResponse, as: Response
+      alias InternalApi.ServerFarm.Job.JobService.Stub, as: Stub
+
+      {:ok, job} = Support.Factories.Job.create(:started, %{request: agent_job_request()})
+
+      {:ok, channel} = GRPC.Stub.connect("localhost:50051")
+
+      request = Request.new(job_id: job.id)
+
+      assert {:ok, %Response{payload: first}} = Stub.get_agent_payload(channel, request)
+
+      # The agent refetches the payload when a response is lost in transit, so
+      # give any sanitization the first fetch may have scheduled the chance to
+      # land before refetching. Without this the second fetch races it.
+      await_sanitization(job.id)
+
+      assert {:ok, %Response{payload: second}} = Stub.get_agent_payload(channel, request)
+
+      assert_payload_decodable(first)
+      assert_payload_decodable(second)
+      assert second == first
+    end
   end
 
   describe ".can_debug" do
@@ -1166,5 +1191,59 @@ defmodule Zebra.Api.InternalJobApiTest do
                self_hosted: false
              } = reply.job
     end
+  end
+
+  defp agent_job_request do
+    alias Zebra.Workers.JobRequestFactory.JobRequest
+
+    %{
+      "job_id" => Ecto.UUID.generate(),
+      "env_vars" => [
+        JobRequest.env_var("SEMAPHORE_JOB_ID", "job-id"),
+        JobRequest.env_var("SEMAPHORE_OIDC_TOKEN", "oidc-token"),
+        JobRequest.env_var("MY_SECRET", "s3cr3t")
+      ],
+      "files" => [
+        JobRequest.file("/home/semaphore/.npmrc", "//registry/:_authToken=abc", "0600")
+      ]
+    }
+  end
+
+  # Blocks until the stored request is sanitized, or until the deadline passes.
+  # Returns as soon as sanitization lands, so the caller never depends on timing
+  # to observe it.
+  defp await_sanitization(job_id, deadline_in_ms \\ 1_000) do
+    alias Zebra.Models.Job
+    alias Zebra.Workers.JobRequestFactory.JobRequest
+
+    deadline = System.monotonic_time(:millisecond) + deadline_in_ms
+
+    Stream.repeatedly(fn ->
+      {:ok, job} = Job.find(job_id)
+
+      if JobRequest.sanitized?(job.request) do
+        :sanitized
+      else
+        Process.sleep(10)
+        :pending
+      end
+    end)
+    |> Enum.find(fn result ->
+      result == :sanitized or System.monotonic_time(:millisecond) >= deadline
+    end)
+  end
+
+  defp assert_payload_decodable(payload) do
+    request = Poison.decode!(payload)
+
+    Enum.each(request["env_vars"], fn env_var ->
+      assert match?({:ok, _}, Base.decode64(env_var["value"])),
+             "env var #{env_var["name"]} is not decodable: #{inspect(env_var["value"])}"
+    end)
+
+    Enum.each(request["files"], fn file ->
+      assert match?({:ok, _}, Base.decode64(file["content"])),
+             "file #{file["path"]} is not decodable: #{inspect(file["content"])}"
+    end)
   end
 end

--- a/zebra/test/zebra/models/job_test.exs
+++ b/zebra/test/zebra/models/job_test.exs
@@ -199,6 +199,19 @@ defmodule Zebra.Models.JobTest do
       assert Zebra.Models.Task.finished?(task)
     end
 
+    test "when sanitization raises => still finishes the job" do
+      {:ok, job} = Support.Factories.Job.create(:scheduled, %{request: sensitive_request()})
+
+      with_mock JobRequest, [:passthrough], sanitize: fn _ -> raise "boom" end do
+        assert {:ok, finished} = Job.force_finish(job, "Santa said that he was naughty")
+
+        assert Job.finished?(finished)
+        assert finished.request == %{}
+      end
+
+      assert Job.reload(job).request == %{}
+    end
+
     test "sanitizes the job request" do
       {:ok, job} = Support.Factories.Job.create(:scheduled, %{request: sensitive_request()})
 
@@ -226,6 +239,19 @@ defmodule Zebra.Models.JobTest do
       assert job2.aasm_state == "finished"
       assert job2.result == "failed"
       refute is_nil(job2.finished_at)
+    end
+
+    test "when sanitization raises => still finishes the job" do
+      {:ok, job} = Support.Factories.Job.create(:enqueued, %{request: sensitive_request()})
+
+      with_mock JobRequest, [:passthrough], sanitize: fn _ -> raise "boom" end do
+        Zebra.Models.Job.bulk_force_finish([job.id], "They were bad")
+      end
+
+      reloaded = Job.reload(job)
+
+      assert Job.finished?(reloaded)
+      assert reloaded.request == %{}
     end
 
     test "sanitizes the job request" do
@@ -376,6 +402,21 @@ defmodule Zebra.Models.JobTest do
   end
 
   describe ".start" do
+    test "when sanitization raises => still starts the job" do
+      {:ok, job} = Support.Factories.Job.create(:scheduled, %{request: sensitive_request()})
+
+      agent = %Agent{id: @agent_id, ip_address: "1.2.3.4", ctrl_port: 80}
+
+      with_mock JobRequest, [:passthrough], sanitize: fn _ -> raise "boom" end do
+        assert {:ok, started} = Job.start(job, agent, sanitize_request: true)
+
+        assert started.aasm_state == "started"
+        assert started.request == %{}
+      end
+
+      assert Job.reload(job).request == %{}
+    end
+
     test "when the job is pending => error" do
       {:ok, job} = Support.Factories.Job.create(:pending)
 
@@ -476,6 +517,19 @@ defmodule Zebra.Models.JobTest do
         assert Job.stopped?(job)
         assert Job.finished?(job)
       end)
+    end
+
+    test "when sanitization raises => still stops the job" do
+      {:ok, job} = Support.Factories.Job.create(:started, %{request: sensitive_request()})
+
+      with_mock JobRequest, [:passthrough], sanitize: fn _ -> raise "boom" end do
+        assert {:ok, stopped} = Job.stop(job)
+
+        assert Job.finished?(stopped)
+        assert stopped.request == %{}
+      end
+
+      assert Job.reload(job).request == %{}
     end
 
     test "sanitizes the job request" do
@@ -579,6 +633,19 @@ defmodule Zebra.Models.JobTest do
       assert Job.finished?(job)
       assert Job.passed?(job)
       refute is_nil(job.finished_at)
+    end
+
+    test "when sanitization raises => still finishes the job" do
+      {:ok, job} = Support.Factories.Job.create(:started, %{request: sensitive_request()})
+
+      with_mock JobRequest, [:passthrough], sanitize: fn _ -> raise "boom" end do
+        assert {:ok, finished} = Job.finish(job, "passed")
+
+        assert Job.finished?(finished)
+        assert finished.request == %{}
+      end
+
+      assert Job.reload(job).request == %{}
     end
 
     test "when the request is malformed => still finishes the job" do

--- a/zebra/test/zebra/models/job_test.exs
+++ b/zebra/test/zebra/models/job_test.exs
@@ -634,34 +634,6 @@ defmodule Zebra.Models.JobTest do
     end
   end
 
-  describe ".sanitize_job_request" do
-    test "sanitizes the stored request" do
-      {:ok, job} = Support.Factories.Job.create(:started, %{request: sensitive_request()})
-
-      refute JobRequest.sanitized?(job.request)
-      assert secrets_present?(job.request)
-
-      Job.sanitize_job_request(job.id)
-
-      assert_fully_sanitized(Job.reload(job).request)
-    end
-
-    test "when the request is already sanitized => leaves it alone" do
-      {:ok, job} = Support.Factories.Job.create(:started, %{request: sensitive_request()})
-
-      Job.sanitize_job_request(job.id)
-      sanitized = Job.reload(job).request
-
-      Job.sanitize_job_request(job.id)
-
-      assert Job.reload(job).request == sanitized
-    end
-
-    test "when the job does not exist => does not raise" do
-      assert Job.sanitize_job_request(Ecto.UUID.generate()) == :ok
-    end
-  end
-
   describe ".detect_type" do
     test "when it is a pipeline job => pipeline_job" do
       {:ok, task} = Support.Factories.Task.create()

--- a/zebra/test/zebra/models/job_test.exs
+++ b/zebra/test/zebra/models/job_test.exs
@@ -204,8 +204,8 @@ defmodule Zebra.Models.JobTest do
 
       assert {:ok, job} = Job.force_finish(job, "Santa said that he was naughty")
 
-      assert JobRequest.sanitized?(job.request)
-      assert JobRequest.sanitized?(Job.reload(job).request)
+      assert_fully_sanitized(job.request)
+      assert_fully_sanitized(Job.reload(job).request)
     end
   end
 
@@ -226,6 +226,14 @@ defmodule Zebra.Models.JobTest do
       assert job2.aasm_state == "finished"
       assert job2.result == "failed"
       refute is_nil(job2.finished_at)
+    end
+
+    test "sanitizes the job request" do
+      {:ok, job} = Support.Factories.Job.create(:enqueued, %{request: sensitive_request()})
+
+      Zebra.Models.Job.bulk_force_finish([job.id], "They were bad")
+
+      assert_fully_sanitized(Job.reload(job).request)
     end
   end
 
@@ -470,6 +478,15 @@ defmodule Zebra.Models.JobTest do
       end)
     end
 
+    test "sanitizes the job request" do
+      {:ok, job} = Support.Factories.Job.create(:started, %{request: sensitive_request()})
+
+      assert {:ok, job} = Job.stop(job)
+
+      assert_fully_sanitized(job.request)
+      assert_fully_sanitized(Job.reload(job).request)
+    end
+
     test "preserves whether execution ever started" do
       {:ok, enqueued_job} = Support.Factories.Job.create(:enqueued)
       {:ok, started_job} = Support.Factories.Job.create(:started)
@@ -564,13 +581,27 @@ defmodule Zebra.Models.JobTest do
       refute is_nil(job.finished_at)
     end
 
+    test "when the request is malformed => still finishes the job" do
+      malformed = %{
+        "env_vars" => [%{"name" => "MY_SECRET", "leftover" => "s3cr3t"}],
+        "compose" => %{"containers" => [%{"name" => "main"}], "image_pull_credentials" => []}
+      }
+
+      {:ok, job} = Support.Factories.Job.create(:started, %{request: malformed})
+
+      assert {:ok, job} = Job.finish(job, "passed")
+
+      assert Job.finished?(job)
+      refute secrets_present?(Job.reload(job).request)
+    end
+
     test "sanitizes the job request" do
       {:ok, job} = Support.Factories.Job.create(:started, %{request: sensitive_request()})
 
       assert {:ok, job} = Job.finish(job, "passed")
 
-      assert JobRequest.sanitized?(job.request)
-      assert JobRequest.sanitized?(Job.reload(job).request)
+      assert_fully_sanitized(job.request)
+      assert_fully_sanitized(Job.reload(job).request)
     end
 
     test "when the result is failed => finishes the job" do
@@ -608,10 +639,11 @@ defmodule Zebra.Models.JobTest do
       {:ok, job} = Support.Factories.Job.create(:started, %{request: sensitive_request()})
 
       refute JobRequest.sanitized?(job.request)
+      assert secrets_present?(job.request)
 
       Job.sanitize_job_request(job.id)
 
-      assert JobRequest.sanitized?(Job.reload(job).request)
+      assert_fully_sanitized(Job.reload(job).request)
     end
 
     test "when the request is already sanitized => leaves it alone" do
@@ -888,14 +920,46 @@ defmodule Zebra.Models.JobTest do
     end
   end
 
+  @secret_value "s3cr3t"
+  @secret_file_content "//registry/:_authToken=abc"
+
+  # Asserts on the actual values, not just JobRequest.sanitized?/1, which
+  # inspects env vars only and so cannot see an unsanitized file.
+  defp assert_fully_sanitized(request) do
+    assert JobRequest.sanitized?(request)
+
+    Enum.each(request["env_vars"], fn env_var ->
+      if env_var["name"] == "MY_SECRET" do
+        assert env_var["value"] == "{SANITIZED}"
+      end
+    end)
+
+    Enum.each(request["files"], fn file ->
+      assert file["content"] == "{SANITIZED}",
+             "file #{file["path"]} was not sanitized: #{inspect(file["content"])}"
+    end)
+
+    refute secrets_present?(request)
+  end
+
+  # Shape independent backstop: no secret material anywhere in the request.
+  defp secrets_present?(request) do
+    encoded = Poison.encode!(request)
+
+    String.contains?(encoded, Base.encode64(@secret_value)) or
+      String.contains?(encoded, Base.encode64(@secret_file_content)) or
+      String.contains?(encoded, @secret_value) or
+      String.contains?(encoded, @secret_file_content)
+  end
+
   defp sensitive_request do
     %{
       "env_vars" => [
         JobRequest.env_var("SEMAPHORE_JOB_ID", "job-id"),
-        JobRequest.env_var("MY_SECRET", "s3cr3t")
+        JobRequest.env_var("MY_SECRET", @secret_value)
       ],
       "files" => [
-        JobRequest.file("/home/semaphore/.npmrc", "//registry/:_authToken=abc", "0600")
+        JobRequest.file("/home/semaphore/.npmrc", @secret_file_content, "0600")
       ]
     }
   end

--- a/zebra/test/zebra/models/job_test.exs
+++ b/zebra/test/zebra/models/job_test.exs
@@ -3,6 +3,7 @@ defmodule Zebra.Models.JobTest do
 
   alias Zebra.Models.Job
   alias Zebra.Workers.Agent.HostedAgent, as: Agent
+  alias Zebra.Workers.JobRequestFactory.JobRequest
 
   @org_id Ecto.UUID.generate()
   @project_id Ecto.UUID.generate()
@@ -196,6 +197,15 @@ defmodule Zebra.Models.JobTest do
       assert Job.failed?(job)
       assert job.failure_reason == "Santa said that he was naughty"
       assert Zebra.Models.Task.finished?(task)
+    end
+
+    test "sanitizes the job request" do
+      {:ok, job} = Support.Factories.Job.create(:scheduled, %{request: sensitive_request()})
+
+      assert {:ok, job} = Job.force_finish(job, "Santa said that he was naughty")
+
+      assert JobRequest.sanitized?(job.request)
+      assert JobRequest.sanitized?(Job.reload(job).request)
     end
   end
 
@@ -554,6 +564,15 @@ defmodule Zebra.Models.JobTest do
       refute is_nil(job.finished_at)
     end
 
+    test "sanitizes the job request" do
+      {:ok, job} = Support.Factories.Job.create(:started, %{request: sensitive_request()})
+
+      assert {:ok, job} = Job.finish(job, "passed")
+
+      assert JobRequest.sanitized?(job.request)
+      assert JobRequest.sanitized?(Job.reload(job).request)
+    end
+
     test "when the result is failed => finishes the job" do
       {:ok, job} = Support.Factories.Job.create(:started)
 
@@ -581,6 +600,33 @@ defmodule Zebra.Models.JobTest do
       assert Job.finished?(job)
       assert Job.passed?(job)
       assert Zebra.Models.Task.finished?(task)
+    end
+  end
+
+  describe ".sanitize_job_request" do
+    test "sanitizes the stored request" do
+      {:ok, job} = Support.Factories.Job.create(:started, %{request: sensitive_request()})
+
+      refute JobRequest.sanitized?(job.request)
+
+      Job.sanitize_job_request(job.id)
+
+      assert JobRequest.sanitized?(Job.reload(job).request)
+    end
+
+    test "when the request is already sanitized => leaves it alone" do
+      {:ok, job} = Support.Factories.Job.create(:started, %{request: sensitive_request()})
+
+      Job.sanitize_job_request(job.id)
+      sanitized = Job.reload(job).request
+
+      Job.sanitize_job_request(job.id)
+
+      assert Job.reload(job).request == sanitized
+    end
+
+    test "when the job does not exist => does not raise" do
+      assert Job.sanitize_job_request(Ecto.UUID.generate()) == :ok
     end
   end
 
@@ -840,5 +886,17 @@ defmodule Zebra.Models.JobTest do
       assert copy.organization_id == ctx.original.organization_id
       assert copy.project_id == ctx.original.project_id
     end
+  end
+
+  defp sensitive_request do
+    %{
+      "env_vars" => [
+        JobRequest.env_var("SEMAPHORE_JOB_ID", "job-id"),
+        JobRequest.env_var("MY_SECRET", "s3cr3t")
+      ],
+      "files" => [
+        JobRequest.file("/home/semaphore/.npmrc", "//registry/:_authToken=abc", "0600")
+      ]
+    }
   end
 end

--- a/zebra/test/zebra/workers/job_request_factory/job_request_test.exs
+++ b/zebra/test/zebra/workers/job_request_factory/job_request_test.exs
@@ -540,6 +540,48 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequestTest do
     end
   end
 
+  describe ".sanitize/1 with malformed collections" do
+    test "image pull credential that is not a map => does not raise" do
+      assert %{"compose" => %{"image_pull_credentials" => ["junk"]}} =
+               JobRequest.sanitize(%{
+                 "compose" => %{"containers" => [], "image_pull_credentials" => ["junk"]}
+               })
+    end
+
+    test "image_pull_credentials that is not a list => does not raise" do
+      assert %{"compose" => %{"image_pull_credentials" => "junk"}} =
+               JobRequest.sanitize(%{
+                 "compose" => %{"containers" => [], "image_pull_credentials" => "junk"}
+               })
+    end
+
+    test "containers that is not a list => does not raise" do
+      assert %{"compose" => %{"containers" => "junk"}} =
+               JobRequest.sanitize(%{
+                 "compose" => %{"containers" => "junk", "image_pull_credentials" => []}
+               })
+    end
+
+    test "env_vars that is not a list => does not raise" do
+      assert %{"env_vars" => "junk"} = JobRequest.sanitize(%{"env_vars" => "junk"})
+    end
+
+    test "files that is not a list => does not raise" do
+      assert %{"files" => "junk"} = JobRequest.sanitize(%{"files" => "junk"})
+    end
+
+    test "ssh_public_keys that is not a list => does not raise" do
+      assert %{"ssh_public_keys" => "junk"} = JobRequest.sanitize(%{"ssh_public_keys" => "junk"})
+    end
+
+    test "a request that is not a map => does not raise" do
+      assert JobRequest.sanitize("junk") == "junk"
+      assert JobRequest.sanitize(42) == 42
+      assert JobRequest.sanitize([]) == []
+      assert is_nil(JobRequest.sanitize(nil))
+    end
+  end
+
   describe "env_var" do
     test "value is nil => encodes using empty string" do
       assert JobRequest.env_var("A", nil) == %{

--- a/zebra/test/zebra/workers/job_request_factory/job_request_test.exs
+++ b/zebra/test/zebra/workers/job_request_factory/job_request_test.exs
@@ -494,6 +494,52 @@ defmodule Zebra.Workers.JobRequestFactory.JobRequestTest do
     end
   end
 
+  describe ".sanitize/1 with malformed requests" do
+    test "env var with neither value nor unencrypted_content => scrubbed, does not raise" do
+      assert %{"env_vars" => [%{"name" => "MY_SECRET", "value" => "{SANITIZED}"}]} =
+               JobRequest.sanitize(%{
+                 "env_vars" => [%{"name" => "MY_SECRET", "leftover" => "s3cr3t"}]
+               })
+    end
+
+    test "env var with a nil name => treated as sensitive, does not raise" do
+      assert %{"env_vars" => [%{"value" => "{SANITIZED}"}]} =
+               JobRequest.sanitize(%{"env_vars" => [%{"name" => nil, "value" => "s3cr3t"}]})
+    end
+
+    test "env var that is not a map => does not raise" do
+      assert %{"env_vars" => ["junk"]} = JobRequest.sanitize(%{"env_vars" => ["junk"]})
+    end
+
+    test "compose container missing env_vars and files => does not raise" do
+      assert %{"compose" => %{"containers" => [%{"name" => "main"}]}} =
+               JobRequest.sanitize(%{
+                 "compose" => %{
+                   "containers" => [%{"name" => "main"}],
+                   "image_pull_credentials" => []
+                 }
+               })
+    end
+
+    test "compose container with only env_vars => scrubs them, does not raise" do
+      assert %{
+               "compose" => %{
+                 "containers" => [
+                   %{"env_vars" => [%{"name" => "MY_SECRET", "value" => "{SANITIZED}"}]}
+                 ]
+               }
+             } =
+               JobRequest.sanitize(%{
+                 "compose" => %{
+                   "containers" => [
+                     %{"env_vars" => [JobRequest.env_var("MY_SECRET", "s3cr3t")]}
+                   ],
+                   "image_pull_credentials" => []
+                 }
+               })
+    end
+  end
+
   describe "env_var" do
     test "value is nil => encodes using empty string" do
       assert JobRequest.env_var("A", nil) == %{


### PR DESCRIPTION
## Problem

Self-hosted jobs intermittently failed with `Failed to export env vars`, before the pre-job hook or checkout ran. Rerunning the job always succeeded, and unrelated jobs across different projects could fail within the same second.

## Root cause

`get_agent_payload/2` was not idempotent. It fired

```elixir
Task.start(Zebra.Models.Job, :sanitize_job_request, [job.id])
```

and returned `Poison.encode!(job.request)` — read *before* that task ran. So the first fetch returned the real payload and overwrote the stored row with a sanitized copy; any second fetch re-read the row and returned the sanitized copy.

In the sanitized copy, sensitive values are the literal string `{SANITIZED}`. That is 11 characters containing `{` and `}`, so it is not valid base64. Self-hosted agents base64-decode every env var before running anything, so a single undecodable value fails the job up front.

Self-hosted only: hosted jobs have the payload *pushed* and sanitized synchronously (`dispatcher.ex:63`, `Job.start(job, agent, sanitize_request: true)`). Self-hosted jobs *pull* it (`dispatcher.ex:101`, no sanitize), so the DB row is the only copy. Nothing caches it — agent → `self_hosted_hub` → zebra is a fresh DB read per call.

The trigger in production is the agent's pre-existing transport retry: attempt 1 reaches zebra (payload sent, sanitize scheduled) but the response is lost; attempt 2 gets `{SANITIZED}`. That explains the intermittency, why a rerun succeeds (fresh job row), and why several agents fail within the same second (one network blip, many simultaneous retries).

## Change

1. **`internal_job_api.ex`** — drop the sanitization from the read path. `get_agent_payload/2` no longer mutates what it serves.
2. **`job.ex`** — sanitize on the terminal transitions that did not already do it: `finish/2` and `force_finish/2`. `stop/1` and `bulk_force_finish/2` already did.
3. **`job_request.ex`** — make `sanitize/1` total. It raised on ten request shapes, which mattered little while the only self-hosted caller was a crash-swallowing `Task.start`, but would have made a job impossible to finish once `finish/2` started calling it.

Sanitization becomes a property of reaching a terminal state rather than a side effect of a read.

## Tests

Regression test fetches the same job twice and asserts every env var and file in **both** payloads still base64-decodes. Verified failing before the fix:

```
1) test .get_agent_payload when the job is fetched twice => both payloads are intact
   env var SEMAPHORE_OIDC_TOKEN is not decodable: "{SANITIZED}"
```

All four terminal transitions — `finish/2`, `force_finish/2`, `stop/1`, `bulk_force_finish/2` — now assert sanitization. Assertions check the env var and file **values**, not `JobRequest.sanitized?/1`, which inspects env vars only and is therefore blind to an unsanitized file. This was not theoretical: with `files` sanitization disabled outright, the first version of these tests passed 109/109. The current version fails 5 tests and names the offending file. A shape-independent backstop greps the encoded request for the fixture's secret material.

`sanitize/1` totality has one test per raise site, each failing before its fix with `FunctionClauseError`, `KeyError` or `Protocol.UndefinedError`, plus a `finish/2` test covering the malformed-request case that previously made a job impossible to finish.

Note on how this landed: the first totality commit (`746399ec`) claimed completeness and was wrong. It fixed the per-entry cases and left every per-collection one — six inputs still raised, one of which was caught in review. The follow-up commit closes those. The mistake was verifying with tests that only exercised the shapes just fixed; totality is now checked by sweeping 97 combinations of junk values across every field, nested `compose` field, and the request itself, which reports zero raises. `746399ec`'s message still carries the original overstatement — it is left as-is rather than rewriting pushed history, and the follow-up commit states the correction.

Full suite: 558 tests, 2 failures, both pre-existing on `main` (`JobTerminatorTest`, `JobStopperTest` — `Task.await` timeouts, reproduced on a clean tree). `mix format --check-formatted` and `mix credo --all` clean.
