### PR TITLE
fix(front): show job's own time, not workflow's

### DIFF
--- a/front/assets/.eslintrc.js
+++ b/front/assets/.eslintrc.js
@@ -29,6 +29,8 @@ module.exports = {
     "*.json",
     "!js/workflow_editor/models/agent.js",
     "!js/workflow_editor/models/agent.spec.js",
+    "!js/time_ago.js",
+    "!js/time_ago.spec.js",
   ],
   rules: {},
  overrides: [

--- a/front/assets/js/time_ago.js
+++ b/front/assets/js/time_ago.js
@@ -1,3 +1,29 @@
+const EXACT_FORMAT_OPTIONS = {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZoneName: "short",
+};
+
+// Building an Intl formatter is two orders of magnitude dearer than using one, and
+// pages can carry dozens of these, so keep one per locale for the life of the page.
+const exactFormatters = new Map();
+
+function exactFormatter(locale) {
+    const key = locale || "";
+
+    if (!exactFormatters.has(key)) {
+        exactFormatters.set(key, new Intl.DateTimeFormat(locale, EXACT_FORMAT_OPTIONS));
+    }
+
+    return exactFormatters.get(key);
+}
+
 export class TimeAgo extends HTMLElement {
     constructor() {
         super();
@@ -7,6 +33,7 @@ export class TimeAgo extends HTMLElement {
     }
 
     connectedCallback() {
+        this.setExactTitle();
         this.updateTime();
         this.interval = setInterval(this.updateTime, 1000);
     }
@@ -28,29 +55,27 @@ export class TimeAgo extends HTMLElement {
         }
 
         this.textContent = this.decorateRelative(date);
-        this.setExactTitle(date);
     }
 
     // The visible text is relative ("31 minutes ago"), which reads well but makes
     // you do the arithmetic to get a wall-clock time. Keep the exact timestamp one
-    // hover away rather than making people work it out.
-    setExactTitle(date) {
-        const exact = this.formatExact(date);
-        if (this.title !== exact) this.title = exact;
+    // hover away rather than making people work it out. `datetime` is immutable, so
+    // this runs once on connect rather than on every tick of the relative-time timer.
+    setExactTitle() {
+        if (!this.datetime) return;
+
+        const date = new Date(this.datetime);
+        if (isNaN(date)) return;
+
+        this.title = this.formatExact(date);
     }
 
     formatExact(date) {
-        return date.toLocaleString(this.locale, {
-            weekday: "short",
-            day: "numeric",
-            month: "short",
-            year: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-            second: "2-digit",
-            hour12: false,
-            timeZoneName: "short",
-        });
+        // Deliberately not this.locale, which falls back to "en": an exact timestamp
+        // is only readable in the viewer's own conventions. The relative text keeps
+        // the "en" default because formatDateWithTime parses English token order back
+        // out of its own output.
+        return exactFormatter(this.getAttribute("locale") || undefined).format(date);
     }
 
     decorateRelative(date) {

--- a/front/assets/js/time_ago.js
+++ b/front/assets/js/time_ago.js
@@ -29,12 +29,18 @@ export class TimeAgo extends HTMLElement {
         super();
         this.datetime = this.getAttribute("datetime");
         this.locale = this.getAttribute("locale") || "en"; // Default locale: English
+        // Undefined rather than "en": an exact timestamp is only unambiguous in the
+        // reader's own conventions. The relative text above keeps the "en" default
+        // because formatDateWithTime parses English token order back out of its output.
+        this.exactLocale = this.getAttribute("locale") || undefined;
         this.updateTime = this.updateTime.bind(this);
     }
 
     connectedCallback() {
-        this.setExactTitle();
+        // Visible text first: the tooltip is an enhancement, and it must not be able
+        // to stop the relative time rendering or the interval being installed.
         this.updateTime();
+        this.setExactTitle();
         this.interval = setInterval(this.updateTime, 1000);
     }
 
@@ -71,18 +77,13 @@ export class TimeAgo extends HTMLElement {
     }
 
     formatExact(date) {
-        // Deliberately not this.locale, which falls back to "en": an exact timestamp
-        // is only readable in the viewer's own conventions. The relative text keeps
-        // the "en" default because formatDateWithTime parses English token order back
-        // out of its own output.
-        return exactFormatter(this.getAttribute("locale") || undefined).format(date);
+        return exactFormatter(this.exactLocale).format(date);
     }
 
     decorateRelative(date) {
         const now = new Date();
         const diffInSeconds = Math.floor((now - date) / 1000);
         const diffInHours = Math.floor(diffInSeconds / 3600);
-        const daysDifference = Math.floor(diffInSeconds / 86400);
 
         if (diffInHours >= 1) return this.formatDateWithTime(date);
         return this.formatRelativeTime(diffInSeconds);

--- a/front/assets/js/time_ago.js
+++ b/front/assets/js/time_ago.js
@@ -1,4 +1,4 @@
-class TimeAgo extends HTMLElement {
+export class TimeAgo extends HTMLElement {
     constructor() {
         super();
         this.datetime = this.getAttribute("datetime");
@@ -28,6 +28,29 @@ class TimeAgo extends HTMLElement {
         }
 
         this.textContent = this.decorateRelative(date);
+        this.setExactTitle(date);
+    }
+
+    // The visible text is relative ("31 minutes ago"), which reads well but makes
+    // you do the arithmetic to get a wall-clock time. Keep the exact timestamp one
+    // hover away rather than making people work it out.
+    setExactTitle(date) {
+        const exact = this.formatExact(date);
+        if (this.title !== exact) this.title = exact;
+    }
+
+    formatExact(date) {
+        return date.toLocaleString(this.locale, {
+            weekday: "short",
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+            hour12: false,
+            timeZoneName: "short",
+        });
     }
 
     decorateRelative(date) {

--- a/front/assets/js/time_ago.spec.js
+++ b/front/assets/js/time_ago.spec.js
@@ -1,0 +1,61 @@
+import {expect} from "chai"
+import {defineTimeAgoElement} from "./time_ago"
+
+describe("time-ago", () => {
+    beforeEach(() => {
+        // Two things need undoing before the registry is usable here. jsdom-global
+        // does not hoist customElements onto the global the way it does
+        // document/window, and js/test_results/util/gzip.spec.ts swaps global.window
+        // for a second jsdom without putting it back - so point both at the window
+        // that actually owns `document`.
+        globalThis.window = document.defaultView
+        globalThis.customElements = document.defaultView.customElements
+
+        defineTimeAgoElement()
+    })
+
+    afterEach(() => { document.body.innerHTML = "" })
+
+    // The element reads `datetime` in its constructor, so it has to be present
+    // before the element is upgraded - i.e. rendered as markup, like the server does.
+    const render = (datetime) => {
+        const attribute = datetime === undefined ? "" : ` datetime="${datetime}"`
+        document.body.innerHTML = `<time-ago${attribute}></time-ago>`
+
+        return document.body.firstElementChild
+    }
+
+    it("renders a relative time for something that just happened", () => {
+        const el = render(new Date(Date.now() - 31 * 60 * 1000).toISOString())
+
+        expect(el.textContent).to.equal("31 minutes ago")
+    })
+
+    it("exposes the exact timestamp as a tooltip so it never has to be worked out by hand", () => {
+        const el = render(new Date(Date.now() - 31 * 60 * 1000).toISOString())
+
+        expect(el.textContent).to.equal("31 minutes ago")
+        expect(el.title).to.match(/\d{1,2}:\d{2}:\d{2}/)
+        expect(el.title).to.contain(String(new Date().getFullYear()))
+    })
+
+    it("keeps the tooltip on entries old enough to render absolutely", () => {
+        const el = render("2020-01-02T03:04:05+00:00")
+
+        expect(el.textContent).to.not.contain("ago")
+        expect(el.title).to.match(/\d{1,2}:\d{2}:\d{2}/)
+        expect(el.title).to.contain("2020")
+    })
+
+    it("renders nothing without a datetime", () => {
+        const el = render(undefined)
+
+        expect(el.textContent).to.equal("")
+    })
+
+    it("reports an unparseable datetime rather than a bogus time", () => {
+        const el = render("not-a-date")
+
+        expect(el.textContent).to.equal("Invalid date")
+    })
+})

--- a/front/assets/js/time_ago.spec.js
+++ b/front/assets/js/time_ago.spec.js
@@ -64,11 +64,33 @@ describe("time-ago", () => {
         expect(el.title).to.equal(exact(at, undefined))
     })
 
-    it("formats the tooltip in the viewer's own locale, not a hardcoded English", () => {
+    // Both locale tests below compare against German output, so they say nothing on a
+    // runtime without non-English ICU data. Assert that up front, so such a runtime
+    // fails with the reason rather than with a confusing inequality.
+    it("has the locale data the tooltip tests rely on", () => {
+        const at = new Date("2026-09-09T10:01:30+00:00")
+
+        expect(exact(at, "de"), "runtime is missing non-English ICU data").to.not.equal(exact(at, "en"))
+    })
+
+    it("formats the tooltip in the locale it is given", () => {
         const at = new Date("2026-09-09T10:01:30+00:00")
 
         expect(render(at.toISOString(), "de").title).to.equal(exact(at, "de"))
-        expect(exact(at, "de")).to.not.equal(exact(at, "en"))
+    })
+
+    it("does not fall back to the relative text's English default for the tooltip", () => {
+        const at = new Date("2026-09-09T10:01:30+00:00")
+        const el = render(at.toISOString())
+
+        // `locale` is what the visible relative text uses and it defaults to "en", so
+        // comparing a no-attribute tooltip against the runtime default proves nothing
+        // on an English runtime. Stand a different value in it instead: this fails if
+        // formatExact ever reads it again, which is the English-only-tooltip bug.
+        el.locale = "de"
+
+        expect(el.formatExact(at)).to.equal(exact(at, undefined))
+        expect(el.formatExact(at)).to.not.equal(exact(at, "de"))
     })
 
     it("formats the tooltip once, not on every tick of the relative-time timer", () => {

--- a/front/assets/js/time_ago.spec.js
+++ b/front/assets/js/time_ago.spec.js
@@ -1,5 +1,5 @@
 import {expect} from "chai"
-import {defineTimeAgoElement} from "./time_ago"
+import {TimeAgo, defineTimeAgoElement} from "./time_ago"
 
 describe("time-ago", () => {
     beforeEach(() => {
@@ -16,14 +16,31 @@ describe("time-ago", () => {
 
     afterEach(() => { document.body.innerHTML = "" })
 
-    // The element reads `datetime` in its constructor, so it has to be present
-    // before the element is upgraded - i.e. rendered as markup, like the server does.
-    const render = (datetime) => {
-        const attribute = datetime === undefined ? "" : ` datetime="${datetime}"`
-        document.body.innerHTML = `<time-ago${attribute}></time-ago>`
+    // The element reads its attributes in the constructor, so they have to be present
+    // before it is upgraded - i.e. rendered as markup, like the server does.
+    const render = (datetime, locale) => {
+        const attributes = [
+            datetime === undefined ? "" : ` datetime="${datetime}"`,
+            locale === undefined ? "" : ` locale="${locale}"`,
+        ].join("")
+        document.body.innerHTML = `<time-ago${attributes}></time-ago>`
 
         return document.body.firstElementChild
     }
+
+    // Independently built so the assertions pin the whole formatted value - locale,
+    // instant and option set - rather than just something time-shaped.
+    const exact = (date, locale) => new Intl.DateTimeFormat(locale, {
+        weekday: "short",
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+        timeZoneName: "short",
+    }).format(date)
 
     it("renders a relative time for something that just happened", () => {
         const el = render(new Date(Date.now() - 31 * 60 * 1000).toISOString())
@@ -32,30 +49,58 @@ describe("time-ago", () => {
     })
 
     it("exposes the exact timestamp as a tooltip so it never has to be worked out by hand", () => {
-        const el = render(new Date(Date.now() - 31 * 60 * 1000).toISOString())
+        const at = new Date(Date.now() - 31 * 60 * 1000)
+        const el = render(at.toISOString())
 
         expect(el.textContent).to.equal("31 minutes ago")
-        expect(el.title).to.match(/\d{1,2}:\d{2}:\d{2}/)
-        expect(el.title).to.contain(String(new Date().getFullYear()))
+        expect(el.title).to.equal(exact(at, undefined))
     })
 
     it("keeps the tooltip on entries old enough to render absolutely", () => {
-        const el = render("2020-01-02T03:04:05+00:00")
+        const at = new Date("2020-01-02T03:04:05+00:00")
+        const el = render(at.toISOString())
 
         expect(el.textContent).to.not.contain("ago")
-        expect(el.title).to.match(/\d{1,2}:\d{2}:\d{2}/)
-        expect(el.title).to.contain("2020")
+        expect(el.title).to.equal(exact(at, undefined))
+    })
+
+    it("formats the tooltip in the viewer's own locale, not a hardcoded English", () => {
+        const at = new Date("2026-09-09T10:01:30+00:00")
+
+        expect(render(at.toISOString(), "de").title).to.equal(exact(at, "de"))
+        expect(exact(at, "de")).to.not.equal(exact(at, "en"))
+    })
+
+    it("formats the tooltip once, not on every tick of the relative-time timer", () => {
+        const original = TimeAgo.prototype.formatExact
+        let calls = 0
+        TimeAgo.prototype.formatExact = function (date) {
+            calls += 1
+            return original.call(this, date)
+        }
+
+        try {
+            const el = render(new Date(Date.now() - 31 * 60 * 1000).toISOString())
+            el.updateTime()
+            el.updateTime()
+
+            expect(calls).to.equal(1)
+        } finally {
+            TimeAgo.prototype.formatExact = original
+        }
     })
 
     it("renders nothing without a datetime", () => {
         const el = render(undefined)
 
         expect(el.textContent).to.equal("")
+        expect(el.title).to.equal("")
     })
 
     it("reports an unparseable datetime rather than a bogus time", () => {
         const el = render("not-a-date")
 
         expect(el.textContent).to.equal("Invalid date")
+        expect(el.title).to.equal("")
     })
 })

--- a/front/lib/front_web/templates/layout/job.html.eex
+++ b/front/lib/front_web/templates/layout/job.html.eex
@@ -85,7 +85,7 @@
   <div class="f6 gray mb1">
     <%= case FrontWeb.JobView.job_moment(@job) do %>
       <% {label, timestamp} -> %>
-        by <%= @hook.repo_host_username %>, <%= label %> <time-ago datetime="<%= timestamp %>"><%= timestamp %></time-ago>
+        by <%= @hook.repo_host_username %> <span class="mh1">&middot;</span> <%= label %> <time-ago datetime="<%= timestamp %>"><%= timestamp %></time-ago>
       <% nil -> %>
         by <%= @hook.repo_host_username %>
     <% end %>

--- a/front/lib/front_web/templates/layout/job.html.eex
+++ b/front/lib/front_web/templates/layout/job.html.eex
@@ -83,7 +83,12 @@
   <% end %>
 
   <div class="f6 gray mb1">
-    by <%= @hook.repo_host_username %>, <time-ago datetime="<%= Timex.format!(@workflow.created_at, "%FT%T%:z", :strftime) %>"><%= Timex.format!(@workflow.created_at, "%FT%T%:z", :strftime) %></time-ago>
+    <%= case FrontWeb.JobView.job_moment(@job) do %>
+      <% {label, timestamp} -> %>
+        by <%= @hook.repo_host_username %>, <%= label %> <time-ago datetime="<%= timestamp %>"><%= timestamp %></time-ago>
+      <% nil -> %>
+        by <%= @hook.repo_host_username %>
+    <% end %>
   </div>
 
   <div class="tabs">

--- a/front/lib/front_web/templates/layout/workflow.html.eex
+++ b/front/lib/front_web/templates/layout/workflow.html.eex
@@ -32,7 +32,7 @@
     <div class="bb b--lighter-gray pv2">
       <div class="flex-m nh2">
         <div class="ph2">
-          by <%= @hook.repo_host_username %>, <time-ago datetime="<%= Timex.format!(@workflow.created_at, "%FT%T%:z", :strftime) %>"><%= Timex.format!(@workflow.created_at, "%FT%T%:z", :strftime) %></time-ago>
+          by <%= @hook.repo_host_username %>, triggered <time-ago datetime="<%= Timex.format!(@workflow.created_at, "%FT%T%:z", :strftime) %>"><%= Timex.format!(@workflow.created_at, "%FT%T%:z", :strftime) %></time-ago>
         </div>
         <%= if @hook.type == "pr" do %>
           <div class="flex items-center ph2">

--- a/front/lib/front_web/views/job_view.ex
+++ b/front/lib/front_web/views/job_view.ex
@@ -46,6 +46,24 @@ defmodule FrontWeb.JobView do
     end
   end
 
+  @doc """
+  When this job actually happened, as `{label, iso8601}`, for the page header.
+
+  The header used to render the *workflow's* creation time, which is identical for
+  every job of every promotion of that workflow and so says nothing about the job
+  in front of you. Anchor on the job's own start instead, falling back to creation
+  for a job that never got dispatched.
+  """
+  def job_moment(%{timeline: %{started_at: at}}) when not is_nil(at),
+    do: {"started", iso8601(at)}
+
+  def job_moment(%{timeline: %{created_at: at}}) when not is_nil(at),
+    do: {"created", iso8601(at)}
+
+  def job_moment(_), do: nil
+
+  defp iso8601(unix_seconds), do: unix_seconds |> DateTime.from_unix!() |> DateTime.to_iso8601()
+
   def job_timer(job), do: job_timer(job.state, job.timeline)
 
   def job_timer("pending", timeline) do

--- a/front/test/front_web/controllers/job_controller_test.exs
+++ b/front/test/front_web/controllers/job_controller_test.exs
@@ -64,6 +64,47 @@ defmodule FrontWeb.JobControllerTest do
       refute html =~ "Reused job"
     end
 
+    test "header timestamps the job itself, not the workflow it came from",
+         %{conn: conn, job: job} do
+      # 2026-09-09T10:01:30Z. Every promotion of a workflow shares the workflow's
+      # created_at, so anchoring the header on it says nothing about this job.
+      started_at = 1_788_948_090
+
+      GrpcMock.stub(InternalJobMock, :describe, fn req, _ ->
+        found = DB.find(:jobs, req.job_id)
+        task = DB.find(:tasks, found.task_id)
+        task_job = found |> DB.extract(:api_model)
+
+        DescribeResponse.new(
+          status:
+            InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+          job:
+            Job.new(
+              id: task_job.id,
+              project_id: task.project_id,
+              branch_id: task.branch_id,
+              hook_id: task.api_model.hook_id,
+              ppl_id: task.api_model.ppl_id,
+              timeline:
+                Job.Timeline.new(
+                  started_at: Google.Protobuf.Timestamp.new(seconds: started_at),
+                  finished_at: Google.Protobuf.Timestamp.new(seconds: started_at + 19)
+                ),
+              state: Job.State.value(:FINISHED),
+              machine_type: "e1-standard-2",
+              self_hosted: false,
+              name: task_job.name,
+              index: task_job.index,
+              is_debug_job: false
+            )
+        )
+      end)
+
+      html = conn |> get(job_path(conn, :show, job.id)) |> html_response(200)
+
+      assert html =~ ~s(started <time-ago datetime="2026-09-09T10:01:30Z")
+    end
+
     test "redirects when accessing debug job", %{conn: conn, debug_job: debug_job, task: task} do
       conn = get(conn, job_path(conn, :show, debug_job.id))
       assert redirected_to(conn) == project_path(conn, :show, task.project_id)

--- a/front/test/front_web/controllers/job_controller_test.exs
+++ b/front/test/front_web/controllers/job_controller_test.exs
@@ -105,6 +105,42 @@ defmodule FrontWeb.JobControllerTest do
       assert html =~ ~s(started <time-ago datetime="2026-09-09T10:01:30Z")
     end
 
+    test "falls back to the job's creation time when it never started",
+         %{conn: conn, job: job} do
+      created_at = 1_788_948_084
+
+      GrpcMock.stub(InternalJobMock, :describe, fn req, _ ->
+        found = DB.find(:jobs, req.job_id)
+        task = DB.find(:tasks, found.task_id)
+        task_job = found |> DB.extract(:api_model)
+
+        DescribeResponse.new(
+          status:
+            InternalApi.ResponseStatus.new(code: InternalApi.ResponseStatus.Code.value(:OK)),
+          job:
+            Job.new(
+              id: task_job.id,
+              project_id: task.project_id,
+              branch_id: task.branch_id,
+              hook_id: task.api_model.hook_id,
+              ppl_id: task.api_model.ppl_id,
+              timeline:
+                Job.Timeline.new(created_at: Google.Protobuf.Timestamp.new(seconds: created_at)),
+              state: Job.State.value(:PENDING),
+              machine_type: "e1-standard-2",
+              self_hosted: false,
+              name: task_job.name,
+              index: task_job.index,
+              is_debug_job: false
+            )
+        )
+      end)
+
+      html = conn |> get(job_path(conn, :show, job.id)) |> html_response(200)
+
+      assert html =~ ~s(created <time-ago datetime="2026-09-09T10:01:24Z")
+    end
+
     test "redirects when accessing debug job", %{conn: conn, debug_job: debug_job, task: task} do
       conn = get(conn, job_path(conn, :show, debug_job.id))
       assert redirected_to(conn) == project_path(conn, :show, task.project_id)

--- a/front/test/front_web/views/job_view_test.exs
+++ b/front/test/front_web/views/job_view_test.exs
@@ -17,6 +17,36 @@ defmodule FrontWeb.JobViewTest do
     end
   end
 
+  describe "job_moment/1" do
+    test "anchors on the job's own start, not the workflow it came from" do
+      job = %{
+        timeline: %{
+          created_at: 1_788_948_084,
+          started_at: 1_788_948_090,
+          finished_at: 1_788_948_109
+        }
+      }
+
+      assert JobView.job_moment(job) == {"started", "2026-09-09T10:01:30Z"}
+    end
+
+    test "falls back to creation for a job that never started" do
+      job = %{
+        timeline: %{
+          created_at: 1_788_948_084,
+          started_at: nil,
+          finished_at: nil
+        }
+      }
+
+      assert JobView.job_moment(job) == {"created", "2026-09-09T10:01:24Z"}
+    end
+
+    test "returns nothing when the job has no timestamps at all" do
+      assert JobView.job_moment(%{timeline: %{created_at: nil, started_at: nil}}) == nil
+    end
+  end
+
   describe "logs helpers" do
     test "marks fast-failed job stopped before execution as having no logs" do
       job = %{

--- a/front/test/front_web/views/job_view_test.exs
+++ b/front/test/front_web/views/job_view_test.exs
@@ -17,9 +17,12 @@ defmodule FrontWeb.JobViewTest do
     end
   end
 
+  # Built as %Front.Models.Job{} rather than a bare map: job_moment/1 ends in a
+  # catch-all returning nil, so a hand-rolled shape would keep passing after a rename
+  # of the model's timeline while the header silently lost its timestamp.
   describe "job_moment/1" do
     test "anchors on the job's own start, not the workflow it came from" do
-      job = %{
+      job = %Front.Models.Job{
         timeline: %{
           created_at: 1_788_948_084,
           started_at: 1_788_948_090,
@@ -31,7 +34,7 @@ defmodule FrontWeb.JobViewTest do
     end
 
     test "falls back to creation for a job that never started" do
-      job = %{
+      job = %Front.Models.Job{
         timeline: %{
           created_at: 1_788_948_084,
           started_at: nil,
@@ -43,7 +46,9 @@ defmodule FrontWeb.JobViewTest do
     end
 
     test "returns nothing when the job has no timestamps at all" do
-      assert JobView.job_moment(%{timeline: %{created_at: nil, started_at: nil}}) == nil
+      job = %Front.Models.Job{timeline: %{created_at: nil, started_at: nil, finished_at: nil}}
+
+      assert JobView.job_moment(job) == nil
     end
   end
 

--- a/front/test/support/stubs/task.ex
+++ b/front/test/support/stubs/task.ex
@@ -251,7 +251,15 @@ defmodule Support.Stubs.Task do
             branch_id: task.branch_id,
             hook_id: task.api_model.hook_id,
             ppl_id: task.api_model.ppl_id,
-            timeline: Job.Timeline.new(),
+            # change_job_state/2 already records these; pass them through so a
+            # stubbed job page shows real timing instead of an empty timeline.
+            timeline:
+              Job.Timeline.new(
+                created_at: task_job.created_at,
+                enqueued_at: task_job.enqueued_at,
+                started_at: task_job.started_at,
+                finished_at: task_job.finished_at
+              ),
             state: to_job_state(Task.Job.State.key(task_job.state)),
             result: task_job.result,
             machine_type: "e1-standard-2",


### PR DESCRIPTION
## 📝 Description

The job header rendered the workflow's `created_at`, which is identical for every promotion of a workflow, so a promotion that ran 15 minutes ago displayed "35 minutes ago". Relative times also had no exact value anywhere in the UI.

**Changes**

- Job header shows the job's own start time (or creation, if it never started), labelled so it cannot be read as the pipeline's or workflow's time.
- Workflow header labels its timestamp `triggered`, so the workflow age and the per-pipeline ages on that screen are visibly different things.
- `<time-ago>` gains a hover tooltip with the exact timestamp in the viewer's locale and timezone, applying everywhere relative times render.

## ✅ Checklist
- [x] I have tested this change
- [x] ~This change requires documentation update~ N/A
