### PR TITLE
fix(repohub): bound watchman metric names, log per-repo durations instead

### DIFF
--- a/repohub/pkg/bench/bench.go
+++ b/repohub/pkg/bench/bench.go
@@ -1,0 +1,72 @@
+// Package bench pairs a watchman benchmark with a log line.
+//
+// Metric names have to stay bounded: repohub shares a statsd sidecar that
+// never expires timer series, so a repository URL or an id baked into a metric
+// name grows the sidecar's memory until it is OOM killed. Without those ids
+// Grafana is aggregate only - it shows that an operation got slower, not which
+// repository made it slower. The log line closes that gap: it carries the same
+// measurement, plus the repository or project the call was made for, so a spike
+// in a graph can be traced back to concrete repositories in the logs.
+package bench
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/renderedtext/go-watchman"
+)
+
+// Only measurements at least this slow are logged, so the fast common path
+// stays quiet. Override with BENCHMARK_LOG_THRESHOLD_MS while chasing a spike;
+// 0 logs every measurement.
+const defaultLogThreshold = 1 * time.Second
+
+const logThresholdEnvVar = "BENCHMARK_LOG_THRESHOLD_MS"
+
+var logThreshold = readLogThreshold(os.Getenv(logThresholdEnvVar))
+
+// Observe submits the metric to watchman under its bounded name, and logs the
+// measurement together with target - the repository URL, repository id or
+// project id the call was made for - when it is slow enough to be interesting.
+//
+// Meant to be deferred, in place of watchman.Benchmark:
+//
+//	defer bench.Observe(time.Now(), "gitrekt.Search", repo.HttpURL)
+func Observe(start time.Time, metric string, target string) {
+	elapsed := time.Since(start)
+
+	_ = watchman.Benchmark(start, metric)
+
+	if elapsed < logThreshold {
+		return
+	}
+
+	log.Printf(
+		"(bench) metric=%s duration_ms=%d target=%s",
+		metric,
+		elapsed.Milliseconds(),
+		target,
+	)
+}
+
+func readLogThreshold(raw string) time.Duration {
+	if raw == "" {
+		return defaultLogThreshold
+	}
+
+	ms, err := strconv.Atoi(raw)
+	if err != nil || ms < 0 {
+		log.Printf(
+			"(err) Ignoring %s=%q, using %v",
+			logThresholdEnvVar,
+			raw,
+			defaultLogThreshold,
+		)
+
+		return defaultLogThreshold
+	}
+
+	return time.Duration(ms) * time.Millisecond
+}

--- a/repohub/pkg/bench/bench_test.go
+++ b/repohub/pkg/bench/bench_test.go
@@ -1,0 +1,92 @@
+package bench
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestObserve_LogsSlowMeasurements(t *testing.T) {
+	out := captureLog(t, 500*time.Millisecond, func() {
+		Observe(time.Now().Add(-2*time.Second), "gitrekt.Search", "https://github.com/foo/bar")
+	})
+
+	for _, want := range []string{
+		"(bench)",
+		"metric=gitrekt.Search",
+		"duration_ms=200",
+		"target=https://github.com/foo/bar",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log %q does not contain %q", out, want)
+		}
+	}
+}
+
+func TestObserve_SkipsFastMeasurements(t *testing.T) {
+	out := captureLog(t, time.Second, func() {
+		Observe(time.Now(), "gitrekt.Search", "https://github.com/foo/bar")
+	})
+
+	if out != "" {
+		t.Errorf("expected no log output, got %q", out)
+	}
+}
+
+func TestObserve_ZeroThresholdLogsEverything(t *testing.T) {
+	out := captureLog(t, 0, func() {
+		Observe(time.Now(), "hub.Describe", "9c1a2b3d-0000-0000-0000-000000000000")
+	})
+
+	if !strings.Contains(out, "metric=hub.Describe") {
+		t.Errorf("expected the measurement to be logged, got %q", out)
+	}
+}
+
+func TestReadLogThreshold(t *testing.T) {
+	for _, test := range []struct {
+		raw  string
+		want time.Duration
+	}{
+		{raw: "", want: defaultLogThreshold},
+		{raw: "0", want: 0},
+		{raw: "250", want: 250 * time.Millisecond},
+		{raw: "-1", want: defaultLogThreshold},
+		{raw: "soon", want: defaultLogThreshold},
+	} {
+		log.SetOutput(&bytes.Buffer{})
+		got := readLogThreshold(test.raw)
+		log.SetOutput(originalLogOutput)
+
+		if got != test.want {
+			t.Errorf("readLogThreshold(%q) = %v, want %v", test.raw, got, test.want)
+		}
+	}
+}
+
+//
+// Internals
+//
+
+var originalLogOutput = log.Writer()
+
+func captureLog(t *testing.T, threshold time.Duration, f func()) string {
+	t.Helper()
+
+	previousThreshold := logThreshold
+	logThreshold = threshold
+
+	out := &bytes.Buffer{}
+	log.SetOutput(out)
+
+	defer func() {
+		logThreshold = previousThreshold
+		log.SetOutput(originalLogOutput)
+	}()
+
+	f()
+
+	return out.String()
+}

--- a/repohub/pkg/gitrekt/commit.go
+++ b/repohub/pkg/gitrekt/commit.go
@@ -38,9 +38,7 @@ type CommitPayload struct {
 }
 
 func Commit(repo *Repository, payload CommitPayload) (rev *Revision, err error) {
-	defer watchman.BenchmarkWithTags(time.Now(), "gitrekt.commit", []string{
-		repo.HttpURL,
-	})
+	defer watchman.Benchmark(time.Now(), "gitrekt.commit")
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/repohub/pkg/gitrekt/commit.go
+++ b/repohub/pkg/gitrekt/commit.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	git "github.com/libgit2/git2go/v34"
-	"github.com/renderedtext/go-watchman"
+	bench "github.com/semaphoreio/semaphore/repohub/pkg/bench"
 )
 
 func check(err error, message string) {
@@ -38,7 +38,7 @@ type CommitPayload struct {
 }
 
 func Commit(repo *Repository, payload CommitPayload) (rev *Revision, err error) {
-	defer watchman.Benchmark(time.Now(), "gitrekt.commit")
+	defer bench.Observe(time.Now(), "gitrekt.commit", repo.HttpURL)
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/repohub/pkg/gitrekt/list_changed_files.go
+++ b/repohub/pkg/gitrekt/list_changed_files.go
@@ -16,9 +16,7 @@ const (
 )
 
 func ListChangedFiles(repo *Repository, base Revision, head Revision, comparison ListChangedFilesComparisonType) ([]string, error) {
-	defer watchman.BenchmarkWithTags(time.Now(), "gitrekt.ListChangedFiles", []string{
-		repo.HttpURL,
-	})
+	defer watchman.Benchmark(time.Now(), "gitrekt.ListChangedFiles")
 
 	log.Printf("ListChangedFiles Started. Repo: %s", repo.HttpURL)
 

--- a/repohub/pkg/gitrekt/list_changed_files.go
+++ b/repohub/pkg/gitrekt/list_changed_files.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	git "github.com/libgit2/git2go/v34"
-	"github.com/renderedtext/go-watchman"
+	bench "github.com/semaphoreio/semaphore/repohub/pkg/bench"
 )
 
 type ListChangedFilesComparisonType int
@@ -16,7 +16,7 @@ const (
 )
 
 func ListChangedFiles(repo *Repository, base Revision, head Revision, comparison ListChangedFilesComparisonType) ([]string, error) {
-	defer watchman.Benchmark(time.Now(), "gitrekt.ListChangedFiles")
+	defer bench.Observe(time.Now(), "gitrekt.ListChangedFiles", repo.HttpURL)
 
 	log.Printf("ListChangedFiles Started. Repo: %s", repo.HttpURL)
 

--- a/repohub/pkg/gitrekt/search.go
+++ b/repohub/pkg/gitrekt/search.go
@@ -21,9 +21,7 @@ type SearchOptions struct {
 }
 
 func Search(repo *Repository, rev Revision, options *SearchOptions) ([]*File, error) {
-	defer watchman.BenchmarkWithTags(time.Now(), "gitrekt.Search", []string{
-		repo.HttpURL,
-	})
+	defer watchman.Benchmark(time.Now(), "gitrekt.Search")
 
 	log.Printf(
 		"Search Started. Repo %s, revision %+v",

--- a/repohub/pkg/gitrekt/search.go
+++ b/repohub/pkg/gitrekt/search.go
@@ -7,7 +7,7 @@ import (
 
 	doublestar "github.com/bmatcuk/doublestar"
 	git "github.com/libgit2/git2go/v34"
-	"github.com/renderedtext/go-watchman"
+	bench "github.com/semaphoreio/semaphore/repohub/pkg/bench"
 )
 
 type SearchOptionsSelectors struct {
@@ -21,7 +21,7 @@ type SearchOptions struct {
 }
 
 func Search(repo *Repository, rev Revision, options *SearchOptions) ([]*File, error) {
-	defer watchman.Benchmark(time.Now(), "gitrekt.Search")
+	defer bench.Observe(time.Now(), "gitrekt.Search", repo.HttpURL)
 
 	log.Printf(
 		"Search Started. Repo %s, revision %+v",

--- a/repohub/pkg/gitrekt/update_or_clone.go
+++ b/repohub/pkg/gitrekt/update_or_clone.go
@@ -13,7 +13,7 @@ import (
 )
 
 func UpdateOrClone(repo *Repository, revision *Revision) (string, error) {
-	defer watchman.BenchmarkWithTags(time.Now(), "gitrekt.UpdateOrClone", []string{repo.HttpURL})
+	defer watchman.Benchmark(time.Now(), "gitrekt.UpdateOrClone")
 
 	reference := extractReference(revision)
 
@@ -61,7 +61,7 @@ func (o *UpdateOrCloneOperation) Run() error {
 }
 
 func (o *UpdateOrCloneOperation) Update() error {
-	defer watchman.BenchmarkWithTags(time.Now(), "gitrekt.UpdateOrClone.Update", []string{o.Repository.HttpURL})
+	defer watchman.Benchmark(time.Now(), "gitrekt.UpdateOrClone.Update")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
@@ -94,7 +94,7 @@ func (o *UpdateOrCloneOperation) Update() error {
 func (o *UpdateOrCloneOperation) Clone() error {
 	var err error
 
-	defer watchman.BenchmarkWithTags(time.Now(), "gitrekt.UpdateOrClone.Clone", []string{o.Repository.HttpURL})
+	defer watchman.Benchmark(time.Now(), "gitrekt.UpdateOrClone.Clone")
 
 	log.Printf("cloning %s", o.Repository.Path())
 

--- a/repohub/pkg/gitrekt/update_or_clone.go
+++ b/repohub/pkg/gitrekt/update_or_clone.go
@@ -9,11 +9,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/renderedtext/go-watchman"
+	bench "github.com/semaphoreio/semaphore/repohub/pkg/bench"
 )
 
 func UpdateOrClone(repo *Repository, revision *Revision) (string, error) {
-	defer watchman.Benchmark(time.Now(), "gitrekt.UpdateOrClone")
+	defer bench.Observe(time.Now(), "gitrekt.UpdateOrClone", repo.HttpURL)
 
 	reference := extractReference(revision)
 
@@ -61,7 +61,7 @@ func (o *UpdateOrCloneOperation) Run() error {
 }
 
 func (o *UpdateOrCloneOperation) Update() error {
-	defer watchman.Benchmark(time.Now(), "gitrekt.UpdateOrClone.Update")
+	defer bench.Observe(time.Now(), "gitrekt.UpdateOrClone.Update", o.Repository.HttpURL)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
@@ -94,7 +94,7 @@ func (o *UpdateOrCloneOperation) Update() error {
 func (o *UpdateOrCloneOperation) Clone() error {
 	var err error
 
-	defer watchman.Benchmark(time.Now(), "gitrekt.UpdateOrClone.Clone")
+	defer bench.Observe(time.Now(), "gitrekt.UpdateOrClone.Clone", o.Repository.HttpURL)
 
 	log.Printf("cloning %s", o.Repository.Path())
 

--- a/repohub/pkg/hub/repo_service.go
+++ b/repohub/pkg/hub/repo_service.go
@@ -39,9 +39,7 @@ func NewRepoService(db *gorm.DB) *RepoService {
 }
 
 func (s *RepoService) Describe(ctx context.Context, request *ia_repository.DescribeRequest) (*ia_repository.DescribeResponse, error) {
-	defer watchman.BenchmarkWithTags(time.Now(), "hub.Describe", []string{
-		request.RepositoryId,
-	})
+	defer watchman.Benchmark(time.Now(), "hub.Describe")
 
 	log.Printf("Describe: Request %v", request)
 
@@ -56,9 +54,7 @@ func (s *RepoService) Describe(ctx context.Context, request *ia_repository.Descr
 }
 
 func (s *RepoService) List(ctx context.Context, request *ia_repository.ListRequest) (*ia_repository.ListResponse, error) {
-	defer watchman.BenchmarkWithTags(time.Now(), "hub.List", []string{
-		request.ProjectId,
-	})
+	defer watchman.Benchmark(time.Now(), "hub.List")
 
 	log.Printf("List: Request %v", request)
 
@@ -84,9 +80,7 @@ func (s *RepoService) List(ctx context.Context, request *ia_repository.ListReque
 }
 
 func (s *RepoService) GetFiles(ctx context.Context, request *ia_repository.GetFilesRequest) (*ia_repository.GetFilesResponse, error) {
-	defer watchman.BenchmarkWithTags(time.Now(), "hub.GetFiles", []string{
-		request.RepositoryId,
-	})
+	defer watchman.Benchmark(time.Now(), "hub.GetFiles")
 
 	log.Printf(
 		"GetFiles: Repo %s, Revision %+v, Selectors %+v, IncludeContent %+v",
@@ -138,9 +132,7 @@ func (s *RepoService) GetFiles(ctx context.Context, request *ia_repository.GetFi
 }
 
 func (s *RepoService) Commit(ctx context.Context, request *ia_repository.CommitRequest) (*ia_repository.CommitResponse, error) {
-	defer watchman.BenchmarkWithTags(time.Now(), "hub.Commit", []string{
-		request.RepositoryId,
-	})
+	defer watchman.Benchmark(time.Now(), "hub.Commit")
 
 	log.Printf(
 		"Commit: Repo %s, User %s, Branch %s, CommitMessage: %s, Changes: %+v",
@@ -215,9 +207,7 @@ func (s *RepoService) Commit(ctx context.Context, request *ia_repository.CommitR
 }
 
 func (s *RepoService) GetChangedFilePaths(ctx context.Context, request *ia_repository.GetChangedFilePathsRequest) (*ia_repository.GetChangedFilePathsResponse, error) {
-	defer watchman.BenchmarkWithTags(time.Now(), "hub.GetChangedFilePaths", []string{
-		request.RepositoryId,
-	})
+	defer watchman.Benchmark(time.Now(), "hub.GetChangedFilePaths")
 
 	log.Printf(
 		"GetChangedFilePaths: Repo %s, Head %v, Base %v",

--- a/repohub/pkg/hub/repo_service.go
+++ b/repohub/pkg/hub/repo_service.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/renderedtext/go-watchman"
+	bench "github.com/semaphoreio/semaphore/repohub/pkg/bench"
 	gitrekt "github.com/semaphoreio/semaphore/repohub/pkg/gitrekt"
 	models "github.com/semaphoreio/semaphore/repohub/pkg/models"
 	tokenstore "github.com/semaphoreio/semaphore/repohub/pkg/tokenstore"
@@ -39,7 +39,7 @@ func NewRepoService(db *gorm.DB) *RepoService {
 }
 
 func (s *RepoService) Describe(ctx context.Context, request *ia_repository.DescribeRequest) (*ia_repository.DescribeResponse, error) {
-	defer watchman.Benchmark(time.Now(), "hub.Describe")
+	defer bench.Observe(time.Now(), "hub.Describe", request.RepositoryId)
 
 	log.Printf("Describe: Request %v", request)
 
@@ -54,7 +54,7 @@ func (s *RepoService) Describe(ctx context.Context, request *ia_repository.Descr
 }
 
 func (s *RepoService) List(ctx context.Context, request *ia_repository.ListRequest) (*ia_repository.ListResponse, error) {
-	defer watchman.Benchmark(time.Now(), "hub.List")
+	defer bench.Observe(time.Now(), "hub.List", request.ProjectId)
 
 	log.Printf("List: Request %v", request)
 
@@ -80,7 +80,7 @@ func (s *RepoService) List(ctx context.Context, request *ia_repository.ListReque
 }
 
 func (s *RepoService) GetFiles(ctx context.Context, request *ia_repository.GetFilesRequest) (*ia_repository.GetFilesResponse, error) {
-	defer watchman.Benchmark(time.Now(), "hub.GetFiles")
+	defer bench.Observe(time.Now(), "hub.GetFiles", request.RepositoryId)
 
 	log.Printf(
 		"GetFiles: Repo %s, Revision %+v, Selectors %+v, IncludeContent %+v",
@@ -132,7 +132,7 @@ func (s *RepoService) GetFiles(ctx context.Context, request *ia_repository.GetFi
 }
 
 func (s *RepoService) Commit(ctx context.Context, request *ia_repository.CommitRequest) (*ia_repository.CommitResponse, error) {
-	defer watchman.Benchmark(time.Now(), "hub.Commit")
+	defer bench.Observe(time.Now(), "hub.Commit", request.RepositoryId)
 
 	log.Printf(
 		"Commit: Repo %s, User %s, Branch %s, CommitMessage: %s, Changes: %+v",
@@ -207,7 +207,7 @@ func (s *RepoService) Commit(ctx context.Context, request *ia_repository.CommitR
 }
 
 func (s *RepoService) GetChangedFilePaths(ctx context.Context, request *ia_repository.GetChangedFilePathsRequest) (*ia_repository.GetChangedFilePathsResponse, error) {
-	defer watchman.Benchmark(time.Now(), "hub.GetChangedFilePaths")
+	defer bench.Observe(time.Now(), "hub.GetChangedFilePaths", request.RepositoryId)
 
 	log.Printf(
 		"GetChangedFilePaths: Repo %s, Head %v, Base %v",


### PR DESCRIPTION
## 📝 Description

#### What

`watchman.Benchmark*` in `gitrekt` and `hub` no longer bakes the repo URL / repository id / project id into the metric name (11 call sites), and a new `pkg/bench` helper logs each measurement together with that identity instead.

#### Why

repohub shares an Etsy-statsd sidecar whose config never expires timer series, so every repository added a permanent timer key and the sidecar climbed into its 100Mi limit. Bounded metric names remove the leak; the log line preserves the per-repository view that Grafana loses with the tags gone - spot a spike in the graph, then find the repositories behind it in the logs.

#### Notes

The series name keeps its shape: `tagged.repohub.<ns>.<repo-url>.no_tag.no_tag.<metric>` becomes `tagged.repohub.<ns>.no_tag.no_tag.no_tag.<metric>`, because go-watchman pads missing tags. Wildcard panels keep matching and now show one aggregate series; only panels that enumerate per-repo series need editing.

The log line uses fixed keys so one query covers every operation: `(bench) metric=gitrekt.UpdateOrClone.Clone duration_ms=48213 target=https://github.com/acme/monorepo`.

Only measurements slower than 1s are logged. `BENCHMARK_LOG_THRESHOLD_MS` tunes that (`0` logs every measurement).

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
