### PR TITLE
fix(front): stop tagging job-page duration metrics with the job id

### DIFF
--- a/front/lib/front_web/controllers/job_controller.ex
+++ b/front/lib/front_web/controllers/job_controller.ex
@@ -237,7 +237,7 @@ defmodule FrontWeb.JobController do
   end
 
   def logs(conn, params) do
-    Watchman.benchmark({"logs.duration", ["#{conn.assigns.job.id}"]}, fn ->
+    Watchman.benchmark("logs.duration", fn ->
       job = conn.assigns.job
 
       case missing_logs_message(job) do

--- a/front/lib/job_page/api/loghub.ex
+++ b/front/lib/job_page/api/loghub.ex
@@ -4,7 +4,7 @@ defmodule JobPage.Api.Loghub do
   alias JobPage.GrpcConfig
 
   def fetch(job_id, starting_line, tracing_headers \\ nil) do
-    Watchman.benchmark({"fetch_logs.duration", ["#{job_id}"]}, fn ->
+    Watchman.benchmark("fetch_logs.duration", fn ->
       req =
         InternalApi.Loghub.GetLogEventsRequest.new(job_id: job_id, starting_line: starting_line)
 

--- a/front/lib/job_page/events.ex
+++ b/front/lib/job_page/events.ex
@@ -1,6 +1,6 @@
 defmodule JobPage.Events do
   def fetch_events(job_id, starting_event) do
-    Watchman.benchmark({"fetch_events.duration", ["#{job_id}"]}, fn ->
+    Watchman.benchmark("fetch_events.duration", fn ->
       case JobPage.Api.Loghub.fetch(job_id, starting_event) do
         {:ok, events} ->
           recoded_events = events.events |> recode_events()
@@ -13,7 +13,7 @@ defmodule JobPage.Events do
   end
 
   def raw_events(job_id, starting_event, take) do
-    Watchman.benchmark({"raw_events.duration", ["#{job_id}"]}, fn ->
+    Watchman.benchmark("raw_events.duration", fn ->
       case JobPage.Api.Loghub.fetch(job_id, starting_event) do
         {:ok, events} ->
           events = limit_take(events, take)
@@ -27,7 +27,7 @@ defmodule JobPage.Events do
   end
 
   def raw_logs(job_id, starting_event, take) do
-    Watchman.benchmark({"raw_logs.duration", ["#{job_id}"]}, fn ->
+    Watchman.benchmark("raw_logs.duration", fn ->
       case JobPage.Api.Loghub.fetch(job_id, starting_event) do
         {:ok, events} ->
           events = limit_take(events, take)


### PR DESCRIPTION
## 📝 Description

Drops the `job_id` tag from five job-page `Watchman.benchmark` timers: `logs.duration`, `fetch_logs.duration`, `fetch_events.duration`, `raw_events.duration`, `raw_logs.duration`.

The graphite backend folds tags into the metric name and the statsd image never expires timer keys, so every job id minted a permanent timer series.

Panels keep matching (the tag position becomes literal `no_tag`, `tagged.<prefix>.no_tag.no_tag.no_tag.logs.duration`) and now show one aggregate series instead of one per job. No replacement logging needed: `RequestLogger` already logs `GET /jobs/<id>/logs 200 123.4ms`.


## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
