### PR TITLE
chore(front): bump js-yaml to 3.15.2 / 4.3.2 (CVE-2026-84375)

### DIFF
--- a/front/assets/package-lock.json
+++ b/front/assets/package-lock.json
@@ -32,7 +32,7 @@
         "domurl": "2.3.0",
         "highlight.js": "^9.16.2",
         "jquery": ">= 3.1",
-        "js-yaml": "^3.15.1",
+        "js-yaml": "^3.15.2",
         "lodash": "4.18.1",
         "markdown-it": "^14.1.0",
         "markdown-it-textual-uml": "^0.17.1",
@@ -3102,9 +3102,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -7404,9 +7404,9 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -8996,9 +8996,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -10554,9 +10554,9 @@
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/front/assets/package.json
+++ b/front/assets/package.json
@@ -40,7 +40,7 @@
     "domurl": "2.3.0",
     "highlight.js": "^9.16.2",
     "jquery": ">= 3.1",
-    "js-yaml": "^3.15.1",
+    "js-yaml": "^3.15.2",
     "lodash": "4.18.1",
     "markdown-it": "^14.1.0",
     "markdown-it-textual-uml": "^0.17.1",
@@ -124,13 +124,13 @@
       "d3-color": "3.1.0"
     },
     "eslint": {
-      "js-yaml": "^4.3.1"
+      "js-yaml": "^4.3.2"
     },
     "@eslint/eslintrc": {
-      "js-yaml": "^4.3.1"
+      "js-yaml": "^4.3.2"
     },
     "mocha": {
-      "js-yaml": "^4.3.1"
+      "js-yaml": "^4.3.2"
     }
   }
 }


### PR DESCRIPTION
## 📝 Description

Bumps `js-yaml` to clear CVE-2026-84375 (HIGH), a DoS in YAML merge-key processing (`maxTotalMergeKeys` does not count empty mapping sources).

| Instance | From | To |
|---|---|---|
| `js-yaml` (direct, prod) | 3.15.1 | 3.15.2 |
| `js-yaml` dev overrides (eslint, @eslint/eslintrc, mocha) | 4.3.1 | 4.3.2 |

The scan flagged the direct js-yaml 3.15.1 (used client-side by the workflow YAML editor; a crafted document can hang the editing user's tab). The dev-only 4.3.1 instances share the same CVE (4.x fix is 4.3.2) so they were bumped too, for completeness.

## Notes
Diff limited to `assets/package.json` and `assets/package-lock.json`. Verified: every js-yaml instance in the lock resolves to a fixed version (3.15.2 direct, 4.3.2 dev).

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
