### PR TITLE
fix(zebra,self_hosted_hub): keep stopped jobs from reaching agents

### DIFF
--- a/self_hosted_hub/pkg/agentsync/protocol.go
+++ b/self_hosted_hub/pkg/agentsync/protocol.go
@@ -173,9 +173,8 @@ func handleWaitingForJobsState(ctx context.Context, publisher *amqp.Publisher, a
 		// last_sync_job_id is the last job the agent reported working on, so if
 		// it matches, the agent has this job in hand and this is a stale
 		// waiting-for-jobs request racing its own start. Releasing would give
-		// the slot away while the agent keeps running, and its finished-job
-		// sync would then be rejected for having no assignment. Leave the
-		// assignment alone; the running-job sync is what carries stop-job.
+		// the slot away while the agent keeps running. Leave the assignment
+		// alone; the running-job sync is what carries stop-job.
 		if jobID.String() == agent.LastSyncJobID {
 			return actionContinue(req), nil
 		}
@@ -264,7 +263,15 @@ func handleRunningJobState(agent *models.Agent, req *Request) (*Response, error)
  */
 func handleFinishedJobState(ctx context.Context, publisher *amqp.Publisher, agent *models.Agent, requestedJobID string, result JobResult) (*Response, error) {
 	if agent.AssignedJobID == nil {
-		logging.ForAgent(agent).Warningf("Agent is not assigned to any job - rejecting finished job %s", requestedJobID)
+		// last_sync_job_id only ever names a job this agent was really assigned,
+		// so a match means the finish already landed and we released the agent:
+		// this is a retry whose original response never arrived. Answer it the
+		// same way, instead of erroring until the agent gives up and exits.
+		if requestedJobID == agent.LastSyncJobID {
+			return afterFinishedJob(agent), nil
+		}
+
+		logging.ForAgent(agent).Warningf("Agent never ran job %s - rejecting", requestedJobID)
 		return nil, fmt.Errorf("%w: agent has no assigned job", ErrInvalidStateTransition)
 	}
 
@@ -272,23 +279,29 @@ func handleFinishedJobState(ctx context.Context, publisher *amqp.Publisher, agen
 		return nil, err
 	}
 
+	return afterFinishedJob(agent), nil
+}
+
+// The shutdown-or-wait decision once a job is done. Shared by the normal path
+// and by the retry of a finish that already landed, so both answer the same.
+func afterFinishedJob(agent *models.Agent) *Response {
 	// If agent was disconnected from the UI, we tell it to shut down.
 	if agent.DisabledAt != nil {
-		return actionShutdown(ShutdownReasonRequested), nil
+		return actionShutdown(ShutdownReasonRequested)
 	}
 
 	// If agent is supposed to run only a single job, we tell it to shut down.
 	if agent.SingleJob {
-		return actionShutdown(ShutdownReasonJobFinished), nil
+		return actionShutdown(ShutdownReasonJobFinished)
 	}
 
 	// If agent was interrupted, we tell it to shutdown.
 	if agent.InterruptedAt != nil {
-		return actionShutdown(ShutdownReasonInterrupted), nil
+		return actionShutdown(ShutdownReasonInterrupted)
 	}
 
 	// If none of the conditions above are met, the agent should wait for more jobs.
-	return actionWaitForJobs(), nil
+	return actionWaitForJobs()
 }
 
 func finishAssignedJob(ctx context.Context, publisher *amqp.Publisher, agent *models.Agent, requestedJobID string, result JobResult) error {

--- a/self_hosted_hub/pkg/agentsync/protocol.go
+++ b/self_hosted_hub/pkg/agentsync/protocol.go
@@ -170,6 +170,16 @@ func handleWaitingForJobsState(ctx context.Context, publisher *amqp.Publisher, a
 	if agent.JobStopRequestedAt != nil && agent.AssignedJobID != nil {
 		jobID := *agent.AssignedJobID
 
+		// last_sync_job_id is the last job the agent reported working on, so if
+		// it matches, the agent has this job in hand and this is a stale
+		// waiting-for-jobs request racing its own start. Releasing would give
+		// the slot away while the agent keeps running, and its finished-job
+		// sync would then be rejected for having no assignment. Leave the
+		// assignment alone; the running-job sync is what carries stop-job.
+		if jobID.String() == agent.LastSyncJobID {
+			return actionContinue(req), nil
+		}
+
 		// A single-job agent runs one job and shuts down, so releasing it would
 		// let it pick up an unrelated job instead. Registering with a job_id
 		// requires single_job, so this is also every agent bound to a specific

--- a/self_hosted_hub/pkg/agentsync/protocol.go
+++ b/self_hosted_hub/pkg/agentsync/protocol.go
@@ -163,6 +163,19 @@ func handleWaitingForJobsState(ctx context.Context, publisher *amqp.Publisher, a
 		return actionShutdown(ShutdownReasonInterrupted), nil
 	}
 
+	// The job was stopped before the agent ever asked for it. StopJob leaves
+	// the assignment in place, so without this the agent would be told to run a
+	// job that is already over, and would then fail fetching its payload.
+	// Release the assignment instead, so the agent is free for real work.
+	if agent.JobStopRequestedAt != nil && agent.AssignedJobID != nil {
+		jobID := *agent.AssignedJobID
+		if _, err := models.ReleaseAgent(agent.OrganizationID, agent.AgentTypeName, jobID); err != nil {
+			logging.ForAgent(agent).Errorf("Error releasing agent from stopped job %s: %v", jobID, err)
+		}
+
+		return actionContinue(req), nil
+	}
+
 	// If the agent was assigned a job during registration,
 	// we don't need to look for an occupation request again.
 	if agent.AssignedJobID != nil && agent.AssignedJobID.String() != agent.LastSyncJobID {

--- a/self_hosted_hub/pkg/agentsync/protocol.go
+++ b/self_hosted_hub/pkg/agentsync/protocol.go
@@ -169,6 +169,15 @@ func handleWaitingForJobsState(ctx context.Context, publisher *amqp.Publisher, a
 	// Release the assignment instead, so the agent is free for real work.
 	if agent.JobStopRequestedAt != nil && agent.AssignedJobID != nil {
 		jobID := *agent.AssignedJobID
+
+		// A single-job agent runs one job and shuts down, so releasing it would
+		// let it pick up an unrelated job instead. Registering with a job_id
+		// requires single_job, so this is also every agent bound to a specific
+		// job. Shut it down the same way finishing the job would.
+		if agent.SingleJob {
+			return actionShutdown(ShutdownReasonJobFinished), nil
+		}
+
 		if _, err := models.ReleaseAgent(agent.OrganizationID, agent.AgentTypeName, jobID); err != nil {
 			logging.ForAgent(agent).Errorf("Error releasing agent from stopped job %s: %v", jobID, err)
 		}

--- a/self_hosted_hub/pkg/agentsync/protocol.go
+++ b/self_hosted_hub/pkg/agentsync/protocol.go
@@ -163,21 +163,25 @@ func handleWaitingForJobsState(ctx context.Context, publisher *amqp.Publisher, a
 		return actionShutdown(ShutdownReasonInterrupted), nil
 	}
 
+	// last_sync_job_id names the last job the agent reported working on, so a
+	// match means the agent has this assignment in hand and this request is a
+	// stale waiting-for-jobs racing its own start. Answering anything else
+	// takes the job away from a running agent: releasing gives the slot up,
+	// and falling through to the dispatch checks below skips them both - the
+	// assignment equals last_sync_job_id - and occupies the agent with a
+	// second job, overwriting the one it is running and consuming the queued
+	// job's request. A job that has been stopped reaches the agent through the
+	// running-job sync, which is what carries stop-job.
+	if agent.AssignedJobID != nil && agent.AssignedJobID.String() == agent.LastSyncJobID {
+		return actionContinue(req), nil
+	}
+
 	// The job was stopped before the agent ever asked for it. StopJob leaves
 	// the assignment in place, so without this the agent would be told to run a
 	// job that is already over, and would then fail fetching its payload.
 	// Release the assignment instead, so the agent is free for real work.
 	if agent.JobStopRequestedAt != nil && agent.AssignedJobID != nil {
 		jobID := *agent.AssignedJobID
-
-		// last_sync_job_id is the last job the agent reported working on, so if
-		// it matches, the agent has this job in hand and this is a stale
-		// waiting-for-jobs request racing its own start. Releasing would give
-		// the slot away while the agent keeps running. Leave the assignment
-		// alone; the running-job sync is what carries stop-job.
-		if jobID.String() == agent.LastSyncJobID {
-			return actionContinue(req), nil
-		}
 
 		// A single-job agent runs one job and shuts down, so releasing it would
 		// let it pick up an unrelated job instead. Registering with a job_id

--- a/self_hosted_hub/pkg/publicapi/server.go
+++ b/self_hosted_hub/pkg/publicapi/server.go
@@ -194,11 +194,6 @@ func (s *Server) DescribeJob(w http.ResponseWriter, r *http.Request) {
 
 	payload, err := zebraclient.GetJobPayload(jobID)
 	if err != nil {
-		// Zebra scrubs the payload once a job reaches a terminal state and
-		// refuses to serve it rather than handing out the scrubbed copy. That
-		// is a permanent answer, not a failure: 404 is what the agent already
-		// understands as "this job is not yours to run", and it stops the
-		// retries a 500 would provoke.
 		if status.Code(err) == codes.FailedPrecondition {
 			logging.ForAgent(agent).Warningf("Job %s is no longer running - not serving payload: %v", jobID, err)
 			respondWith404(w)

--- a/self_hosted_hub/pkg/publicapi/server.go
+++ b/self_hosted_hub/pkg/publicapi/server.go
@@ -27,6 +27,8 @@ import (
 	quotas "github.com/semaphoreio/semaphore/self_hosted_hub/pkg/quotas"
 	"github.com/semaphoreio/semaphore/self_hosted_hub/pkg/workers/agentcounter"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"gorm.io/gorm"
 )
 
@@ -192,6 +194,17 @@ func (s *Server) DescribeJob(w http.ResponseWriter, r *http.Request) {
 
 	payload, err := zebraclient.GetJobPayload(jobID)
 	if err != nil {
+		// Zebra scrubs the payload once a job reaches a terminal state and
+		// refuses to serve it rather than handing out the scrubbed copy. That
+		// is a permanent answer, not a failure: 404 is what the agent already
+		// understands as "this job is not yours to run", and it stops the
+		// retries a 500 would provoke.
+		if status.Code(err) == codes.FailedPrecondition {
+			logging.ForAgent(agent).Warningf("Job %s is no longer running - not serving payload: %v", jobID, err)
+			respondWith404(w)
+			return
+		}
+
 		logging.ForAgent(agent).Errorf("Error fetching job payload for %s: %v", jobID, err)
 		_ = watchman.IncrementWithTags("server.error", []string{"zebra_failure", agent.OrganizationID.String()})
 		respondWith500(w)

--- a/self_hosted_hub/pkg/publicapi/server.go
+++ b/self_hosted_hub/pkg/publicapi/server.go
@@ -182,6 +182,14 @@ func (s *Server) DescribeJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The payload of a stopped job is scrubbed of its secrets, so serving it
+	// would hand the agent a request it cannot use.
+	if agent.JobStopRequestedAt != nil {
+		logging.ForAgent(agent).Warningf("Job %s is stopped", jobID)
+		respondWith404(w)
+		return
+	}
+
 	payload, err := zebraclient.GetJobPayload(jobID)
 	if err != nil {
 		logging.ForAgent(agent).Errorf("Error fetching job payload for %s: %v", jobID, err)

--- a/self_hosted_hub/pkg/publicapi/server_test.go
+++ b/self_hosted_hub/pkg/publicapi/server_test.go
@@ -741,7 +741,7 @@ func Test__Sync(t *testing.T) {
 
 	// This test makes sure backwards compatibility with the deprecated callback broker models works.
 	// We can remove it once we are sure no more old agents are being registered.
-	t.Run("finished-job => already released agent is rejected", func(t *testing.T) {
+	t.Run("finished-job => already released agent replaying its own job waits for jobs", func(t *testing.T) {
 		_ = declareExchangeAndQueue()
 		agent, token, err := newAgent(agentType)
 		require.Nil(t, err)
@@ -777,9 +777,98 @@ func Test__Sync(t *testing.T) {
 		_, err = models.ReleaseAgent(testOrgID, agent.AgentTypeName, jobId)
 		require.Nil(t, err)
 
+		// The finish already landed, so replaying it must not publish again,
+		// but must still answer, or the agent errors until it exits.
+		sync(t, syncAssertion{
+			state:          agentsync.AgentStateFinishedJob,
+			token:          token,
+			action:         agentsync.AgentActionWaitForJobs,
+			jobIdOnRequest: jobId.String(),
+			jobResult:      agentsync.JobResultPassed,
+		})
+
+		checkNoFinishedEventReceived(t)
+		checkNoTeardownFinishedEventReceived(t)
+		_ = purgeExchangeAndQueue()
+		require.Nil(t, agent.Disconnect())
+	})
+
+	t.Run("finished-job => released single-job agent replaying its own job shuts down", func(t *testing.T) {
+		_ = declareExchangeAndQueue()
+		agent, token, err := newAgentWithMetadata(agentType, models.AgentMetadata{SingleJob: true})
+		require.Nil(t, err)
+
+		jobId := database.UUID()
+		models.CreateOccupationRequest(testOrgID, agentType.Name, jobId)
+
+		sync(t, syncAssertion{
+			state:           agentsync.AgentStateWaitingForJobs,
+			token:           token,
+			action:          agentsync.AgentActionRunJob,
+			jobIdOnResponse: jobId.String(),
+		})
+
+		sync(t, syncAssertion{
+			state:          agentsync.AgentStateRunningJob,
+			token:          token,
+			action:         agentsync.AgentActionContinue,
+			jobIdOnRequest: jobId.String(),
+		})
+
+		_, err = models.ReleaseAgent(testOrgID, agent.AgentTypeName, jobId)
+		require.Nil(t, err)
+
+		// A single-job agent must still be told to shut down on the replay,
+		// otherwise it lingers waiting for work it will never take.
 		req := &agentsync.Request{
 			State:     agentsync.AgentStateFinishedJob,
 			JobID:     jobId.String(),
+			JobResult: agentsync.JobResultPassed,
+		}
+
+		res := run("POST", "/sync", token, req)
+		require.Equal(t, http.StatusOK, res.Code)
+
+		response := &agentsync.Response{}
+		require.Nil(t, unmarshalJSON(res.Body, response))
+		require.Equal(t, agentsync.AgentAction(agentsync.AgentActionShutdown), response.Action)
+		require.Equal(t, agentsync.ShutdownReason(agentsync.ShutdownReasonJobFinished), response.ShutdownReason)
+
+		checkNoFinishedEventReceived(t)
+		checkNoTeardownFinishedEventReceived(t)
+		_ = purgeExchangeAndQueue()
+		require.Nil(t, agent.Disconnect())
+	})
+
+	t.Run("finished-job => released agent replaying a job it never ran is rejected", func(t *testing.T) {
+		_ = declareExchangeAndQueue()
+		agent, token, err := newAgent(agentType)
+		require.Nil(t, err)
+
+		jobId := database.UUID()
+		models.CreateOccupationRequest(testOrgID, agentType.Name, jobId)
+
+		sync(t, syncAssertion{
+			state:           agentsync.AgentStateWaitingForJobs,
+			token:           token,
+			action:          agentsync.AgentActionRunJob,
+			jobIdOnResponse: jobId.String(),
+		})
+
+		sync(t, syncAssertion{
+			state:          agentsync.AgentStateRunningJob,
+			token:          token,
+			action:         agentsync.AgentActionContinue,
+			jobIdOnRequest: jobId.String(),
+		})
+
+		_, err = models.ReleaseAgent(testOrgID, agent.AgentTypeName, jobId)
+		require.Nil(t, err)
+
+		// Replaying some other job, not the one it ran, is not a retry.
+		req := &agentsync.Request{
+			State:     agentsync.AgentStateFinishedJob,
+			JobID:     database.UUID().String(),
 			JobResult: agentsync.JobResultPassed,
 		}
 

--- a/self_hosted_hub/pkg/publicapi/server_test.go
+++ b/self_hosted_hub/pkg/publicapi/server_test.go
@@ -1440,6 +1440,51 @@ func Test__SyncDoesNotReleaseAJobTheAgentAlreadyStarted(t *testing.T) {
 	require.NotNil(t, req)
 }
 
+func Test__SyncDoesNotOccupyAnAgentThatAlreadyStartedItsJob(t *testing.T) {
+	database.TruncateTables()
+	_ = declareExchangeAndQueue()
+
+	agentType, _, err := newAgentType("s1-test")
+	require.Nil(t, err)
+
+	agent, token, err := newAgent(agentType)
+	require.Nil(t, err)
+
+	jobID, err := models.ForcefullyOccupyAgentWithJobID(agent)
+	require.NoError(t, err)
+
+	// The agent acknowledges the job, which is what last_sync_job_id records.
+	sync(t, syncAssertion{
+		state:          agentsync.AgentStateStartingJob,
+		token:          token,
+		jobIdOnRequest: jobID.String(),
+		action:         agentsync.AgentActionContinue,
+	})
+
+	// another job is queued for the same agent type
+	otherJobID := database.UUID()
+	require.NoError(t, models.CreateOccupationRequest(testOrgID, agentType.Name, otherJobID))
+
+	// Same stale sync as above, but with no stop pending. Without an early
+	// return the assignment matches last_sync_job_id, so the dispatch branch is
+	// skipped and the agent is occupied with the queued job instead - which
+	// overwrites the job it is running and consumes the queued job's request.
+	sync(t, syncAssertion{
+		state:  agentsync.AgentStateWaitingForJobs,
+		token:  token,
+		action: agentsync.AgentActionContinue,
+	})
+
+	reloaded, err := models.FindAgentByToken(testOrgID.String(), agent.TokenHash)
+	require.NoError(t, err)
+	require.Equal(t, &jobID, reloaded.AssignedJobID)
+
+	// the queued job must still be waiting for an agent that is free
+	req, err := models.FindOccupationRequest(testOrgID, agentType.Name, otherJobID)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+}
+
 func Test__ListJobs(t *testing.T) {
 	database.TruncateTables()
 	grpcmock.Start()

--- a/self_hosted_hub/pkg/publicapi/server_test.go
+++ b/self_hosted_hub/pkg/publicapi/server_test.go
@@ -1191,6 +1191,45 @@ func Test__DescribeJob(t *testing.T) {
 		res := run("GET", "/jobs/"+jobID.String(), token, nil)
 		require.Equal(t, http.StatusNotFound, res.Code)
 	})
+
+	t.Run("when the job assigned to the agent was stopped", func(t *testing.T) {
+		jobID, _ := models.ForcefullyOccupyAgentWithJobID(agent)
+		require.NoError(t, models.StopJob(testOrgID, jobID))
+
+		res := run("GET", "/jobs/"+jobID.String(), token, nil)
+
+		require.Equal(t, http.StatusNotFound, res.Code)
+	})
+}
+
+func Test__SyncDoesNotRunStoppedJobs(t *testing.T) {
+	database.TruncateTables()
+	_ = declareExchangeAndQueue()
+
+	agentType, _, err := newAgentType("s1-test")
+	require.Nil(t, err)
+
+	agent, token, err := newAgent(agentType)
+	require.Nil(t, err)
+
+	// The job was assigned to the agent, then stopped before the agent ever
+	// asked for it. StopJob leaves assigned_job_id in place, so the dispatch
+	// path used to hand the agent a job that was already over.
+	jobID, err := models.ForcefullyOccupyAgentWithJobID(agent)
+	require.NoError(t, err)
+	require.NoError(t, models.StopJob(testOrgID, jobID))
+
+	sync(t, syncAssertion{
+		state:  agentsync.AgentStateWaitingForJobs,
+		token:  token,
+		action: agentsync.AgentActionContinue,
+	})
+
+	// The stopped assignment is released, so the agent is free for real work.
+	reloaded, err := models.FindAgentByToken(testOrgID.String(), agent.TokenHash)
+	require.NoError(t, err)
+	require.Nil(t, reloaded.AssignedJobID)
+	require.Nil(t, reloaded.JobStopRequestedAt)
 }
 
 func Test__ListJobs(t *testing.T) {

--- a/self_hosted_hub/pkg/publicapi/server_test.go
+++ b/self_hosted_hub/pkg/publicapi/server_test.go
@@ -25,6 +25,8 @@ import (
 	jobStateProtos "github.com/semaphoreio/semaphore/self_hosted_hub/pkg/protos/server_farm.mq.job_state_exchange"
 	quotas "github.com/semaphoreio/semaphore/self_hosted_hub/pkg/quotas"
 	"github.com/semaphoreio/semaphore/self_hosted_hub/pkg/workers/agentcounter"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	require "github.com/stretchr/testify/require"
@@ -1199,6 +1201,40 @@ func Test__DescribeJob(t *testing.T) {
 		res := run("GET", "/jobs/"+jobID.String(), token, nil)
 
 		require.Equal(t, http.StatusNotFound, res.Code)
+	})
+
+	// Zebra scrubs the payload when a job reaches a terminal state, and answers
+	// FailedPrecondition instead of handing out the scrubbed copy. That is a
+	// permanent answer, so the agent must not keep retrying it.
+	t.Run("when zebra says the job is finished", func(t *testing.T) {
+		defer grpcmock.ResetGetAgentPayloadMock()
+		grpcmock.MockGetAgentPayloadError(status.Error(codes.FailedPrecondition, "Job is stopped"))
+
+		agent, token, err := newAgent(agentType)
+		require.Nil(t, err)
+
+		jobID, err := models.ForcefullyOccupyAgentWithJobID(agent)
+		require.NoError(t, err)
+
+		res := run("GET", "/jobs/"+jobID.String(), token, nil)
+
+		require.Equal(t, http.StatusNotFound, res.Code)
+	})
+
+	// Any other failure is transient, so it stays a 500 and the agent retries.
+	t.Run("when zebra is unavailable", func(t *testing.T) {
+		defer grpcmock.ResetGetAgentPayloadMock()
+		grpcmock.MockGetAgentPayloadError(status.Error(codes.Unavailable, "connection refused"))
+
+		agent, token, err := newAgent(agentType)
+		require.Nil(t, err)
+
+		jobID, err := models.ForcefullyOccupyAgentWithJobID(agent)
+		require.NoError(t, err)
+
+		res := run("GET", "/jobs/"+jobID.String(), token, nil)
+
+		require.Equal(t, http.StatusInternalServerError, res.Code)
 	})
 }
 

--- a/self_hosted_hub/pkg/publicapi/server_test.go
+++ b/self_hosted_hub/pkg/publicapi/server_test.go
@@ -1302,6 +1302,55 @@ func Test__SyncShutsDownSingleJobAgentWhenItsJobIsStopped(t *testing.T) {
 	require.NotNil(t, req)
 }
 
+func Test__SyncDoesNotReleaseAJobTheAgentAlreadyStarted(t *testing.T) {
+	database.TruncateTables()
+	_ = declareExchangeAndQueue()
+
+	agentType, _, err := newAgentType("s1-test")
+	require.Nil(t, err)
+
+	agent, token, err := newAgent(agentType)
+	require.Nil(t, err)
+
+	jobID, err := models.ForcefullyOccupyAgentWithJobID(agent)
+	require.NoError(t, err)
+
+	// The agent acknowledges the job, which is what last_sync_job_id records.
+	sync(t, syncAssertion{
+		state:          agentsync.AgentStateStartingJob,
+		token:          token,
+		jobIdOnRequest: jobID.String(),
+		action:         agentsync.AgentActionContinue,
+	})
+
+	require.NoError(t, models.StopJob(testOrgID, jobID))
+
+	// another job is queued for the same agent type
+	otherJobID := database.UUID()
+	require.NoError(t, models.CreateOccupationRequest(testOrgID, agentType.Name, otherJobID))
+
+	// Nothing serialises two syncs from the same agent, so a waiting-for-jobs
+	// request can be read after the agent has already been told to run the job.
+	// Releasing on that stale request would hand the slot to another job while
+	// the agent keeps running this one, and its finished-job sync would then be
+	// rejected for having no assignment - losing the completion callback.
+	sync(t, syncAssertion{
+		state:  agentsync.AgentStateWaitingForJobs,
+		token:  token,
+		action: agentsync.AgentActionContinue,
+	})
+
+	reloaded, err := models.FindAgentByToken(testOrgID.String(), agent.TokenHash)
+	require.NoError(t, err)
+	require.Equal(t, &jobID, reloaded.AssignedJobID)
+	require.NotNil(t, reloaded.JobStopRequestedAt)
+
+	// the queued job must not have been handed to an agent that is busy
+	req, err := models.FindOccupationRequest(testOrgID, agentType.Name, otherJobID)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+}
+
 func Test__ListJobs(t *testing.T) {
 	database.TruncateTables()
 	grpcmock.Start()

--- a/self_hosted_hub/pkg/publicapi/server_test.go
+++ b/self_hosted_hub/pkg/publicapi/server_test.go
@@ -1232,6 +1232,40 @@ func Test__SyncDoesNotRunStoppedJobs(t *testing.T) {
 	require.Nil(t, reloaded.JobStopRequestedAt)
 }
 
+func Test__SyncShutsDownSingleJobAgentWhenItsJobIsStopped(t *testing.T) {
+	database.TruncateTables()
+	_ = declareExchangeAndQueue()
+
+	agentType, _, err := newAgentType("s1-test")
+	require.Nil(t, err)
+
+	agent, token, err := newAgentWithMetadata(agentType, models.AgentMetadata{SingleJob: true})
+	require.Nil(t, err)
+
+	// The agent was registered for one specific job, which was then stopped
+	// before it ever asked for work. It must shut down, exactly as it would
+	// after finishing that job - not be released and handed something else.
+	jobID, err := models.ForcefullyOccupyAgentWithJobID(agent)
+	require.NoError(t, err)
+	require.NoError(t, models.StopJob(testOrgID, jobID))
+
+	// another job is queued for the same agent type
+	otherJobID := database.UUID()
+	require.NoError(t, models.CreateOccupationRequest(testOrgID, agentType.Name, otherJobID))
+
+	sync(t, syncAssertion{
+		state:          agentsync.AgentStateWaitingForJobs,
+		token:          token,
+		action:         agentsync.AgentActionShutdown,
+		shutdownReason: agentsync.ShutdownReasonJobFinished,
+	})
+
+	// the unrelated job must still be waiting for a real agent
+	req, err := models.FindOccupationRequest(testOrgID, agentType.Name, otherJobID)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+}
+
 func Test__ListJobs(t *testing.T) {
 	database.TruncateTables()
 	grpcmock.Start()

--- a/self_hosted_hub/test/grpcmock/zebra.go
+++ b/self_hosted_hub/test/grpcmock/zebra.go
@@ -82,7 +82,23 @@ func (z ZebraService) TotalExecutionTime(context.Context, *zebrapb.TotalExecutio
 	return nil, nil
 }
 
+var getAgentPayloadError error
+
+// MockGetAgentPayloadError makes GetAgentPayload fail with err until
+// ResetGetAgentPayloadMock is called.
+func MockGetAgentPayloadError(err error) {
+	getAgentPayloadError = err
+}
+
+func ResetGetAgentPayloadMock() {
+	getAgentPayloadError = nil
+}
+
 func (z ZebraService) GetAgentPayload(context.Context, *zebrapb.GetAgentPayloadRequest) (*zebrapb.GetAgentPayloadResponse, error) {
+	if getAgentPayloadError != nil {
+		return nil, getAgentPayloadError
+	}
+
 	return &zebrapb.GetAgentPayloadResponse{
 		Payload: `{"id": "123", "fake": "payload"}`,
 	}, nil

--- a/zebra/lib/zebra/apis/internal_job_api.ex
+++ b/zebra/lib/zebra/apis/internal_job_api.ex
@@ -299,6 +299,11 @@ defmodule Zebra.Apis.InternalJobApi do
           # Agents refetch this payload when a response is lost in transit, so it
           # has to stay identical for the whole life of the job. The request is
           # sanitized when the job reaches a terminal state instead.
+
+          if Job.finished?(job) do
+            raise GRPC.RPCError, status: :failed_precondition, message: "Job is stopped"
+          end
+
           InternalApi.ServerFarm.Job.GetAgentPayloadResponse.new(
             payload: Poison.encode!(job.request)
           )

--- a/zebra/lib/zebra/models/job.ex
+++ b/zebra/lib/zebra/models/job.ex
@@ -654,7 +654,7 @@ defmodule Zebra.Models.Job do
       Logger.info("Stopping job '#{job.id}'")
 
       if hosted?(job.machine_type), do: stop_hosted_job(job)
-      if self_hosted?(job.machine_type), do: stop_self_hosted_job(job)
+      if self_hosted?(job.machine_type), do: notify_self_hosted_agent(job)
 
       now = DateTime.utc_now() |> DateTime.truncate(:second)
 
@@ -680,6 +680,23 @@ defmodule Zebra.Models.Job do
       end
     else
       {:error, :invalid_transition}
+    end
+  end
+
+  # The agent learns a job is over from this call, so when it fails the agent is
+  # left asking for a payload this transition is about to scrub. Finishing the
+  # job still has to win - raising here would leave it in its current state and
+  # the stop request retried forever - so record the divergence and carry on.
+  defp notify_self_hosted_agent(job) do
+    case stop_self_hosted_job(job) do
+      :ok ->
+        :ok
+
+      error ->
+        Logger.error("Failed to stop self-hosted job '#{job.id}': #{inspect(error)}")
+        Watchman.increment("job.self_hosted_stop.failed")
+
+        :error
     end
   end
 

--- a/zebra/lib/zebra/models/job.ex
+++ b/zebra/lib/zebra/models/job.ex
@@ -649,6 +649,10 @@ defmodule Zebra.Models.Job do
     end
   end
 
+  # Shorter than the 5s Task.await in Zebra.Parallel.in_batches, so a stop that
+  # cannot reach the hub fails this one job instead of the whole batch.
+  @self_hosted_stop_timeout 4_000
+
   def stop(job) do
     if valid_transition?(job.aasm_state, state_finished()) do
       Logger.info("Stopping job '#{job.id}'")
@@ -687,9 +691,19 @@ defmodule Zebra.Models.Job do
   # left asking for a payload this transition is about to scrub. Finishing the
   # job still has to win - raising here would leave it in its current state and
   # the stop request retried forever - so record the divergence and carry on.
+  #
+  # Capturing is what makes that true. An unreachable endpoint raises out of the
+  # gRPC client's channel setup rather than returning an error, and blocks for
+  # the connect timeout while it does; both outlive the Task.await that
+  # Zebra.Parallel gives each stop request, so the rest of the batch dies with
+  # it. Under capture every outcome - error, crash, or a hub too slow to matter
+  # - comes back as a value, on a deadline shorter than that await.
   defp notify_self_hosted_agent(job) do
-    case stop_self_hosted_job(job) do
-      :ok ->
+    case Wormhole.capture(__MODULE__, :stop_self_hosted_job, [job],
+           timeout: @self_hosted_stop_timeout,
+           stacktrace: true
+         ) do
+      {:ok, :ok} ->
         :ok
 
       error ->

--- a/zebra/test/zebra/apis/internal_job_api_test.exs
+++ b/zebra/test/zebra/apis/internal_job_api_test.exs
@@ -924,6 +924,49 @@ defmodule Zebra.Api.InternalJobApiTest do
                Stub.get_agent_payload(channel, request)
     end
 
+    test "when the job is finished => refuses to serve the payload" do
+      alias InternalApi.ServerFarm.Job.GetAgentPayloadRequest, as: Request
+      alias InternalApi.ServerFarm.Job.JobService.Stub, as: Stub
+
+      {:ok, job} =
+        Support.Factories.Job.create(:finished, %{
+          machine_type: "s1-test",
+          result: "stopped",
+          request: agent_job_request()
+        })
+
+      {:ok, channel} = GRPC.Stub.connect("localhost:50051")
+
+      assert {:error, %GRPC.RPCError{message: "Job is stopped", status: 9}} =
+               Stub.get_agent_payload(channel, Request.new(job_id: job.id))
+    end
+
+    test "when the job was stopped => refuses instead of serving a sanitized payload" do
+      alias InternalApi.ServerFarm.Job.GetAgentPayloadRequest, as: Request
+      alias InternalApi.ServerFarm.Job.JobService.Stub, as: Stub
+      alias Zebra.Models.Job
+
+      GrpcMock.stub(Support.FakeServers.SelfHosted, :stop_job, fn _, _ ->
+        InternalApi.SelfHosted.StopJobResponse.new()
+      end)
+
+      {:ok, job} =
+        Support.Factories.Job.create(:started, %{
+          machine_type: "s1-test",
+          request: agent_job_request()
+        })
+
+      # Stopping scrubs the request in the same update that finishes the job, so
+      # an agent that fetches afterwards used to receive '{SANITIZED}' values and
+      # die exporting env vars instead of learning the job was stopped.
+      assert {:ok, _} = Job.stop(job)
+
+      {:ok, channel} = GRPC.Stub.connect("localhost:50051")
+
+      assert {:error, %GRPC.RPCError{message: "Job is stopped", status: 9}} =
+               Stub.get_agent_payload(channel, Request.new(job_id: job.id))
+    end
+
     test "when the job is fetched twice => both payloads are intact" do
       alias InternalApi.ServerFarm.Job.GetAgentPayloadRequest, as: Request
       alias InternalApi.ServerFarm.Job.GetAgentPayloadResponse, as: Response

--- a/zebra/test/zebra/models/job_test.exs
+++ b/zebra/test/zebra/models/job_test.exs
@@ -588,6 +588,29 @@ defmodule Zebra.Models.JobTest do
       assert Job.finished?(job)
     end
 
+    test "still stops the job when the self-hosted hub is unreachable" do
+      # A failed gRPC call comes back as a tuple, but an unreachable endpoint
+      # raises out of GRPC.Stub.connect's hard match instead - and blocks long
+      # enough to outlive the Task.await in Zebra.Parallel, which takes the
+      # whole batch of stop requests down with it.
+      previous = Application.get_env(:zebra, :self_hosted_agents_grpc_endpoint)
+      Application.put_env(:zebra, :self_hosted_agents_grpc_endpoint, "localhost:1")
+
+      on_exit(fn ->
+        Application.put_env(:zebra, :self_hosted_agents_grpc_endpoint, previous)
+      end)
+
+      {:ok, job} = Support.Factories.Job.create(:started, %{machine_type: "s1-job-test"})
+
+      with_mock Watchman, [:passthrough], increment: fn _ -> :ok end do
+        assert {:ok, job} = Job.stop(job)
+
+        assert Job.finished?(job)
+        assert Job.stopped?(job)
+        assert_called(Watchman.increment("job.self_hosted_stop.failed"))
+      end
+    end
+
     test "records a metric when the self-hosted hub can't be told about the stop" do
       GrpcMock.stub(Support.FakeServers.SelfHosted, :stop_job, fn _, _ ->
         raise "muahhahaaha"

--- a/zebra/test/zebra/models/job_test.exs
+++ b/zebra/test/zebra/models/job_test.exs
@@ -588,6 +588,21 @@ defmodule Zebra.Models.JobTest do
       assert Job.finished?(job)
     end
 
+    test "records a metric when the self-hosted hub can't be told about the stop" do
+      GrpcMock.stub(Support.FakeServers.SelfHosted, :stop_job, fn _, _ ->
+        raise "muahhahaaha"
+      end)
+
+      {:ok, job} = Support.Factories.Job.create(:started, %{machine_type: "s1-job-test"})
+
+      with_mock Watchman, [:passthrough], increment: fn _ -> :ok end do
+        assert {:ok, job} = Job.stop(job)
+
+        assert Job.finished?(job)
+        assert_called(Watchman.increment("job.self_hosted_stop.failed"))
+      end
+    end
+
     test "tries to finish the task" do
       {:ok, task} = Support.Factories.Task.create()
       {:ok, job} = Support.Factories.Job.create(:scheduled, %{build_id: task.id})


### PR DESCRIPTION
## 📝 Description
`StopJob` leaves `assigned_job_id` in place and only the running-job sync path read `job_stop_requested_at`, so an agent whose job had been stopped before it asked for work was told to run it anyway — then fetched a payload whose secrets zebra had already scrubbed in the same update that finished the job, died exporting env vars, and reported the cancellation as a failure.

The hub now releases the assignment instead of dispatching, and zebra refuses to serve the payload of a finished job. `TaskFailFast` bulk-creates stop requests for every unfinished job in a task, which is why this arrived as bursts of several jobs failing across separate agents within a few hundred milliseconds.

## ✅ Checklist
- [ ] I have tested this change
- [ ] This change requires documentation update
