### PR TITLE
feat(statsd): add tests for metrics flushing to Graphite and update Dockerfile and Makefile

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3440,6 +3440,23 @@ blocks:
             - make pull
             - make build
             - make push
+  - name: "statsd: Tests"
+    dependencies: ["statsd: Provision Prod Image"]
+    run:
+      when: "change_in('/statsd', {pipeline_file: 'ignore', default_branch: 'main'})"
+    task:
+      env_vars:
+        - name: DOCKER_BUILDKIT
+          value: "1"
+        - name: APP_ENV
+          value: prod
+      prologue:
+        commands:
+          - checkout && cd statsd
+      jobs:
+        - name: "Test"
+          commands:
+            - make test
   - name: "statsd: Security Checks"
     dependencies: ["statsd: Provision Prod Image"]
     run:

--- a/statsd/Dockerfile
+++ b/statsd/Dockerfile
@@ -1,5 +1,5 @@
-ARG NODE_VERSION=18.19.0
-ARG ALPINE_VERSION=3.19
+ARG NODE_VERSION=22
+ARG ALPINE_VERSION=3.22
 ARG BASE_IMAGE="node:${NODE_VERSION}-alpine${ALPINE_VERSION}"
 ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
 
@@ -15,18 +15,18 @@ FROM base AS dev
 
 CMD [ "/bin/ash",  "-c \"while sleep 1000; do :; done\"" ]
 
-FROM base AS runner
+FROM ${RUNNER_IMAGE} AS runner
 
 # This is needed to connect the GitHub Container Registry package with our repository.
-LABEL org.opencontainers.image.source https://github.com/semaphoreio/semaphore
+LABEL org.opencontainers.image.source=https://github.com/semaphoreio/semaphore
 
 EXPOSE 8125
 HEALTHCHECK NONE
 
 # trivyfs security updates
-RUN apk add --upgrade --no-cache && \
-  apk add --no-cache make netcat-openbsd tcpdump && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk upgrade --no-cache && \
+  apk add --no-cache nodejs make netcat-openbsd tcpdump && \
+  rm -rf /var/lib/apt/lists/* /var/cache/apk/* /tmp/* /var/tmp/*
 
 WORKDIR /app
 RUN chown nobody /app
@@ -34,6 +34,7 @@ RUN chown nobody /app
 USER nobody
 
 COPY --from=base --chown=nobody:root /app/node_modules /app/node_modules
+COPY --from=base --chown=nobody:root /app/package.json /app/package.json
 COPY --from=base --chown=nobody:root /app/localConfig.js /app/localConfig.js
 
 CMD [ "/bin/sh", "-c", "./node_modules/.bin/statsd localConfig.js" ]

--- a/statsd/Makefile
+++ b/statsd/Makefile
@@ -1,4 +1,15 @@
+APP_ENV=prod
+
 include ../Makefile
 
 APP_NAME=statsd
-APP_ENV=prod
+
+DOCKER_RUN_USER?=$(shell id -u):$(shell id -g)
+
+TEST_CMD=node --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=out/test-reports.xml test/*.test.js
+
+test.js: build
+	mkdir -p out
+	docker run --rm -u $(DOCKER_RUN_USER) -v $(PWD)/test:/app/test -v $(PWD)/out:/app/out $(IMAGE):$(IMAGE_TAG) sh -c "$(TEST_CMD)"
+
+test: test.js

--- a/statsd/package.json
+++ b/statsd/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mkdir -p out && node --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=out/test-reports.xml test/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/statsd/test/graphite.integration.test.js
+++ b/statsd/test/graphite.integration.test.js
@@ -1,0 +1,196 @@
+const assert = require("node:assert/strict");
+const dgram = require("node:dgram");
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+const { once } = require("node:events");
+const test = require("node:test");
+
+const statsdRoot = path.join(__dirname, "..");
+const statsdBin = path.join(statsdRoot, "node_modules", ".bin", "statsd");
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const parseGraphiteLine = (line) => {
+  const [metric, value, timestamp] = line.trim().split(/\s+/);
+
+  return {
+    metric,
+    value: Number.parseFloat(value),
+    timestamp: Number.parseInt(timestamp, 10),
+  };
+};
+
+const createGraphiteServer = async () => {
+  const lines = [];
+  const handlers = new Set();
+  const server = net.createServer((socket) => {
+    let buffer = "";
+
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      while (buffer.includes("\n")) {
+        const index = buffer.indexOf("\n");
+        const line = buffer.slice(0, index).trim();
+        buffer = buffer.slice(index + 1);
+        if (!line) continue;
+        lines.push(line);
+        for (const handler of handlers) {
+          handler(line);
+        }
+      }
+    });
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+  const waitForLine = (predicate, timeoutMs = 2000) =>
+    new Promise((resolve, reject) => {
+      const existing = lines.find(predicate);
+      if (existing) {
+        resolve(existing);
+        return;
+      }
+
+      const handler = (line) => {
+        if (predicate(line)) {
+          cleanup();
+          resolve(line);
+        }
+      };
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(
+          new Error(
+            `Timed out waiting for graphite line; received: ${lines.join(", ")}`
+          )
+        );
+      }, timeoutMs);
+      const cleanup = () => {
+        clearTimeout(timeout);
+        handlers.delete(handler);
+      };
+
+      handlers.add(handler);
+    });
+
+  return { server, port: server.address().port, waitForLine };
+};
+
+const getFreeUdpPort = () =>
+  new Promise((resolve, reject) => {
+    const socket = dgram.createSocket("udp4");
+    socket.on("error", reject);
+    socket.bind(0, "127.0.0.1", () => {
+      const { port } = socket.address();
+      socket.close(() => resolve(port));
+    });
+  });
+
+const sendMetrics = async (port, messages) => {
+  const socket = dgram.createSocket("udp4");
+  for (const message of messages) {
+    await new Promise((resolve, reject) => {
+      socket.send(message, port, "127.0.0.1", (err) =>
+        err ? reject(err) : resolve()
+      );
+    });
+  }
+  socket.close();
+};
+
+const buildConfig = (statsdPort, graphitePort, flushIntervalMs) => `{
+  port: ${statsdPort}
+, address: "127.0.0.1"
+, graphiteHost: "127.0.0.1"
+, graphitePort: ${graphitePort}
+, graphite: { legacyNamespace: false }
+, backends: ["./backends/graphite"]
+, debug: false
+, dumpMessages: false
+, flushInterval: ${flushIntervalMs}
+, deleteGauges: true
+, deleteCounters: true
+}
+`;
+
+const shutdownProcess = async (child) => {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  const exited = await Promise.race([once(child, "exit"), wait(1000)]);
+  if (!exited && child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+    await once(child, "exit");
+  }
+};
+
+test("statsd flushes metrics to graphite", async () => {
+  if (!fs.existsSync(statsdBin)) {
+    throw new Error(`statsd binary not found at ${statsdBin}; run npm install`);
+  }
+
+  const graphite = await createGraphiteServer();
+  const statsdPort = await getFreeUdpPort();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "statsd-test-"));
+  const configPath = path.join(tmpDir, "statsd-config.js");
+  const statsdOutput = [];
+  let statsd;
+
+  try {
+    fs.writeFileSync(configPath, buildConfig(statsdPort, graphite.port, 100));
+
+    statsd = spawn(statsdBin, [configPath], {
+      cwd: statsdRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    statsd.stdout.on("data", (chunk) =>
+      statsdOutput.push(chunk.toString("utf8"))
+    );
+    statsd.stderr.on("data", (chunk) =>
+      statsdOutput.push(chunk.toString("utf8"))
+    );
+
+    await wait(100);
+    if (statsd.exitCode !== null || statsd.signalCode !== null) {
+      throw new Error(
+        `statsd exited early (${statsd.exitCode}); output: ${statsdOutput.join(
+          ""
+        )}`
+      );
+    }
+
+    await sendMetrics(statsdPort, [
+      "statsd_test.counter:1|c",
+      "statsd_test.counter:1|c",
+      "statsd_test.gauge:42|g",
+    ]);
+
+    const counterMetricNames = [
+      "stats.counters.statsd_test.counter.count",
+      "statsd_test.counter.count",
+      "statsd_test.counter",
+    ];
+    const gaugeMetricNames = ["stats.gauges.statsd_test.gauge", "statsd_test.gauge"];
+    const lineStartsWith = (metricNames, line) =>
+      metricNames.some((name) => line.startsWith(`${name} `));
+
+    const counterLine = await graphite.waitForLine((line) =>
+      lineStartsWith(counterMetricNames, line)
+    );
+    const gaugeLine = await graphite.waitForLine((line) =>
+      lineStartsWith(gaugeMetricNames, line)
+    );
+
+    const counter = parseGraphiteLine(counterLine);
+    const gauge = parseGraphiteLine(gaugeLine);
+
+    assert.equal(counter.value, 2);
+    assert.equal(gauge.value, 42);
+  } finally {
+    await shutdownProcess(statsd);
+    await new Promise((resolve) => graphite.server.close(resolve));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 📝 Description

Clears the statsd Docker-scan findings and adds a Graphite integration-test harness.

Security fix (`statsd/Dockerfile`):

| Finding | Severity | Fix |
|---|---|---|
| CVE-2026-59873 (node-tar decompression bomb) | Critical | runtime stage switched to bare `alpine:3.22` + `apk add nodejs` (Alpine Node runtime, no npm, so no bundled node-tar); build stage still `npm install`s on `node:22-alpine3.22` |
| OS-EOL-001 (Alpine 3.19 end of life) | High | base bumped Alpine 3.19 to 3.22, Node 18.19.0 to 22 |

Tests:
- New `statsd/test/graphite.integration.test.js` covering metrics flushing to Graphite.
- `package.json` `test` script now runs `node --test` with spec + junit reporters.

## Notes
statsd's app dependencies pull no tar; the flagged tar-6.2.0 was the Node base image's global npm copy, removed by dropping npm from the runtime.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
